### PR TITLE
feat: handlers and dispatchers for get_bso and put_bso

### DIFF
--- a/src/db/models.rs
+++ b/src/db/models.rs
@@ -300,7 +300,7 @@ impl DBManager {
 }
 
 /// BSO records from the DB
-#[derive(Debug, Queryable)]
+#[derive(Debug, Queryable, Serialize)]
 pub struct BSO {
     pub collection_id: i64,
     pub id: String,

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -1,13 +1,14 @@
 //! `Dispatcher` is a command dispatching actor that distributes commands to the appropriate
 //! actor for a given user. If an actor for that user is no longer active, it creates and
 //! initializes the actor before dispatching the command.
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::{Arc, Mutex, MutexGuard, RwLock};
 use std::collections::HashMap;
 use std::io::{Error, ErrorKind};
 
 use actix::{Actor, Addr, Context, SyncContext, Handler, Message};
 
-use db::models::{BSO, DBConfig, DBManager};
+use db::models::{BSO, DBConfig, DBManager, PutBSO};
+use db::util::ms_since_epoch;
 
 // Messages that can be sent to the user
 #[derive(Default)]
@@ -30,8 +31,45 @@ impl Message for GetBso {
     type Result = Result<Option<BSO>, Error>;
 }
 
+#[derive(Clone, Default)]
+pub struct PutBso {
+    pub user_id: String,
+    pub collection: String,
+    pub bso_id: String,
+    pub sortindex: Option<i64>,
+    pub payload: Option<String>,
+    pub ttl: Option<i64>,
+}
+
+impl Message for PutBso {
+    type Result = Result<(), Error>;
+}
+
 pub struct DBExecutor {
     pub db_handles: Arc<RwLock<HashMap<String, Mutex<DBManager>>>>,
+}
+
+impl DBExecutor {
+    fn execute<R>(
+        &self,
+        user_id: &str,
+        action: &Fn(MutexGuard<DBManager>) -> Result<R, Error>,
+    ) -> Result<R, Error> {
+        self.db_handles
+            .read()
+            .map_err(|error| Error::new(ErrorKind::Other, "db handles lock error"))
+            .and_then(|db_handles| {
+                db_handles
+                    .get(user_id)
+                    .ok_or_else(|| Error::new(ErrorKind::NotFound, "unknown user"))
+                    .and_then(|mutex| {
+                        mutex
+                            .lock()
+                            .map_err(|error| Error::new(ErrorKind::Other, "db manager mutex error"))
+                            .and_then(action)
+                    })
+            })
+    }
 }
 
 impl Handler<CollectionInfo> for DBExecutor {
@@ -46,30 +84,42 @@ impl Handler<GetBso> for DBExecutor {
     type Result = Result<Option<BSO>, Error>;
 
     fn handle(&mut self, msg: GetBso, _: &mut Self::Context) -> Self::Result {
-        self
-            .db_handles
-            .read()
-            .map_err(|error| Error::new(ErrorKind::Other, "db handles lock error"))
-            .and_then(|db_handles| {
-                db_handles
-                    .get(&msg.user_id)
-                    .ok_or_else(|| Error::new(ErrorKind::NotFound, "unknown user"))
-                    .and_then(|mutex| {
-                        mutex
-                            .lock()
-                            .map_err(|error| Error::new(ErrorKind::Other, "db manager mutex error"))
-                            .and_then(|db_manager| {
-                                db_manager
-                                    .get_collection_id(&msg.collection)
-                                    .map_err(|error| Error::new(ErrorKind::Other, error))
-                                    .and_then(|collection_id| {
-                                        db_manager
-                                            .get_bso(collection_id, &msg.bso_id)
-                                            .map_err(|error| Error::new(ErrorKind::Other, error))
-                                    })
-                            })
-                    })
-            })
+        self.execute(&msg.user_id, &|db_manager| {
+            db_manager
+                .get_collection_id(&msg.collection)
+                .map_err(|error| Error::new(ErrorKind::Other, error))
+                .and_then(|collection_id| {
+                    db_manager
+                        .get_bso(collection_id, &msg.bso_id)
+                        .map_err(|error| Error::new(ErrorKind::Other, error))
+                })
+        })
+    }
+}
+
+impl Handler<PutBso> for DBExecutor {
+    type Result = Result<(), Error>;
+
+    fn handle(&mut self, msg: PutBso, _: &mut Self::Context) -> Self::Result {
+        self.execute(&msg.user_id, &|db_manager| {
+            // error[E0507]: cannot move out of captured outer variable in an `Fn` closure
+            let msg = msg.clone();
+            db_manager
+                .get_collection_id(&msg.collection)
+                .map_err(|error| Error::new(ErrorKind::Other, error))
+                .and_then(|collection_id| {
+                    db_manager
+                        .put_bso(&PutBSO {
+                            collection_id,
+                            id: msg.bso_id,
+                            sortindex: msg.sortindex,
+                            payload: msg.payload,
+                            last_modified: ms_since_epoch(),
+                            ttl: msg.ttl,
+                        })
+                        .map_err(|error| Error::new(ErrorKind::Other, error))
+                })
+        })
     }
 }
 

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -90,9 +90,9 @@ pub struct BsoParams {
     bso: String,
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Serialize)]
 pub struct BsoBody {
-    sortindex: Option<i64>,
-    payload: Option<String>,
-    ttl: Option<i64>,
+    pub sortindex: Option<i64>,
+    pub payload: Option<String>,
+    pub ttl: Option<i64>,
 }

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -42,3 +42,21 @@ pub fn collection_info(state: State<ServerState>) -> FutureResponse<HttpResponse
         })
         .responder()
 }
+
+pub fn get_bso(
+    (params, state): (Path<(String, String, String)>, State<ServerState>)
+) -> FutureResponse<HttpResponse> {
+    state
+        .db_executor
+        .send(dispatcher::GetBso {
+            user_id: params.0.clone(),
+            collection: params.1.clone(),
+            bso_id: params.2.clone(),
+        })
+        .from_err()
+        .and_then(|res| match res {
+            Ok(info) => Ok(HttpResponse::Ok().json(info)),
+            Err(_) => Ok(HttpResponse::InternalServerError().into()),
+        })
+        .responder()
+}

--- a/src/server.rs
+++ b/src/server.rs
@@ -39,6 +39,11 @@ impl Server {
                                 r.method(http::Method::GET)
                                     .with(handlers::collection_info)
                             })
+                        .resource(
+                            "{uid}/storage/{collection}/{bso}", |r| {
+                                r.method(http::Method::GET)
+                                    .with(handlers::get_bso)
+                            })
                         .register()
                 })
         }).bind(format!("127.0.0.1:{}", settings.port))

--- a/src/server.rs
+++ b/src/server.rs
@@ -42,7 +42,9 @@ impl Server {
                         .resource(
                             "{uid}/storage/{collection}/{bso}", |r| {
                                 r.method(http::Method::GET)
-                                    .with(handlers::get_bso)
+                                    .with(handlers::get_bso);
+                                r.method(http::Method::PUT)
+                                    .with(handlers::put_bso);
                             })
                         .register()
                 })

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,4 +1,8 @@
 //! Main application server
+
+#[cfg(test)]
+mod test;
+
 use std::sync::{Arc, RwLock};
 use std::collections::HashMap;
 

--- a/src/server/test.rs
+++ b/src/server/test.rs
@@ -1,0 +1,109 @@
+use std::sync::{Arc, Mutex, RwLock};
+
+use actix_web::test::TestServer;
+use actix_web::HttpMessage;
+
+use super::*;
+use db::models::{DBConfig, DBManager};
+use db::util::ms_since_epoch;
+use handlers::BsoBody;
+
+fn setup() -> TestServer {
+    TestServer::build_with_state(move || {
+        let db_executor = SyncArbiter::start(num_cpus::get(), move || {
+            let db_manager = DBManager::new(":memory:", DBConfig::default()).unwrap();
+            db_manager.init().unwrap();
+
+            let mut db_handles = HashMap::new();
+            db_handles.insert("deadbeef".to_string(), Mutex::new(db_manager));
+
+            DBExecutor {
+                db_handles: Arc::new(RwLock::new(db_handles)),
+            }
+        });
+
+        ServerState { db_executor }
+    }).start(|app| {
+        app.resource("{uid}/info/collections", |r| {
+            r.method(http::Method::GET).with(handlers::collection_info);
+        }).resource("{uid}/storage/{collection}/{bso}", |r| {
+            r.method(http::Method::GET).with(handlers::get_bso);
+            r.method(http::Method::PUT).with(handlers::put_bso);
+        });
+    })
+}
+
+#[test]
+fn collection_info() {
+    let mut server = setup();
+
+    let request = server
+        .client(http::Method::GET, "deadbeef/info/collections")
+        .finish()
+        .unwrap();
+
+    let response = server.execute(request.send()).unwrap();
+    assert!(response.status().is_success());
+
+    let body = server.execute(response.body()).unwrap();
+    assert_eq!(body, "{}".as_bytes());
+}
+
+#[test]
+fn get_bso() {
+    let mut server = setup();
+    let bso_path = format!("storage/bookmarks/test.server.get_bso.{}", ms_since_epoch());
+
+    let good_path = format!("deadbeef/{}", &bso_path);
+    let request = server
+        .client(http::Method::GET, &good_path)
+        .finish()
+        .unwrap();
+
+    let response = server.execute(request.send()).unwrap();
+    assert!(response.status().is_success());
+
+    let body = server.execute(response.body()).unwrap();
+    assert_eq!(body, "null".as_bytes());
+
+    let bad_path = format!("baadf00d/{}", &bso_path);
+    let request = server
+        .client(http::Method::GET, &bad_path)
+        .finish()
+        .unwrap();
+
+    let response = server.execute(request.send()).unwrap();
+    assert!(response.status().is_server_error());
+}
+
+#[test]
+fn put_bso() {
+    let mut server = setup();
+    let bso_path = format!("storage/bookmarks/test.server.put_bso.{}", ms_since_epoch());
+
+    let good_path = format!("deadbeef/{}", &bso_path);
+    let request = server
+        .client(http::Method::PUT, &good_path)
+        .json(BsoBody {
+            sortindex: Some(0),
+            payload: Some("wibble".to_string()),
+            ttl: Some(31536000000),
+        })
+        .unwrap();
+
+    let response = server.execute(request.send()).unwrap();
+    assert!(response.status().is_success());
+
+    let bad_path = format!("baadf00d/{}", &bso_path);
+    let request = server
+        .client(http::Method::PUT, &bad_path)
+        .json(BsoBody {
+            sortindex: Some(0),
+            payload: Some("wibble".to_string()),
+            ttl: Some(31536000000),
+        })
+        .unwrap();
+
+    let response = server.execute(request.send()).unwrap();
+    assert!(response.status().is_server_error());
+}


### PR DESCRIPTION
I spent a bit of time today working on dispatchers for `get_bso` and `put_bso`. Although they broadly seem to work (they compile! :smile:), I'm not very happy with the code as it stands. As usual I had some trouble bending Rust to my will, hence I'm opening a WIP PR in the hope that you guys can help me with some async pointers on what I could be doing better.

The main problem I struggled with was extracting the common code from the two dispatcher bodies out to a separate method. As you'll see in the diff, there is a fair amount of duplicate code in each body and the indentation got pretty crazy as it wouldn't let me flatten the combinator chains.

I tried two things to fix it:

1. A helper method on `DBExecutor` that returns `MutexGuard<DBManager>`:

   ```rust
   impl DBExecutor {
       fn lock(&self, user_id: &str) -> Result<MutexGuard<DBManager>, Error> {
           self
               .db_handles
               .read()
               .map_err(|error| Error::new(ErrorKind::Other, "db handles lock error"))
               .and_then(|db_handles| {
                   db_handles
                       .get(user_id)
                       .ok_or_else(|| Error::new(ErrorKind::NotFound, "unknown user"))
               })
               .and_then(|mutex| {
                   mutex
                       .lock()
                       .map_err(|error| Error::new(ErrorKind::Other, "db manager mutex error"))
               })
       }
   }
   ```

   That complains about the lifetime of `db_handles`:

   ```
   error[E0597]: `db_handles` does not live long enough
     --> src/dispatcher.rs:59:17
      |
   59 |                 db_handles
      |                 ^^^^^^^^^^ borrowed value does not live long enough
   ...
   67 |             })
      |             - borrowed value only lives until here
      |
   note: borrowed value must be valid for the anonymous lifetime #1 defined on the method body at 53:5...
     --> src/dispatcher.rs:53:5
      |
   53 | /     fn lock(&self, user_id: &str) -> Result<MutexGuard<DBManager>, Error> {
   54 | |         self
   55 | |             .db_handles
   56 | |             .read()
   ...  |
   67 | |             })
   68 | |     }
      | |_____^
   ```

2. Variation on the above, this time the helper method takes an `FnOnce` for running the action code before `db_handles` goes out of scope:

   ```rust
   impl DBExecutor {
       fn lock<R>(&self, user_id: &str, action: &FnOnce(MutexGuard<DBManager>) -> Result<R, Error>) -> Result<R, Error> {
           self
               .db_handles
               .read()
               .map_err(|error| Error::new(ErrorKind::Other, "db handles lock error"))
               .and_then(|db_handles| {
                   db_handles
                       .get(user_id)
                       .ok_or_else(|| Error::new(ErrorKind::NotFound, "unknown user"))
                       .and_then(|mutex| {
                           mutex
                               .lock()
                               .map_err(|error| Error::new(ErrorKind::Other, "db manager mutex error"))
                               .and_then(action)
                       })
               })
       }
   }
   ```

   ...which complained about unsatisfied `FnOnce` trait bounds:

   ```
   error[E0277]: the trait bound `for<'r> std::ops::FnOnce(std::sync::MutexGuard<'r, db::models::DBManager>) -> std::result::Result<R, std::io::Error>: std::ops::Fn<(std::sync::MutexGuard<'_, db::models::DBManager>,)>` is not satisfied
     --> src/dispatcher.rs:66:30
      |
   66 |                             .and_then(action)
      |                              ^^^^^^^^ the trait `std::ops::Fn<(std::sync::MutexGuard<'_, db::models::DBManager>,)>` is not implemented for `for<'r> std::ops::FnOnce(std::sync::MutexGuard<'r, db::models::DBManager>) -> std::result::Result<R, std::io::Error>`
      |
      = note: required because of the requirements on the impl of `std::ops::FnOnce<(std::sync::MutexGuard<'_, db::models::DBManager>,)>` for `&for<'r> std::ops::FnOnce(std::sync::MutexGuard<'r, db::models::DBManager>) -> std::result::Result<R, std::io::Error>`
   ```

(also the error handling is a hack right now)

Any suggestions @bbangert / @pjenvey / @rfk?