### PR TITLE
fix: turn on cargo fmt in CI and fix fmt errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,17 @@ rust:
 
 cache: cargo
 
+before_script:
+  - rustup component add rustfmt-preview
+
+script:
+  - cargo fmt -- --write-mode=diff
+  # HACK: Force CI to fail if there are rustfmt diffs. We can stop doing this
+  #       as soon as `cargo fmt -- --check` works in stable.
+  - if [ "$(cargo fmt -- --write-mode=diff | wc -l)" != "0" ]; then exit 1; fi
+  - cargo build
+  - cargo test
+
 notifications:
   email: false
   slack:

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -1,13 +1,13 @@
 //! `Dispatcher` is a command dispatching actor that distributes commands to the appropriate
 //! actor for a given user. If an actor for that user is no longer active, it creates and
 //! initializes the actor before dispatching the command.
-use std::sync::{Arc, Mutex, MutexGuard, RwLock};
 use std::collections::HashMap;
 use std::io::{Error, ErrorKind};
+use std::sync::{Arc, Mutex, MutexGuard, RwLock};
 
-use actix::{Actor, Addr, Context, SyncContext, Handler, Message};
+use actix::{Actor, Addr, Context, Handler, Message, SyncContext};
 
-use db::models::{BSO, DBConfig, DBManager, PutBSO};
+use db::models::{DBConfig, DBManager, PutBSO, BSO};
 use db::util::ms_since_epoch;
 
 // Messages that can be sent to the user

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -1,7 +1,7 @@
 //! API Handlers
 use actix::{ActorResponse, Addr};
 use actix_web::{
-    error, Error, AsyncResponder, FromRequest, FutureResponse, HttpRequest, HttpResponse, Json,
+    error, AsyncResponder, Error, FromRequest, FutureResponse, HttpRequest, HttpResponse, Json,
     Path, Responder, State,
 };
 use futures::Future;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -3,8 +3,8 @@
 #[cfg(test)]
 mod test;
 
-use std::sync::{Arc, RwLock};
 use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
 
 use actix::{SyncArbiter, System, SystemRunner};
 use actix_web::{http, middleware::cors::Cors, server::HttpServer, App};
@@ -24,8 +24,8 @@ impl Server {
 
         // Start dispatcher with the arbiter
         let db_pool = Arc::new(RwLock::new(HashMap::new()));
-        let db_executor = SyncArbiter::start(num_cpus::get(), move || {
-            DBExecutor { db_handles: db_pool.clone() }
+        let db_executor = SyncArbiter::start(num_cpus::get(), move || DBExecutor {
+            db_handles: db_pool.clone(),
         });
 
         HttpServer::new(move || {


### PR DESCRIPTION
Not sure how you guys feel about this, no worries if it's not wanted for some reason.

Anyway, it was kind of low-level annoying last week when I ran `cargo fmt` and a bunch of files unrelated to my changes were also updated. If we run it in CI it makes it easier to stay on top of things is all I'm thinking.

There is a slight hack in the CI script because `--write-mode=diff` doesn't exit with an error code when there are diffs, so I added an explicit exit to make it fail. That's just a temporary measure until we can use `--check` in stable.

Just to prove that it actually fails when there are diffs, you can see the failing build for 58f5481 here:

https://travis-ci.org/philbooth/syncstorage-rs/builds/410320506

And here is the follow-up build for 80e4471 with the fixes:

https://travis-ci.org/philbooth/syncstorage-rs/builds/410321703

@bbangert @pjenvey r?