### PR TITLE
fix(tests): stop creating a fresh DBManager on every request

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1534,6 +1534,7 @@ dependencies = [
  "rand 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,4 +22,5 @@ num_cpus = "1.8.0"
 rand = "0.5.2"
 serde = "1.0.67"
 serde_derive = "1.0.67"
+serde_json = "1.0.24"
 uuid = { version = "0.6.5", features = ["serde", "v4"] }

--- a/src/db/models.rs
+++ b/src/db/models.rs
@@ -330,7 +330,7 @@ impl DBManager {
 }
 
 /// BSO records from the DB
-#[derive(Debug, Queryable, Serialize)]
+#[derive(Debug, Queryable, Serialize, Deserialize)]
 pub struct BSO {
     pub collection_id: i64,
     pub id: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ extern crate num_cpus;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;
+extern crate serde_json;
 extern crate rand;
 extern crate uuid;
 


### PR DESCRIPTION
When I wrote the server tests I hadn't understood what `SyncArbiter::start` does, so didn't realise the callback was being invoked on every request. This change moves construction of the db stuff out of that callback, so the same `DBManager` gets used for the entire life of the `TestServer` instance.

As a result of that, I could also write the test that I couldn't get to work last week in #4: a round-trip of `put_bso` then `get_bso`, followed by some assertions that what comes out is the same as what went in. Hence those assertions are also added to the `put_bso` test.

@pjenvey, @bbangert r?