### PR TITLE
feat: stub out some more endpoints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,7 @@ before_script:
   - rustup component add rustfmt-preview
 
 script:
-  - cargo fmt -- --write-mode=diff
-  # HACK: Force CI to fail if there are rustfmt diffs. We can stop doing this
-  #       as soon as `cargo fmt -- --check` works in stable.
-  - if [ "$(cargo fmt -- --write-mode=diff | wc -l)" != "0" ]; then exit 1; fi
+  - cargo fmt -- --check
   - cargo build
   - cargo test
 

--- a/src/db/models.rs
+++ b/src/db/models.rs
@@ -324,7 +324,8 @@ impl DBManager {
     }
 
     pub fn last_modified(&self) -> Result<i64, DieselError> {
-        Ok(self.get_key(STORAGE_LAST_MODIFIED)?
+        Ok(self
+            .get_key(STORAGE_LAST_MODIFIED)?
             .map_or(0, |last_modified| last_modified.parse().unwrap()))
     }
 }

--- a/src/db/models_test.rs
+++ b/src/db/models_test.rs
@@ -176,13 +176,15 @@ fn get_bsos_limit_offset() {
         db.put_bso(&bso).unwrap();
     }
 
-    let bsos = db.get_bsos(cid, &[], MAX_TIMESTAMP, 0, Sorting::Index, 0, 0)
+    let bsos = db
+        .get_bsos(cid, &[], MAX_TIMESTAMP, 0, Sorting::Index, 0, 0)
         .unwrap();
     assert!(bsos.bsos.is_empty());
     assert!(bsos.more);
     assert_eq!(bsos.offset, 0);
 
-    let bsos = db.get_bsos(cid, &[], MAX_TIMESTAMP, 0, Sorting::Index, -1, 0)
+    let bsos = db
+        .get_bsos(cid, &[], MAX_TIMESTAMP, 0, Sorting::Index, -1, 0)
         .unwrap();
     assert_eq!(bsos.bsos.len(), size as usize);
     assert!(!bsos.more);
@@ -197,45 +199,48 @@ fn get_bsos_limit_offset() {
     .. etc
     */
 
-    let bsos = db.get_bsos(
-        cid,
-        &[],
-        MAX_TIMESTAMP,
-        newer,
-        Sorting::Newest,
-        limit,
-        offset,
-    ).unwrap();
+    let bsos =
+        db.get_bsos(
+            cid,
+            &[],
+            MAX_TIMESTAMP,
+            newer,
+            Sorting::Newest,
+            limit,
+            offset,
+        ).unwrap();
     assert_eq!(bsos.bsos.len(), 5 as usize);
     assert!(bsos.more);
     assert_eq!(bsos.offset, 5);
     assert_eq!(bsos.bsos[0].id, "11");
     assert_eq!(bsos.bsos[4].id, "7");
 
-    let bsos2 = db.get_bsos(
-        cid,
-        &[],
-        MAX_TIMESTAMP,
-        newer,
-        Sorting::Index,
-        limit,
-        bsos.offset,
-    ).unwrap();
+    let bsos2 =
+        db.get_bsos(
+            cid,
+            &[],
+            MAX_TIMESTAMP,
+            newer,
+            Sorting::Index,
+            limit,
+            bsos.offset,
+        ).unwrap();
     assert_eq!(bsos2.bsos.len(), 5 as usize);
     assert!(bsos2.more);
     assert_eq!(bsos2.offset, 10);
     assert_eq!(bsos2.bsos[0].id, "6");
     assert_eq!(bsos2.bsos[4].id, "2");
 
-    let bsos3 = db.get_bsos(
-        cid,
-        &[],
-        MAX_TIMESTAMP,
-        newer,
-        Sorting::Index,
-        limit,
-        bsos2.offset,
-    ).unwrap();
+    let bsos3 =
+        db.get_bsos(
+            cid,
+            &[],
+            MAX_TIMESTAMP,
+            newer,
+            Sorting::Index,
+            limit,
+            bsos2.offset,
+        ).unwrap();
     assert_eq!(bsos3.bsos.len(), 2 as usize);
     assert!(!bsos3.more);
     assert_eq!(bsos3.offset, 0);
@@ -264,46 +269,50 @@ fn get_bsos_newer() {
         db.put_bso(&pbso).unwrap();
     }
 
-    let bsos = db.get_bsos(
-        cid,
-        &[],
-        MAX_TIMESTAMP,
-        modified - 3,
-        Sorting::Newest,
-        10,
-        0,
-    ).unwrap();
+    let bsos =
+        db.get_bsos(
+            cid,
+            &[],
+            MAX_TIMESTAMP,
+            modified - 3,
+            Sorting::Newest,
+            10,
+            0,
+        ).unwrap();
     assert_eq!(bsos.bsos.len(), 3);
     assert_eq!(bsos.bsos[0].id, "b0");
     assert_eq!(bsos.bsos[1].id, "b1");
     assert_eq!(bsos.bsos[2].id, "b2");
 
-    let bsos = db.get_bsos(
-        cid,
-        &[],
-        MAX_TIMESTAMP,
-        modified - 2,
-        Sorting::Newest,
-        10,
-        0,
-    ).unwrap();
+    let bsos =
+        db.get_bsos(
+            cid,
+            &[],
+            MAX_TIMESTAMP,
+            modified - 2,
+            Sorting::Newest,
+            10,
+            0,
+        ).unwrap();
     assert_eq!(bsos.bsos.len(), 2);
     assert_eq!(bsos.bsos[0].id, "b0");
     assert_eq!(bsos.bsos[1].id, "b1");
 
-    let bsos = db.get_bsos(
-        cid,
-        &[],
-        MAX_TIMESTAMP,
-        modified - 1,
-        Sorting::Newest,
-        10,
-        0,
-    ).unwrap();
+    let bsos =
+        db.get_bsos(
+            cid,
+            &[],
+            MAX_TIMESTAMP,
+            modified - 1,
+            Sorting::Newest,
+            10,
+            0,
+        ).unwrap();
     assert_eq!(bsos.bsos.len(), 1);
     assert_eq!(bsos.bsos[0].id, "b0");
 
-    let bsos = db.get_bsos(cid, &[], MAX_TIMESTAMP, modified, Sorting::Newest, 10, 0)
+    let bsos = db
+        .get_bsos(cid, &[], MAX_TIMESTAMP, modified, Sorting::Newest, 10, 0)
         .unwrap();
     assert_eq!(bsos.bsos.len(), 0);
 }
@@ -329,21 +338,24 @@ fn get_bsos_sort() {
         db.put_bso(&pbso).unwrap();
     }
 
-    let bsos = db.get_bsos(cid, &[], MAX_TIMESTAMP, 0, Sorting::Newest, 10, 0)
+    let bsos = db
+        .get_bsos(cid, &[], MAX_TIMESTAMP, 0, Sorting::Newest, 10, 0)
         .unwrap();
     assert_eq!(bsos.bsos.len(), 3);
     assert_eq!(bsos.bsos[0].id, "b0");
     assert_eq!(bsos.bsos[1].id, "b1");
     assert_eq!(bsos.bsos[2].id, "b2");
 
-    let bsos = db.get_bsos(cid, &[], MAX_TIMESTAMP, 0, Sorting::Oldest, 10, 0)
+    let bsos = db
+        .get_bsos(cid, &[], MAX_TIMESTAMP, 0, Sorting::Oldest, 10, 0)
         .unwrap();
     assert_eq!(bsos.bsos.len(), 3);
     assert_eq!(bsos.bsos[0].id, "b2");
     assert_eq!(bsos.bsos[1].id, "b1");
     assert_eq!(bsos.bsos[2].id, "b0");
 
-    let bsos = db.get_bsos(cid, &[], MAX_TIMESTAMP, 0, Sorting::Index, 10, 0)
+    let bsos = db
+        .get_bsos(cid, &[], MAX_TIMESTAMP, 0, Sorting::Index, 10, 0)
         .unwrap();
     assert_eq!(bsos.bsos.len(), 3);
     assert_eq!(bsos.bsos[0].id, "b2");
@@ -539,21 +551,23 @@ fn get_bsos() {
         db.put_bso(&bso).unwrap();
     }
 
-    let bsos = db.get_bsos(
-        cid,
-        &vec!["b0", "b2", "b4"],
-        MAX_TIMESTAMP,
-        0,
-        Sorting::Newest,
-        10,
-        0,
-    ).unwrap();
+    let bsos =
+        db.get_bsos(
+            cid,
+            &vec!["b0", "b2", "b4"],
+            MAX_TIMESTAMP,
+            0,
+            Sorting::Newest,
+            10,
+            0,
+        ).unwrap();
     assert_eq!(bsos.bsos.len(), 3);
     assert_eq!(bsos.bsos[0].id, "b0");
     assert_eq!(bsos.bsos[1].id, "b2");
     assert_eq!(bsos.bsos[2].id, "b4");
 
-    let bsos = db.get_bsos(cid, &[], MAX_TIMESTAMP, 0, Sorting::Index, 2, 0)
+    let bsos = db
+        .get_bsos(cid, &[], MAX_TIMESTAMP, 0, Sorting::Index, 2, 0)
         .unwrap();
     assert_eq!(bsos.bsos.len(), 2);
     assert_eq!(bsos.offset, 2);

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -17,7 +17,7 @@ pub struct CollectionInfo {
 }
 
 impl Message for CollectionInfo {
-    type Result = Result<HashMap<String, String>, Error>;
+    type Result = <DBExecutor as Handler<CollectionInfo>>::Result;
 }
 
 #[derive(Default)]
@@ -28,7 +28,7 @@ pub struct GetBso {
 }
 
 impl Message for GetBso {
-    type Result = Result<Option<BSO>, Error>;
+    type Result = <DBExecutor as Handler<GetBso>>::Result;
 }
 
 #[derive(Clone, Default)]
@@ -42,7 +42,7 @@ pub struct PutBso {
 }
 
 impl Message for PutBso {
-    type Result = Result<(), Error>;
+    type Result = <DBExecutor as Handler<PutBso>>::Result;
 }
 
 pub struct DBExecutor {

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -10,14 +10,25 @@ use actix::{Actor, Addr, Context, Handler, Message, SyncContext};
 use db::models::{DBConfig, DBManager, PutBSO, BSO};
 use db::util::ms_since_epoch;
 
-// Messages that can be sent to the user
-#[derive(Default)]
-pub struct CollectionInfo {
-    pub user_id: String,
+macro_rules! uid_messages {
+    ($($message:ident),+) => ($(
+        #[derive(Default)]
+        pub struct $message {
+            pub user_id: String,
+        }
+
+        impl Message for $message {
+            type Result = <DBExecutor as Handler<$message>>::Result;
+        }
+    )+)
 }
 
-impl Message for CollectionInfo {
-    type Result = <DBExecutor as Handler<CollectionInfo>>::Result;
+uid_messages! {
+    Collections,
+    CollectionCounts,
+    CollectionUsage,
+    Configuration,
+    Quota
 }
 
 #[derive(Default)]
@@ -72,11 +83,43 @@ impl DBExecutor {
     }
 }
 
-impl Handler<CollectionInfo> for DBExecutor {
+impl Handler<Collections> for DBExecutor {
     type Result = Result<HashMap<String, String>, Error>;
 
-    fn handle(&mut self, msg: CollectionInfo, _: &mut Self::Context) -> Self::Result {
+    fn handle(&mut self, msg: Collections, _: &mut Self::Context) -> Self::Result {
         Ok(HashMap::new())
+    }
+}
+
+impl Handler<CollectionCounts> for DBExecutor {
+    type Result = Result<HashMap<String, u64>, Error>;
+
+    fn handle(&mut self, msg: CollectionCounts, _: &mut Self::Context) -> Self::Result {
+        Ok(HashMap::new())
+    }
+}
+
+impl Handler<CollectionUsage> for DBExecutor {
+    type Result = Result<HashMap<String, u32>, Error>;
+
+    fn handle(&mut self, msg: CollectionUsage, _: &mut Self::Context) -> Self::Result {
+        Ok(HashMap::new())
+    }
+}
+
+impl Handler<Configuration> for DBExecutor {
+    type Result = Result<HashMap<String, u64>, Error>;
+
+    fn handle(&mut self, msg: Configuration, _: &mut Self::Context) -> Self::Result {
+        Ok(HashMap::new())
+    }
+}
+
+impl Handler<Quota> for DBExecutor {
+    type Result = Result<Vec<Option<u32>>, Error>;
+
+    fn handle(&mut self, msg: Quota, _: &mut Self::Context) -> Self::Result {
+        Ok(vec![Some(0), None])
     }
 }
 

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -31,29 +31,30 @@ uid_messages! {
     Quota
 }
 
-#[derive(Default)]
-pub struct GetBso {
-    pub user_id: String,
-    pub collection: String,
-    pub bso_id: String,
+macro_rules! bso_messages {
+    ($($message:ident {$($property:ident: $type:ty),*}),+) => ($(
+        #[derive(Clone, Default)]
+        pub struct $message {
+            pub user_id: String,
+            pub collection: String,
+            pub bso_id: String,
+            $(pub $property: $type),*
+        }
+
+        impl Message for $message {
+            type Result = <DBExecutor as Handler<$message>>::Result;
+        }
+    )+)
 }
 
-impl Message for GetBso {
-    type Result = <DBExecutor as Handler<GetBso>>::Result;
-}
-
-#[derive(Clone, Default)]
-pub struct PutBso {
-    pub user_id: String,
-    pub collection: String,
-    pub bso_id: String,
-    pub sortindex: Option<i64>,
-    pub payload: Option<String>,
-    pub ttl: Option<i64>,
-}
-
-impl Message for PutBso {
-    type Result = <DBExecutor as Handler<PutBso>>::Result;
+bso_messages! {
+    DeleteBso {},
+    GetBso {},
+    PutBso {
+        sortindex: Option<i64>,
+        payload: Option<String>,
+        ttl: Option<i64>
+    }
 }
 
 pub struct DBExecutor {
@@ -120,6 +121,14 @@ impl Handler<Quota> for DBExecutor {
 
     fn handle(&mut self, msg: Quota, _: &mut Self::Context) -> Self::Result {
         Ok(vec![Some(0), None])
+    }
+}
+
+impl Handler<DeleteBso> for DBExecutor {
+    type Result = Result<(), Error>;
+
+    fn handle(&mut self, msg: DeleteBso, _: &mut Self::Context) -> Self::Result {
+        Ok(())
     }
 }
 

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -63,43 +63,37 @@ pub struct UidParam {
     uid: String,
 }
 
-pub fn get_bso(
-    (params, state): (Path<BsoParams>, State<ServerState>),
-) -> FutureResponse<HttpResponse> {
-    state
-        .db_executor
-        .send(dispatcher::GetBso {
-            user_id: params.uid.clone(),
-            collection: params.collection.clone(),
-            bso_id: params.bso.clone(),
-        })
-        .from_err()
-        .and_then(|res| match res {
-            Ok(info) => Ok(HttpResponse::Ok().json(info)),
-            Err(_) => Ok(HttpResponse::InternalServerError().into()),
-        })
-        .responder()
+macro_rules! bso_endpoints {
+    ($($handler:ident: $dispatcher:ident ($($param:ident: $type:ty),*) {$($property:ident: $value:expr),*}),+) => ($(
+        pub fn $handler(
+            (params, state$(, $param),*): (Path<BsoParams>, State<ServerState>$(, $type),*),
+        ) -> FutureResponse<HttpResponse> {
+            state
+                .db_executor
+                .send(dispatcher::$dispatcher {
+                    user_id: params.uid.clone(),
+                    collection: params.collection.clone(),
+                    bso_id: params.bso.clone(),
+                    $($property: $value),*
+                })
+                .from_err()
+                .and_then(|res| match res {
+                    Ok(info) => Ok(HttpResponse::Ok().json(info)),
+                    Err(_) => Ok(HttpResponse::InternalServerError().into()),
+                })
+                .responder()
+        }
+    )+)
 }
 
-pub fn put_bso(
-    (params, body, state): (Path<BsoParams>, Json<BsoBody>, State<ServerState>),
-) -> FutureResponse<HttpResponse> {
-    state
-        .db_executor
-        .send(dispatcher::PutBso {
-            user_id: params.uid.clone(),
-            collection: params.collection.clone(),
-            bso_id: params.bso.clone(),
-            sortindex: body.sortindex,
-            payload: body.payload.as_ref().map(|payload| payload.clone()),
-            ttl: body.ttl,
-        })
-        .from_err()
-        .and_then(|res| match res {
-            Ok(info) => Ok(HttpResponse::Ok().json(info)),
-            Err(_) => Ok(HttpResponse::InternalServerError().into()),
-        })
-        .responder()
+bso_endpoints! {
+    delete_bso: DeleteBso () {},
+    get_bso: GetBso () {},
+    put_bso: PutBso (body: Json<BsoBody>) {
+        sortindex: body.sortindex,
+        payload: body.payload.as_ref().map(|payload| payload.clone()),
+        ttl: body.ttl
+    }
 }
 
 #[derive(Deserialize)]

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -55,6 +55,8 @@ impl Server {
                             })
                         .resource(
                             "{uid}/storage/{collection}/{bso}", |r| {
+                                r.method(http::Method::DELETE)
+                                    .with(handlers::delete_bso);
                                 r.method(http::Method::GET)
                                     .with(handlers::get_bso);
                                 r.method(http::Method::PUT)

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -41,7 +41,17 @@ impl Server {
                         .resource(
                             "{uid}/info/collections", |r| {
                                 r.method(http::Method::GET)
-                                    .with(handlers::collection_info)
+                                    .with(handlers::collections)
+                            })
+                        .resource(
+                            "{uid}/info/quota", |r| {
+                                r.method(http::Method::GET)
+                                    .with(handlers::quota);
+                            })
+                        .resource(
+                            "{uid}/info/collection_usage", |r| {
+                                r.method(http::Method::GET)
+                                    .with(handlers::collection_usage);
                             })
                         .resource(
                             "{uid}/storage/{collection}/{bso}", |r| {

--- a/src/server/test.rs
+++ b/src/server/test.rs
@@ -25,8 +25,22 @@ fn setup() -> TestServer {
         ServerState { db_executor }
     }).start(|app| {
         app.resource("{uid}/info/collections", |r| {
-            r.method(http::Method::GET).with(handlers::collection_info);
-        }).resource("{uid}/storage/{collection}/{bso}", |r| {
+            r.method(http::Method::GET).with(handlers::collections);
+        });
+        app.resource("{uid}/info/collection_counts", |r| {
+            r.method(http::Method::GET)
+                .with(handlers::collection_counts);
+        });
+        app.resource("{uid}/info/collection_usage", |r| {
+            r.method(http::Method::GET).with(handlers::collection_usage);
+        });
+        app.resource("{uid}/info/configuration", |r| {
+            r.method(http::Method::GET).with(handlers::configuration);
+        });
+        app.resource("{uid}/info/quota", |r| {
+            r.method(http::Method::GET).with(handlers::quota);
+        });
+        app.resource("{uid}/storage/{collection}/{bso}", |r| {
             r.method(http::Method::GET).with(handlers::get_bso);
             r.method(http::Method::PUT).with(handlers::put_bso);
         });
@@ -34,7 +48,7 @@ fn setup() -> TestServer {
 }
 
 #[test]
-fn collection_info() {
+fn collections() {
     let mut server = setup();
 
     let request = server
@@ -47,6 +61,70 @@ fn collection_info() {
 
     let body = server.execute(response.body()).unwrap();
     assert_eq!(body, "{}".as_bytes());
+}
+
+#[test]
+fn collection_counts() {
+    let mut server = setup();
+
+    let request = server
+        .client(http::Method::GET, "deadbeef/info/collection_counts")
+        .finish()
+        .unwrap();
+
+    let response = server.execute(request.send()).unwrap();
+    assert!(response.status().is_success());
+
+    let body = server.execute(response.body()).unwrap();
+    assert_eq!(body, "{}".as_bytes());
+}
+
+#[test]
+fn collection_usage() {
+    let mut server = setup();
+
+    let request = server
+        .client(http::Method::GET, "deadbeef/info/collection_usage")
+        .finish()
+        .unwrap();
+
+    let response = server.execute(request.send()).unwrap();
+    assert!(response.status().is_success());
+
+    let body = server.execute(response.body()).unwrap();
+    assert_eq!(body, "{}".as_bytes());
+}
+
+#[test]
+fn configuration() {
+    let mut server = setup();
+
+    let request = server
+        .client(http::Method::GET, "deadbeef/info/configuration")
+        .finish()
+        .unwrap();
+
+    let response = server.execute(request.send()).unwrap();
+    assert!(response.status().is_success());
+
+    let body = server.execute(response.body()).unwrap();
+    assert_eq!(body, "{}".as_bytes());
+}
+
+#[test]
+fn quota() {
+    let mut server = setup();
+
+    let request = server
+        .client(http::Method::GET, "deadbeef/info/quota")
+        .finish()
+        .unwrap();
+
+    let response = server.execute(request.send()).unwrap();
+    assert!(response.status().is_success());
+
+    let body = server.execute(response.body()).unwrap();
+    assert_eq!(body, "[0,null]".as_bytes());
 }
 
 #[test]

--- a/src/server/test.rs
+++ b/src/server/test.rs
@@ -41,6 +41,7 @@ fn setup() -> TestServer {
             r.method(http::Method::GET).with(handlers::quota);
         });
         app.resource("{uid}/storage/{collection}/{bso}", |r| {
+            r.method(http::Method::DELETE).with(handlers::delete_bso);
             r.method(http::Method::GET).with(handlers::get_bso);
             r.method(http::Method::PUT).with(handlers::put_bso);
         });
@@ -125,6 +126,22 @@ fn quota() {
 
     let body = server.execute(response.body()).unwrap();
     assert_eq!(body, "[0,null]".as_bytes());
+}
+
+#[test]
+fn delete_bso() {
+    let mut server = setup();
+
+    let request = server
+        .client(http::Method::DELETE, "deadbeef/storage/bookmarks/wibble")
+        .finish()
+        .unwrap();
+
+    let response = server.execute(request.send()).unwrap();
+    assert!(response.status().is_success());
+
+    let body = server.execute(response.body()).unwrap();
+    assert_eq!(body, "null".as_bytes());
 }
 
 #[test]


### PR DESCRIPTION
This afternoon I started stubbing out some more of the API endpoints, the `info/...` ones and `delete_bso`. Handlers and dispatchers are added, but obviously there's no attempt to wire anything into the db layer here.

While doing that, all of the boilerplate started to get a bit annoying so I tried to eliminate some of it using macros. Not sure how intuitive the macro format I ended up with is, so I'm interested to see whether you guys have suggestions to improve those.

I also had to update the `cargo fmt` invocation in travis because of the 1.28.0 release (as predicted by Phil J in #6). That change is included here too along with some related `rustfmt` fixes to `db/models.rs` and `db/models_test.rs`, just so that the build would succeed in Travis.

@bbangert @pjenvey r?