### PR TITLE
feat: add handler stubs for collection endpoints

### DIFF
--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -10,15 +10,25 @@ use actix::{Actor, Addr, Context, Handler, Message, SyncContext};
 use db::models::{DBConfig, DBManager, PutBSO, BSO};
 use db::util::ms_since_epoch;
 
-macro_rules! uid_messages {
-    ($($message:ident),+) => ($(
-        #[derive(Default)]
+macro_rules! message {
+    ($message:ident {$($property:ident: $type:ty),*}) => {
+        #[derive(Clone, Default)]
         pub struct $message {
-            pub user_id: String,
+            $(pub $property: $type),*
         }
 
         impl Message for $message {
             type Result = <DBExecutor as Handler<$message>>::Result;
+        }
+    }
+}
+
+macro_rules! uid_messages {
+    ($($message:ident),+) => ($(
+        message! {
+            $message {
+                user_id: String
+            }
         }
     )+)
 }
@@ -33,16 +43,13 @@ uid_messages! {
 
 macro_rules! bso_messages {
     ($($message:ident {$($property:ident: $type:ty),*}),+) => ($(
-        #[derive(Clone, Default)]
-        pub struct $message {
-            pub user_id: String,
-            pub collection: String,
-            pub bso_id: String,
-            $(pub $property: $type),*
-        }
-
-        impl Message for $message {
-            type Result = <DBExecutor as Handler<$message>>::Result;
+        message! {
+            $message {
+                user_id: String,
+                collection: String,
+                bso_id: String
+                $(, $property: $type)*
+            }
         }
     )+)
 }

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -41,6 +41,36 @@ uid_messages! {
     Quota
 }
 
+macro_rules! collection_messages {
+    ($($message:ident {$($property:ident: $type:ty),*}),+) => ($(
+        message! {
+            $message {
+                user_id: String,
+                collection: String
+                $(, $property: $type)*
+            }
+        }
+    )+)
+}
+
+collection_messages! {
+    DeleteCollection {
+        bso_ids: Vec<String>
+    },
+    GetCollection {},
+    PostCollection {
+        bsos: Vec<PostCollectionBso>
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct PostCollectionBso {
+    pub bso_id: String,
+    pub sortindex: Option<i64>,
+    pub payload: Option<String>,
+    pub ttl: Option<i64>,
+}
+
 macro_rules! bso_messages {
     ($($message:ident {$($property:ident: $type:ty),*}),+) => ($(
         message! {
@@ -128,6 +158,30 @@ impl Handler<Quota> for DBExecutor {
 
     fn handle(&mut self, msg: Quota, _: &mut Self::Context) -> Self::Result {
         Ok(vec![Some(0), None])
+    }
+}
+
+impl Handler<DeleteCollection> for DBExecutor {
+    type Result = Result<(), Error>;
+
+    fn handle(&mut self, msg: DeleteCollection, _: &mut Self::Context) -> Self::Result {
+        Ok(())
+    }
+}
+
+impl Handler<GetCollection> for DBExecutor {
+    type Result = Result<Vec<BSO>, Error>;
+
+    fn handle(&mut self, msg: GetCollection, _: &mut Self::Context) -> Self::Result {
+        Ok(Vec::new())
+    }
+}
+
+impl Handler<PostCollection> for DBExecutor {
+    type Result = Result<(), Error>;
+
+    fn handle(&mut self, msg: PostCollection, _: &mut Self::Context) -> Self::Result {
+        Ok(())
     }
 }
 

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -2,11 +2,12 @@
 use actix::{ActorResponse, Addr};
 use actix_web::{
     error, AsyncResponder, Error, FromRequest, FutureResponse, HttpRequest, HttpResponse, Json,
-    Path, Responder, State,
+    Path, Query, Responder, State,
 };
 use futures::Future;
 // Hawk lib brings in some libs that don't compile at the moment for some reason
 //use hawk::
+use serde::de::{Deserialize, Deserializer};
 
 use dispatcher;
 
@@ -71,6 +72,70 @@ info_endpoints! {
 #[derive(Deserialize)]
 pub struct UidParam {
     uid: String,
+}
+
+macro_rules! collection_endpoints {
+    ($($handler:ident: $dispatcher:ident ($($param:ident: $type:ty),*) {$($property:ident: $value:expr),*}),+) => ($(
+        endpoint! {
+            $handler: $dispatcher (params: CollectionParams $(, $param: $type)*) {
+                user_id: params.uid.clone(),
+                collection: params.collection.clone()
+                $(, $property: $value)*
+            }
+        }
+    )+)
+}
+
+collection_endpoints! {
+    delete_collection: DeleteCollection (query: Query<DeleteCollectionQuery>) {
+        bso_ids: query.ids.as_ref().map_or_else(|| Vec::new(), |ids| ids.0.clone())
+    },
+    get_collection: GetCollection () {},
+    post_collection: PostCollection (body: Json<Vec<PostCollectionBody>>) {
+        bsos: body.into_inner().into_iter().map(From::from).collect()
+    }
+}
+
+#[derive(Deserialize)]
+pub struct DeleteCollectionQuery {
+    ids: Option<BsoIds>,
+}
+
+pub struct BsoIds(pub Vec<String>);
+
+impl<'d> Deserialize<'d> for BsoIds {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'d>,
+    {
+        let value: String = Deserialize::deserialize(deserializer)?;
+        Ok(BsoIds(value.split(",").map(|id| id.to_string()).collect()))
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct PostCollectionBody {
+    pub id: String,
+    pub sortindex: Option<i64>,
+    pub payload: Option<String>,
+    pub ttl: Option<i64>,
+}
+
+impl From<PostCollectionBody> for dispatcher::PostCollectionBso {
+    fn from(body: PostCollectionBody) -> dispatcher::PostCollectionBso {
+        dispatcher::PostCollectionBso {
+            bso_id: body.id.clone(),
+            sortindex: body.sortindex,
+            payload: body.payload.as_ref().map(|payload| payload.clone()),
+            ttl: body.ttl,
+        }
+    }
+}
+
+#[derive(Deserialize)]
+pub struct CollectionParams {
+    uid: String,
+    collection: String,
 }
 
 macro_rules! bso_endpoints {

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,11 +11,11 @@ extern crate futures;
 //extern crate hawk;
 extern crate mozsvc_common;
 extern crate num_cpus;
+extern crate rand;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;
 extern crate serde_json;
-extern crate rand;
 extern crate uuid;
 
 use std::error::Error;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,8 +1,5 @@
 //! Main application server
 
-#[cfg(test)]
-mod test;
-
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
@@ -15,6 +12,35 @@ use dispatcher::DBExecutor;
 use handlers;
 use handlers::ServerState;
 use settings::Settings;
+
+macro_rules! init_routes {
+    ($app:expr) => {
+        $app.resource("{uid}/info/collections", |r| {
+            r.method(http::Method::GET).with(handlers::collections);
+        }).resource("{uid}/info/collection_counts", |r| {
+                r.method(http::Method::GET)
+                    .with(handlers::collection_counts);
+            })
+            .resource("{uid}/info/collection_usage", |r| {
+                r.method(http::Method::GET).with(handlers::collection_usage);
+            })
+            .resource("{uid}/info/configuration", |r| {
+                r.method(http::Method::GET).with(handlers::configuration);
+            })
+            .resource("{uid}/info/quota", |r| {
+                r.method(http::Method::GET).with(handlers::quota);
+            })
+            .resource("{uid}/storage/{collection}/{bso}", |r| {
+                r.method(http::Method::DELETE).with(handlers::delete_bso);
+                r.method(http::Method::GET).with(handlers::get_bso);
+                r.method(http::Method::PUT).with(handlers::put_bso);
+            })
+    };
+}
+
+// The tests depend on the init_routes! macro, so this mod must come after it
+#[cfg(test)]
+mod test;
 
 pub struct Server {}
 
@@ -34,36 +60,7 @@ impl Server {
                 db_executor: db_executor.clone(),
             };
 
-            App::with_state(state)
-                // HTTP handler routes
-                .configure(|app| {
-                    Cors::for_app(app)
-                        .resource(
-                            "{uid}/info/collections", |r| {
-                                r.method(http::Method::GET)
-                                    .with(handlers::collections)
-                            })
-                        .resource(
-                            "{uid}/info/quota", |r| {
-                                r.method(http::Method::GET)
-                                    .with(handlers::quota);
-                            })
-                        .resource(
-                            "{uid}/info/collection_usage", |r| {
-                                r.method(http::Method::GET)
-                                    .with(handlers::collection_usage);
-                            })
-                        .resource(
-                            "{uid}/storage/{collection}/{bso}", |r| {
-                                r.method(http::Method::DELETE)
-                                    .with(handlers::delete_bso);
-                                r.method(http::Method::GET)
-                                    .with(handlers::get_bso);
-                                r.method(http::Method::PUT)
-                                    .with(handlers::put_bso);
-                            })
-                        .register()
-                })
+            App::with_state(state).configure(|app| init_routes!(Cors::for_app(app)).register())
         }).bind(format!("127.0.0.1:{}", settings.port))
             .unwrap()
             .start();

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -30,6 +30,12 @@ macro_rules! init_routes {
             .resource("{uid}/info/quota", |r| {
                 r.method(http::Method::GET).with(handlers::quota);
             })
+            .resource("{uid}/storage/{collection}", |r| {
+                r.method(http::Method::DELETE)
+                    .with(handlers::delete_collection);
+                r.method(http::Method::GET).with(handlers::get_collection);
+                r.method(http::Method::POST).with(handlers::post_collection);
+            })
             .resource("{uid}/storage/{collection}/{bso}", |r| {
                 r.method(http::Method::DELETE).with(handlers::delete_bso);
                 r.method(http::Method::GET).with(handlers::get_bso);

--- a/src/server/test.rs
+++ b/src/server/test.rs
@@ -24,27 +24,7 @@ fn setup() -> TestServer {
 
         ServerState { db_executor }
     }).start(|app| {
-        app.resource("{uid}/info/collections", |r| {
-            r.method(http::Method::GET).with(handlers::collections);
-        });
-        app.resource("{uid}/info/collection_counts", |r| {
-            r.method(http::Method::GET)
-                .with(handlers::collection_counts);
-        });
-        app.resource("{uid}/info/collection_usage", |r| {
-            r.method(http::Method::GET).with(handlers::collection_usage);
-        });
-        app.resource("{uid}/info/configuration", |r| {
-            r.method(http::Method::GET).with(handlers::configuration);
-        });
-        app.resource("{uid}/info/quota", |r| {
-            r.method(http::Method::GET).with(handlers::quota);
-        });
-        app.resource("{uid}/storage/{collection}/{bso}", |r| {
-            r.method(http::Method::DELETE).with(handlers::delete_bso);
-            r.method(http::Method::GET).with(handlers::get_bso);
-            r.method(http::Method::PUT).with(handlers::put_bso);
-        });
+        init_routes!(app);
     })
 }
 

--- a/src/server/test.rs
+++ b/src/server/test.rs
@@ -48,120 +48,61 @@ fn setup() -> TestServer {
     })
 }
 
-#[test]
-fn collections() {
+fn test_endpoint(method: http::Method, path: &str, expected_body: &str) {
     let mut server = setup();
 
-    let request = server
-        .client(http::Method::GET, "deadbeef/info/collections")
-        .finish()
-        .unwrap();
+    let request = server.client(method, path).finish().unwrap();
 
     let response = server.execute(request.send()).unwrap();
     assert!(response.status().is_success());
 
     let body = server.execute(response.body()).unwrap();
-    assert_eq!(body, "{}".as_bytes());
+    assert_eq!(body, expected_body.as_bytes());
+}
+
+#[test]
+fn collections() {
+    test_endpoint(http::Method::GET, "deadbeef/info/collections", "{}");
 }
 
 #[test]
 fn collection_counts() {
-    let mut server = setup();
-
-    let request = server
-        .client(http::Method::GET, "deadbeef/info/collection_counts")
-        .finish()
-        .unwrap();
-
-    let response = server.execute(request.send()).unwrap();
-    assert!(response.status().is_success());
-
-    let body = server.execute(response.body()).unwrap();
-    assert_eq!(body, "{}".as_bytes());
+    test_endpoint(http::Method::GET, "deadbeef/info/collection_counts", "{}");
 }
 
 #[test]
 fn collection_usage() {
-    let mut server = setup();
-
-    let request = server
-        .client(http::Method::GET, "deadbeef/info/collection_usage")
-        .finish()
-        .unwrap();
-
-    let response = server.execute(request.send()).unwrap();
-    assert!(response.status().is_success());
-
-    let body = server.execute(response.body()).unwrap();
-    assert_eq!(body, "{}".as_bytes());
+    test_endpoint(http::Method::GET, "deadbeef/info/collection_usage", "{}");
 }
 
 #[test]
 fn configuration() {
-    let mut server = setup();
-
-    let request = server
-        .client(http::Method::GET, "deadbeef/info/configuration")
-        .finish()
-        .unwrap();
-
-    let response = server.execute(request.send()).unwrap();
-    assert!(response.status().is_success());
-
-    let body = server.execute(response.body()).unwrap();
-    assert_eq!(body, "{}".as_bytes());
+    test_endpoint(http::Method::GET, "deadbeef/info/configuration", "{}");
 }
 
 #[test]
 fn quota() {
-    let mut server = setup();
-
-    let request = server
-        .client(http::Method::GET, "deadbeef/info/quota")
-        .finish()
-        .unwrap();
-
-    let response = server.execute(request.send()).unwrap();
-    assert!(response.status().is_success());
-
-    let body = server.execute(response.body()).unwrap();
-    assert_eq!(body, "[0,null]".as_bytes());
+    test_endpoint(http::Method::GET, "deadbeef/info/quota", "[0,null]");
 }
 
 #[test]
 fn delete_bso() {
-    let mut server = setup();
-
-    let request = server
-        .client(http::Method::DELETE, "deadbeef/storage/bookmarks/wibble")
-        .finish()
-        .unwrap();
-
-    let response = server.execute(request.send()).unwrap();
-    assert!(response.status().is_success());
-
-    let body = server.execute(response.body()).unwrap();
-    assert_eq!(body, "null".as_bytes());
+    test_endpoint(
+        http::Method::DELETE,
+        "deadbeef/storage/bookmarks/wibble",
+        "null",
+    );
 }
 
 #[test]
 fn get_bso() {
-    let mut server = setup();
     let bso_path = format!("storage/bookmarks/test.server.get_bso.{}", ms_since_epoch());
-
     let good_path = format!("deadbeef/{}", &bso_path);
-    let request = server
-        .client(http::Method::GET, &good_path)
-        .finish()
-        .unwrap();
-
-    let response = server.execute(request.send()).unwrap();
-    assert!(response.status().is_success());
-
-    let body = server.execute(response.body()).unwrap();
-    assert_eq!(body, "null".as_bytes());
-
     let bad_path = format!("baadf00d/{}", &bso_path);
+
+    test_endpoint(http::Method::GET, &good_path, "null");
+
+    let mut server = setup();
     let request = server
         .client(http::Method::GET, &bad_path)
         .finish()


### PR DESCRIPTION
The substantive change here is just to add the remaining handler stubs for the collection endpoints. That should mean all the endpoints listed in the API docs now have a handler, unless I've missed any.

Note that `DELETE /storage/{collection}` has two entries in the docs but only one handler here. It behaves differently depending on whether there is an `ids` query param (or rather, it *will* behave differently when we actually hook it up to some behaviour). But obviously that's all just one resource in actix-web's view of things.

In addition to that there's some other small fixes:

* A rustfmt fix for some `extern crate` ordering.

* Some of the repetition between similar macro rules has been eliminated by moving it to a common base macro. This took me longer to get right than I anticipated it would, for a couple of reasons:

  * The ambiguity of trying to parse repeating groups in nested macros; is the repetition part of the child's match arm or the parent's macro body? That ruled out using a kind of higher-order macro approach.

  * Macro hygiene rules, which I hadn't come across before.

* Some of the repetition in the tests has been extracted to a common `test_endpoint` function.

* Mea culpa from #8, I forgot to include some of the `/info` routes in the server setup. ~~This was a side-effect of the really annoying fact that there's apparently no way to share the setup between test server and real server, or at least not one that I've figured out yet (suggestions welcome for that if you have any).~~

@bbangert @pjenvey r?