### PR TITLE
feat: add handler stub for DELETE /{uid}

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -54,6 +54,7 @@ uid_data! {
     CollectionUsage,
     Configuration,
     Quota,
+    DeleteAll,
 }
 
 collection_data! {

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -83,6 +83,7 @@ info_endpoints! {
     collection_usage: CollectionUsage,
     configuration: Configuration,
     quota: Quota,
+    delete_all: DeleteAll,
 }
 
 #[derive(Deserialize)]

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -24,6 +24,12 @@ macro_rules! init_routes {
             .resource("{uid}/info/quota", |r| {
                 r.method(http::Method::GET).with(handlers::quota);
             })
+            .resource("{uid}", |r| {
+                r.method(http::Method::DELETE).with(handlers::delete_all);
+            })
+            .resource("{uid}/storage", |r| {
+                r.method(http::Method::DELETE).with(handlers::delete_all);
+            })
             .resource("{uid}/storage/{collection}", |r| {
                 r.method(http::Method::DELETE)
                     .with(handlers::delete_collection);

--- a/src/server/test.rs
+++ b/src/server/test.rs
@@ -68,6 +68,12 @@ fn quota() {
 }
 
 #[test]
+fn delete_all() {
+    test_endpoint(http::Method::DELETE, "deadbeef", "null");
+    test_endpoint(http::Method::DELETE, "deadbeef/storage", "null");
+}
+
+#[test]
 fn delete_collection() {
     test_endpoint(http::Method::DELETE, "deadbeef/storage/bookmarks", "null");
     test_endpoint(


### PR DESCRIPTION
Fixes #13.

I thought I'd covered all the outstanding endpoints in #9, but I didn't spot `DELETE /{uid}` and `DELETE /{uid}/storage`. Those are definitely the last two though, unless there are others not in the document I'm referring to:

https://mozilla-services.readthedocs.io/en/latest/storage/apis-1.5.html

@bbangert @pjenvey r?


