### PR TITLE
feat: define and mock a db trait

### DIFF
--- a/src/db/mock.rs
+++ b/src/db/mock.rs
@@ -1,0 +1,40 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Mock db implementation with methods stubbed to return default values.
+
+use futures::future;
+
+use super::*;
+
+#[derive(Debug)]
+pub struct MockDb;
+
+macro_rules! mock_db_method {
+    ($name:ident, $type:ident) => {
+        fn $name(&self, _params: params::$type) -> DbFuture<results::$type> {
+            Box::new(future::result(Ok(results::$type::default())))
+        }
+    }
+}
+
+impl Db for MockDb {
+    fn new() -> Box<Db> {
+        Box::new(MockDb)
+    }
+
+    mock_db_method!(get_collections, GetCollections);
+    mock_db_method!(get_collection_counts, GetCollectionCounts);
+    mock_db_method!(get_collection_usage, GetCollectionUsage);
+    mock_db_method!(get_quota, GetQuota);
+    mock_db_method!(delete_all, DeleteAll);
+    mock_db_method!(delete_collection, DeleteCollection);
+    mock_db_method!(get_collection, GetCollection);
+    mock_db_method!(post_collection, PostCollection);
+    mock_db_method!(delete_bso, DeleteBso);
+    mock_db_method!(get_bso, GetBso);
+    mock_db_method!(put_bso, PutBso);
+}
+
+unsafe impl Send for MockDb {}

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,5 +1,67 @@
-pub mod models;
-#[cfg(test)]
-mod models_test;
-pub mod schema;
-pub mod util;
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Generic db abstration.
+
+pub mod mock;
+pub mod params;
+pub mod results;
+
+use std::{
+    error::Error,
+    fmt::{self, Display, Formatter},
+};
+
+use futures::future::Future;
+
+type DbFuture<T> = Box<Future<Item = T, Error = DbError>>;
+
+pub trait Db: Send {
+    fn new() -> Box<Db>
+    where
+        Self: Sized;
+
+    fn get_collections(&self, params: params::GetCollections) -> DbFuture<results::GetCollections>;
+
+    fn get_collection_counts(
+        &self,
+        params: params::GetCollectionCounts,
+    ) -> DbFuture<results::GetCollectionCounts>;
+
+    fn get_collection_usage(
+        &self,
+        params: params::GetCollectionUsage,
+    ) -> DbFuture<results::GetCollectionUsage>;
+
+    fn get_quota(&self, params: params::GetQuota) -> DbFuture<results::GetQuota>;
+
+    fn delete_all(&self, params: params::DeleteAll) -> DbFuture<results::DeleteAll>;
+
+    fn delete_collection(
+        &self,
+        params: params::DeleteCollection,
+    ) -> DbFuture<results::DeleteCollection>;
+
+    fn get_collection(&self, params: params::GetCollection) -> DbFuture<results::GetCollection>;
+
+    fn post_collection(&self, params: params::PostCollection) -> DbFuture<results::PostCollection>;
+
+    fn delete_bso(&self, params: params::DeleteBso) -> DbFuture<results::DeleteBso>;
+
+    fn get_bso(&self, params: params::GetBso) -> DbFuture<results::GetBso>;
+
+    fn put_bso(&self, params: params::PutBso) -> DbFuture<results::PutBso>;
+}
+
+// HACK: temporary placeholder until we have proper error-handling
+#[derive(Debug)]
+pub struct DbError(String);
+
+impl Display for DbError {
+    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
+        write!(formatter, "db error: {}", &self.0)
+    }
+}
+
+impl Error for DbError {}

--- a/src/db/params.rs
+++ b/src/db/params.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, you can obtain one at https://mozilla.org/MPL/2.0/.
 
-//! Data definitions.
+//! Parameter types for database methods.
 
 macro_rules! data {
     ($name:ident {$($property:ident: $type:ty,)*}) => {
@@ -49,11 +49,10 @@ macro_rules! bso_data {
 }
 
 uid_data! {
-    Collections,
-    CollectionCounts,
-    CollectionUsage,
-    Configuration,
-    Quota,
+    GetCollections,
+    GetCollectionCounts,
+    GetCollectionUsage,
+    GetQuota,
     DeleteAll,
 }
 
@@ -71,16 +70,16 @@ bso_data! {
     DeleteBso {},
     GetBso {},
     PutBso {
-        sortindex: Option<i64>,
+        sortindex: Option<i32>,
         payload: Option<String>,
-        ttl: Option<i64>,
+        ttl: Option<u32>,
     },
 }
 
 #[derive(Debug)]
 pub struct PostCollectionBso {
     pub bso_id: String,
-    pub sortindex: Option<i64>,
+    pub sortindex: Option<i32>,
     pub payload: Option<String>,
-    pub ttl: Option<i64>,
+    pub ttl: Option<u32>,
 }

--- a/src/db/results.rs
+++ b/src/db/results.rs
@@ -1,0 +1,47 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Result types for database methods.
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+pub type GetCollections = HashMap<String, u64>;
+pub type GetCollectionCounts = HashMap<String, u64>;
+pub type GetCollectionUsage = HashMap<String, u32>;
+pub type GetQuota = Vec<u32>;
+pub type DeleteAll = ();
+pub type GetCollection = Vec<GetCollectionItem>;
+pub type DeleteCollection = Option<DeleteBsos>;
+pub type DeleteBso = ();
+pub type PutBso = u64;
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum GetCollectionItem {
+    Id(String),
+    Bso(GetBso),
+}
+
+#[derive(Debug, Default, Deserialize, Serialize)]
+pub struct GetBso {
+    pub id: String,
+    pub modified: u64,
+    pub payload: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sortindex: Option<i32>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct DeleteBsos {
+    modified: u64,
+}
+
+#[derive(Debug, Default, Deserialize, Serialize)]
+pub struct PostCollection {
+    pub modified: u64,
+    pub success: Vec<String>,
+    pub failed: HashMap<String, String>,
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! Main application
 #[macro_use]
 extern crate actix;
@@ -22,8 +26,6 @@ use std::error::Error;
 
 use docopt::Docopt;
 
-#[macro_use]
-mod data;
 mod db;
 mod handlers;
 mod server;

--- a/src/server/test.rs
+++ b/src/server/test.rs
@@ -1,14 +1,18 @@
-use std::sync::{Arc, Mutex, RwLock};
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at https://mozilla.org/MPL/2.0/.
 
 use actix_web::test::TestServer;
 use actix_web::HttpMessage;
+use serde::de::DeserializeOwned;
 use serde_json;
 
 use super::*;
+use db::results::{GetBso, GetCollection, PostCollection, PutBso};
 use handlers::{BsoBody, PostCollectionBody};
 
 fn setup() -> TestServer {
-    TestServer::build_with_state(move || ServerState).start(|app| {
+    TestServer::build_with_state(move || ServerState { db: MockDb::new() }).start(|app| {
         init_routes!(app);
     })
 }
@@ -25,8 +29,24 @@ fn test_endpoint(method: http::Method, path: &str, expected_body: &str) {
     assert_eq!(body, expected_body.as_bytes());
 }
 
+fn test_endpoint_with_response<T>(method: http::Method, path: &str, assertions: &Fn(T) -> ())
+where
+    T: DeserializeOwned,
+{
+    let mut server = setup();
+
+    let request = server.client(method, path).finish().unwrap();
+
+    let response = server.execute(request.send()).unwrap();
+    assert!(response.status().is_success());
+
+    let body = server.execute(response.body()).unwrap();
+    let result: T = serde_json::from_slice(&*body).unwrap();
+    assertions(result);
+}
+
 macro_rules! test_endpoint_with_body {
-    ($method:ident, $path:expr, $body:expr, $expected_body:expr) => {
+    ($method:ident $path:expr, $body:expr, $result:ident: $result_type:ty {$($assertion:expr;)+}) => {
         let mut server = setup();
 
         let request = server
@@ -38,33 +58,34 @@ macro_rules! test_endpoint_with_body {
         assert!(response.status().is_success());
 
         let body = server.execute(response.body()).unwrap();
-        assert_eq!(body, $expected_body.as_bytes());
+        let $result: $result_type = serde_json::from_slice(&*body).unwrap();
+        $($assertion;)+
     };
 }
 
 #[test]
 fn collections() {
-    test_endpoint(http::Method::GET, "deadbeef/info/collections", "null");
+    test_endpoint(http::Method::GET, "deadbeef/info/collections", "{}");
 }
 
 #[test]
 fn collection_counts() {
-    test_endpoint(http::Method::GET, "deadbeef/info/collection_counts", "null");
+    test_endpoint(http::Method::GET, "deadbeef/info/collection_counts", "{}");
 }
 
 #[test]
 fn collection_usage() {
-    test_endpoint(http::Method::GET, "deadbeef/info/collection_usage", "null");
+    test_endpoint(http::Method::GET, "deadbeef/info/collection_usage", "{}");
 }
 
 #[test]
 fn configuration() {
-    test_endpoint(http::Method::GET, "deadbeef/info/configuration", "null");
+    test_endpoint(http::Method::GET, "deadbeef/info/configuration", "{}");
 }
 
 #[test]
 fn quota() {
-    test_endpoint(http::Method::GET, "deadbeef/info/quota", "null");
+    test_endpoint(http::Method::GET, "deadbeef/info/quota", "[]");
 }
 
 #[test]
@@ -90,22 +111,30 @@ fn delete_collection() {
 
 #[test]
 fn get_collection() {
-    test_endpoint(http::Method::GET, "deadbeef/storage/bookmarks", "null");
+    test_endpoint_with_response(
+        http::Method::GET,
+        "deadbeef/storage/bookmarks",
+        &move |collection: GetCollection| {
+            assert_eq!(collection.len(), 0);
+        },
+    );
 }
 
 #[test]
 fn post_collection() {
-    test_endpoint_with_body!(
-        POST,
-        "deadbeef/storage/bookmarks",
-        vec![PostCollectionBody {
+    test_endpoint_with_body! {
+        POST "deadbeef/storage/bookmarks", vec![PostCollectionBody {
             id: "foo".to_string(),
             sortindex: Some(0),
             payload: Some("bar".to_string()),
-            ttl: Some(31536000000),
+            ttl: Some(31536000),
         }],
-        "null"
-    );
+        result: PostCollection {
+            assert_eq!(result.modified, 0);
+            assert_eq!(result.success.len(), 0);
+            assert_eq!(result.failed.len(), 0);
+        }
+    };
 }
 
 #[test]
@@ -119,23 +148,28 @@ fn delete_bso() {
 
 #[test]
 fn get_bso() {
-    test_endpoint(
+    test_endpoint_with_response(
         http::Method::GET,
         "deadbeef/storage/bookmarks/wibble",
-        "null",
+        &move |bso: GetBso| {
+            assert_eq!(bso.id, "");
+            assert_eq!(bso.modified, 0);
+            assert_eq!(bso.payload, "");
+            assert!(bso.sortindex.is_none());
+        },
     );
 }
 
 #[test]
 fn put_bso() {
-    test_endpoint_with_body!(
-        PUT,
-        "deadbeef/storage/bookmarks/wibble",
-        BsoBody {
+    test_endpoint_with_body! {
+        PUT "deadbeef/storage/bookmarks/wibble", BsoBody {
             sortindex: Some(0),
             payload: Some("wibble".to_string()),
-            ttl: Some(31536000000),
+            ttl: Some(31536000),
         },
-        "null"
-    );
+        result: PutBso {
+            assert_eq!(result, 0);
+        }
+    };
 }


### PR DESCRIPTION
Fixes #16.

Continuing from the conversation about my WIP branch in IRC yesterday, this leaves the existing db code mostly untouched but defines a new `Db` trait, plus a `MockDb` stubbed implementation thereof.

I say "mostly" untouched because the old `src/db/mod.rs` has been completely clobbered, so that old code is not actually being compiled any more. I realise that's not very different from deleting it all, but there were enough points of difference here in both the struct definitions and where I've moved them to that it really seemed cleaner to start anew. I'll call out some of those differences in the inline comments and hopefully they make sense to you guys. If not, I can revert some stuff, no worries.

I hooked the new trait into a mock implementation just so the tests would have something to assert against really. It's not a very useful mock apart from that and I expect us to delete it as soon as we have an SQLite implementation for local testing. But the upside of plugging in a mock implementation now was that it gave some flesh to the test cases that need to assert result properties.

@bbangert @pjenvey r?