### PR TITLE
feat: implement Deserialize for the master_secret setting

### DIFF
--- a/src/auth/test.rs
+++ b/src/auth/test.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, you can obtain one at https://mozilla.org/MPL/2.0/.
 
-use super::{HawkPayload, Settings};
+use super::{HawkPayload, Secrets, Settings};
 
 #[test]
 fn valid_header() {
@@ -14,7 +14,7 @@ fn valid_header() {
         &fixture.request.path,
         &fixture.request.host,
         fixture.request.port,
-        &fixture.settings.master_token_secret,
+        &fixture.settings.master_secret,
         fixture.expected.expires.round() as u64 - 1,
     );
 
@@ -42,7 +42,7 @@ fn valid_header_with_querystring() {
         &fixture.request.path,
         &fixture.request.host,
         fixture.request.port,
-        &fixture.settings.master_token_secret,
+        &fixture.settings.master_secret,
         fixture.expected.expires.round() as u64 - 1,
     );
 
@@ -62,7 +62,7 @@ fn missing_hawk_prefix() {
         &fixture.request.path,
         &fixture.request.host,
         fixture.request.port,
-        &fixture.settings.master_token_secret,
+        &fixture.settings.master_secret,
         fixture.expected.expires.round() as u64 - 1,
     );
 
@@ -79,7 +79,7 @@ fn bad_master_secret() {
         &fixture.request.path,
         &fixture.request.host,
         fixture.request.port,
-        &"wibble".as_bytes().to_vec(),
+        &Secrets::new("wibble"),
         fixture.expected.expires.round() as u64 - 1,
     );
 
@@ -101,7 +101,7 @@ fn bad_signature() {
         &fixture.request.path,
         &fixture.request.host,
         fixture.request.port,
-        &fixture.settings.master_token_secret,
+        &fixture.settings.master_secret,
         fixture.expected.expires.round() as u64 - 1,
     );
 
@@ -118,7 +118,7 @@ fn expired_payload() {
         &fixture.request.path,
         &fixture.request.host,
         fixture.request.port,
-        &fixture.settings.master_token_secret,
+        &fixture.settings.master_secret,
         fixture.expected.expires.round() as u64,
     );
 
@@ -136,7 +136,7 @@ fn bad_mac() {
         &fixture.request.path,
         &fixture.request.host,
         fixture.request.port,
-        &fixture.settings.master_token_secret,
+        &fixture.settings.master_secret,
         fixture.expected.expires.round() as u64 - 1,
     );
 
@@ -154,7 +154,7 @@ fn bad_nonce() {
         &fixture.request.path,
         &fixture.request.host,
         fixture.request.port,
-        &fixture.settings.master_token_secret,
+        &fixture.settings.master_secret,
         fixture.expected.expires.round() as u64 - 1,
     );
 
@@ -172,7 +172,7 @@ fn bad_ts() {
         &fixture.request.path,
         &fixture.request.host,
         fixture.request.port,
-        &fixture.settings.master_token_secret,
+        &fixture.settings.master_secret,
         fixture.expected.expires.round() as u64 - 1,
     );
 
@@ -190,7 +190,7 @@ fn bad_method() {
         &fixture.request.path,
         &fixture.request.host,
         fixture.request.port,
-        &fixture.settings.master_token_secret,
+        &fixture.settings.master_secret,
         fixture.expected.expires.round() as u64 - 1,
     );
 
@@ -211,7 +211,7 @@ fn bad_path() {
         &fixture.request.path,
         &fixture.request.host,
         fixture.request.port,
-        &fixture.settings.master_token_secret,
+        &fixture.settings.master_secret,
         fixture.expected.expires.round() as u64 - 1,
     );
 
@@ -229,7 +229,7 @@ fn bad_host() {
         &fixture.request.path,
         &fixture.request.host,
         fixture.request.port,
-        &fixture.settings.master_token_secret,
+        &fixture.settings.master_secret,
         fixture.expected.expires.round() as u64 - 1,
     );
 
@@ -247,7 +247,7 @@ fn bad_port() {
         &fixture.request.path,
         &fixture.request.host,
         fixture.request.port,
-        &fixture.settings.master_token_secret,
+        &fixture.settings.master_secret,
         fixture.expected.expires.round() as u64 - 1,
     );
 
@@ -283,7 +283,7 @@ impl TestFixture {
                 database_url: "".to_string(),
                 database_pool_max_size: None,
                 database_use_test_transactions: false,
-                master_token_secret: "Ted Koppel is a robot".as_bytes().to_vec(),
+                master_secret: Secrets::new("Ted Koppel is a robot"),
             },
             expected: HawkPayload {
                 expires: 1536199274.0,

--- a/src/db/mysql/test.rs
+++ b/src/db/mysql/test.rs
@@ -6,7 +6,7 @@ use db::mysql::{
 };
 use db::{params, util::ms_since_epoch, Sorting};
 use env_logger;
-use settings::Settings;
+use settings::{Secrets, Settings};
 
 use diesel::{
     mysql::MysqlConnection,
@@ -36,7 +36,7 @@ pub fn db() -> MysqlDb {
         database_url: settings.database_url,
         database_pool_max_size: Some(1),
         database_use_test_transactions: true,
-        master_token_secret: vec![],
+        master_secret: Secrets::default(),
     };
 
     run_embedded_migrations(&settings).unwrap();

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -12,7 +12,7 @@ use actix_web::{http, middleware::cors::Cors, server::HttpServer, App};
 
 use db::{mock::MockDb, Db};
 use handlers;
-use settings::Settings;
+use settings::{Secrets, Settings};
 
 macro_rules! init_routes {
     ($app:expr) => {
@@ -54,7 +54,7 @@ mod test;
 /// HTTP API calls.
 pub struct ServerState {
     pub db: Box<Db>,
-    pub master_token_secret: Arc<Vec<u8>>,
+    pub secrets: Arc<Secrets>,
 }
 
 pub struct Server {}
@@ -62,14 +62,14 @@ pub struct Server {}
 impl Server {
     pub fn with_settings(settings: Settings) -> SystemRunner {
         let sys = System::new("syncserver");
-        let master_token_secret = Arc::new(settings.master_token_secret);
+        let secrets = Arc::new(settings.master_secret);
 
         HttpServer::new(move || {
             // Setup the server state
             let state = ServerState {
                 // TODO: replace MockDb with a real implementation
                 db: Box::new(MockDb::new()),
-                master_token_secret: master_token_secret.clone(),
+                secrets: secrets.clone(),
             };
 
             App::with_state(state).configure(|app| init_routes!(Cors::for_app(app)).register())


### PR DESCRIPTION
Fixes #26.

The `master_secret` setting is a `Vec<u8>`, for which there is no default deserialization. This change pulls it out to a struct and implements `Deserialize` so that it can be set with a string via environment variable or config file.

That change also represented an opportunity to cache the value of `signing_secret`, which was being freshly calculated on every request even though the value is a constant derived from `master_secret`. So the struct is actually called `Secrets` and has two properties.

This does leave a slightly weird naming mismatch that I wasn't sure what to do with. `master_secret` makes sense from the perspective of setting e.g. a `SYNC_MASTER_SECRET` environment variable, but it looks kind of funny when the code accesses that property internally as a `Secrets` struct with its own `master_secret` and `signing_secret` properties. I tried to minimise the weirdness by passing around the `Secrets` instance and elsewhere referring to that variable/argument as `secrets`. I hope that doesn't seem wilfully confusing.

@bbangert @pjenvey r?