### PR TITLE
chore: quiet diesel warnings under rust 1.29

### DIFF
--- a/src/db/models_test.rs
+++ b/src/db/models_test.rs
@@ -1,3 +1,5 @@
+#![allow(proc_macro_derive_resolution_fallback)]
+
 use std::collections::HashMap;
 
 use diesel::{sql_query, sql_types::Integer, QueryDsl, RunQueryDsl};

--- a/src/db/mysql/models.rs
+++ b/src/db/mysql/models.rs
@@ -1,3 +1,5 @@
+#![allow(proc_macro_derive_resolution_fallback)]
+
 use std::{self, ops::Deref};
 
 use diesel::{

--- a/src/db/mysql/schema.rs
+++ b/src/db/mysql/schema.rs
@@ -1,3 +1,5 @@
+#![allow(proc_macro_derive_resolution_fallback)]
+
 table! {
     batches (user_id, collection_id, id) {
         user_id -> Integer,

--- a/src/db/results.rs
+++ b/src/db/results.rs
@@ -1,5 +1,7 @@
 //! Result types for database methods.
 
+#![allow(proc_macro_derive_resolution_fallback)]
+
 use std::collections::HashMap;
 
 use diesel::sql_types::{BigInt, Integer, Nullable, Text};


### PR DESCRIPTION
temporary until (likely) diesel 1.4:
https://github.com/diesel-rs/diesel/issues/1785