### PR TITLE
feat: load default and env-specific settings from the file system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ autopush_rs/_native*
 target
 *.rs.bk
 .#*
+config/local.*

--- a/config/default.toml
+++ b/config/default.toml
@@ -1,0 +1,5 @@
+debug = false
+port = 8000
+database_url = "mysql://root@127.0.0.1/syncstorage"
+database_use_test_transactions = false
+master_secret = ""

--- a/src/db/mysql/test.rs
+++ b/src/db/mysql/test.rs
@@ -6,7 +6,7 @@ use db::mysql::{
 };
 use db::{params, util::ms_since_epoch, Sorting};
 use env_logger;
-use settings::{Secrets, Settings};
+use settings::Settings;
 
 use diesel::{
     mysql::MysqlConnection,
@@ -29,15 +29,10 @@ impl CustomizeConnection<MysqlConnection, PoolError> for TestTransactionCustomiz
 pub fn db() -> MysqlDb {
     let _ = env_logger::try_init();
     // inherit SYNC_DATABASE_URL from the env
-    let settings = Settings::with_env_and_config_file(&None).unwrap();
-    let settings = Settings {
-        debug: true,
-        port: 8000,
-        database_url: settings.database_url,
-        database_pool_max_size: Some(1),
-        database_use_test_transactions: true,
-        master_secret: Secrets::default(),
-    };
+    let mut settings = Settings::with_env_and_config_file(None).unwrap();
+    settings.debug = true;
+    settings.database_pool_max_size = Some(1);
+    settings.database_use_test_transactions = true;
 
     run_embedded_migrations(&settings).unwrap();
     let pool = MysqlDbPool::new(&settings).unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,7 +59,7 @@ fn main() -> Result<(), Box<Error>> {
     let args: Args = Docopt::new(USAGE)
         .and_then(|d| d.deserialize())
         .unwrap_or_else(|e| e.exit());
-    let settings = settings::Settings::with_env_and_config_file(&args.flag_config)?;
+    let settings = settings::Settings::with_env_and_config_file(args.flag_config)?;
 
     // Setup and run the server
     let sys = server::Server::with_settings(settings);

--- a/src/web/auth.rs
+++ b/src/web/auth.rs
@@ -425,6 +425,8 @@ mod tests {
 
     impl TestFixture {
         fn new() -> TestFixture {
+            let mut settings = Settings::with_env_and_config_file(None).unwrap();
+            settings.master_secret = Secrets::new("Ted Koppel is a robot");
             TestFixture {
                 header: HawkHeader::new(
                     "eyJub2RlIjogImh0dHA6Ly9sb2NhbGhvc3Q6NTAwMCIsICJ1aWQiOiAxLCAiZXhwaXJlcyI6IDE1MzYxOTkyNzQsICJmeGFfdWlkIjogIjMxOWI5OGY5OTYxZmYxZGJkZDA3MzEzY2Q2YmE5MjVhIiwgInNhbHQiOiAiYjAyNjBlIiwgImRldmljZV9pZCI6ICJjMDlkMjZmYWYyYjQ5YWI2NGEyODgyOTA3MjA2ZDBiNSJ96drmQ_KNFOe7U3g1D8ZX5-he2Bv2aRvKZzBPrCjHKO4=",
@@ -438,14 +440,7 @@ mod tests {
                     "localhost",
                     5000,
                 ),
-                settings: Settings {
-                    debug: false,
-                    port: 0,
-                    database_url: "".to_string(),
-                    database_pool_max_size: None,
-                    database_use_test_transactions: false,
-                    master_secret: Secrets::new("Ted Koppel is a robot"),
-                },
+                settings,
                 expected: HawkPayload {
                     expires: 1536199274.0,
                     node: "http://localhost:5000".to_string(),


### PR DESCRIPTION
I wonder whether you guys will think this is over-engineered nonsense, so fwiw I'm totes cool with just closing it if you're thinking YAGNI or whatever.

Anyway, this change pulls out the default settings to `config/default.json` and also tries to load environment-specific settings from `config/$SYNC_ENV.json`. My thinking is that this will be useful when we want to point at a standard GCP region/zone for dev and CI environments.

There's also an attempt to load from `config/local.json`, which is added to `.gitignore` so that there is the option to locally set `master_secret` or a password for the MySQL connection string without accidentally committing them to the repo.

Lastly there is a quick check added to make sure `master_secret` is set to something in prod.

I've retained the `filename` argument (and command-line arg) because I wasn't sure whether they're being used. If they're not and there's no plan to use them we could also just delete.

@bbangert @pjenvey r?