### PR TITLE
refactor: create a db Session w/ a canonical timestamp

### DIFF
--- a/src/db/params.rs
+++ b/src/db/params.rs
@@ -76,7 +76,6 @@ pub struct PutBso<'a> {
     pub user_id: HawkIdentifier,
     pub collection_id: i32,
     pub id: String,
-    pub modified: i64,
     pub sortindex: Option<i32>,
     pub payload: Option<Cow<'a, str>>,
     pub ttl: Option<u32>,

--- a/src/web/handlers.rs
+++ b/src/web/handlers.rs
@@ -3,7 +3,7 @@
 use actix_web::{error::ResponseError, FutureResponse, HttpResponse, Json, Path, Query, State};
 use futures::future::{self, Future};
 
-use db::{params, util::ms_since_epoch, DbError};
+use db::{params, DbError};
 use server::ServerState;
 use web::auth::{HawkIdentifier, HawkPayload};
 use web::extractors::{
@@ -167,7 +167,6 @@ pub fn put_bso(
                 user_id: auth,
                 collection_id: 2,
                 id: params.bso.clone(),
-                modified: ms_since_epoch(),
                 sortindex: body.sortindex,
                 payload: body.payload.as_ref().map(|payload| payload.into()),
                 ttl: body.ttl,


### PR DESCRIPTION
and quiet a warning under #[cfg(test)]

Closes #55