### PR TITLE
feat: add path uid validation to HawkIdentifier extractor

### DIFF
--- a/src/db/mysql/models.rs
+++ b/src/db/mysql/models.rs
@@ -28,7 +28,7 @@ use db::{
     Db, DbFuture, Sorting,
 };
 use settings::Settings;
-use web::auth::HawkIdentifier;
+use web::extractors::HawkIdentifier;
 
 embed_migrations!();
 

--- a/src/db/mysql/test.rs
+++ b/src/db/mysql/test.rs
@@ -15,7 +15,7 @@ use db::mysql::{
 use db::{error::DbErrorKind, params, Sorting};
 use env_logger;
 use settings::{Secrets, ServerLimits, Settings};
-use web::auth::HawkIdentifier;
+use web::extractors::HawkIdentifier;
 
 // distant future (year 2099) timestamp for tests
 pub const MAX_TIMESTAMP: u64 = 4070937600000;

--- a/src/db/params.rs
+++ b/src/db/params.rs
@@ -1,7 +1,7 @@
 //! Parameter types for database methods.
 use std::borrow::Cow;
 
-use web::auth::HawkIdentifier;
+use web::extractors::HawkIdentifier;
 
 macro_rules! data {
     ($name:ident {$($property:ident: $type:ty,)*}) => {

--- a/src/web/auth.rs
+++ b/src/web/auth.rs
@@ -24,42 +24,6 @@ use time::Duration;
 use server::ServerState;
 use settings::{Secrets, Settings};
 
-/// Represents a user-identifier that is extract from the authentication token
-///
-/// This token should be adapted as needed for the storage system to store data
-/// for the user.
-#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
-pub struct HawkIdentifier {
-    /// For MySQL database backends as the primary key
-    pub legacy_id: u64,
-    /// For NoSQL database backends that require randomly distributed primary keys
-    pub fxa_id: String,
-}
-
-impl FromRequest<ServerState> for HawkIdentifier {
-    type Config = Settings;
-    type Result = AuthResult<HawkIdentifier>;
-
-    /// Use HawkPayload extraction and format as HawkIdentifier.
-    fn from_request(request: &HttpRequest<ServerState>, settings: &Self::Config) -> Self::Result {
-        let payload = HawkPayload::from_request(request, settings)?;
-        Ok(HawkIdentifier {
-            legacy_id: payload.user_id,
-            fxa_id: "".to_string(),
-        })
-    }
-}
-
-impl HawkIdentifier {
-    /// Create a new legacy id user identifier
-    pub fn new_legacy(user_id: u64) -> HawkIdentifier {
-        HawkIdentifier {
-            legacy_id: user_id,
-            ..Default::default()
-        }
-    }
-}
-
 /// A parsed and authenticated JSON payload
 /// extracted from the signed `id` property
 /// of a Hawk `Authorization` header.

--- a/src/web/handlers.rs
+++ b/src/web/handlers.rs
@@ -5,9 +5,10 @@ use futures::future::{self, Future};
 
 use db::{params, DbError};
 use server::ServerState;
-use web::auth::{HawkIdentifier, HawkPayload};
+use web::auth::HawkPayload;
 use web::extractors::{
-    BsoBody, BsoParams, BsoQueryParams, CollectionParams, GetCollectionRequest, MetaRequest,
+    BsoBody, BsoParams, BsoQueryParams, CollectionParams, GetCollectionRequest, HawkIdentifier,
+    MetaRequest,
 };
 
 pub fn get_collections(meta: MetaRequest) -> FutureResponse<HttpResponse> {


### PR DESCRIPTION
Per extract_target_resource extraction from the Python version, this
add's uid validation to the HawkIdentifier extraction.

Issue #48