### PR TITLE
fix: return an array from GET /info/quota

### DIFF
--- a/src/server/test.rs
+++ b/src/server/test.rs
@@ -150,7 +150,7 @@ fn configuration() {
 
 #[test]
 fn quota() {
-    test_endpoint(http::Method::GET, "/42/info/quota", "0");
+    test_endpoint(http::Method::GET, "/42/info/quota", "[0,null]");
 }
 
 #[test]

--- a/src/web/handlers.rs
+++ b/src/web/handlers.rs
@@ -50,7 +50,7 @@ pub fn get_quota(meta: MetaRequest) -> FutureResponse<HttpResponse> {
             .get_storage_usage(&params::GetStorageUsage {
                 user_id: meta.user_id,
             }).map_err(From::from)
-            .map(|result| HttpResponse::Ok().json(result)),
+            .map(|result| HttpResponse::Ok().json(vec![Some(result), None])),
     )
 }
 


### PR DESCRIPTION
Just a little tidler, this. I was catching up on some of the changes from last week and noticed the response payload for the quota endpoint got changed from an array.

The API docs say:

> Returns a two-item list giving the user’s current usage and quota (in KB). The second item will be null if the server does not enforce quotas.

And (I think, IIUC) the Python code looks the same?

r?