### PR TITLE
fix: use posix-friendly logical and in docs script

### DIFF
--- a/scripts/build-docs.sh
+++ b/scripts/build-docs.sh
@@ -8,7 +8,7 @@ set -e
 
 echo "Branch: $TRAVIS_BRANCH    Pull request: $TRAVIS_PULL_REQUEST"
 
-if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+if [ "$TRAVIS_BRANCH" == "master" -a "$TRAVIS_PULL_REQUEST" == "false" ]; then
   echo "Building docs for deployment."
   cargo doc --document-private-items
 


### PR DESCRIPTION
Sorry, I only tested my changes to this script locally before pushing them and accidentally included a bash-style `&&` operator that [fails in travis](https://travis-ci.org/mozilla-services/syncstorage-rs/builds/441775963#L548-L551):

```
$ ./scripts/build-docs.sh
Branch: master    Pull request: false
./scripts/build-docs.sh: 11: [: master: unexpected operator
Not building docs for deployment, omitting dependencies.
```

@r?