### PR TITLE
fix: use single = for equality test in docs script

### DIFF
--- a/scripts/build-docs.sh
+++ b/scripts/build-docs.sh
@@ -8,7 +8,7 @@ set -e
 
 echo "Branch: $TRAVIS_BRANCH    Pull request: $TRAVIS_PULL_REQUEST"
 
-if [ "$TRAVIS_BRANCH" == "master" -a "$TRAVIS_PULL_REQUEST" == "false" ]; then
+if [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then
   echo "Building docs for deployment."
   cargo doc --document-private-items
 


### PR DESCRIPTION
I actually checked the [build output](https://travis-ci.org/mozilla-services/syncstorage-rs/builds/442286722#L546-L550) this time and it appears to have run without errors:

```
$ ./scripts/build-docs.sh
Branch: pb/fix-docs-script-again    Pull request: false
Not building docs for deployment, omitting dependencies.
 Documenting syncstorage v0.1.0 (file:///home/travis/build/mozilla-services/syncstorage-rs)
    Finished dev [unoptimized + debuginfo] target(s) in 17.94s
```

Thanks for the tip @pjenvey, you were right about the single/double equals.

r?