### PR TITLE
feat: map db and hawk errors to a common top-level error type

### DIFF
--- a/src/db/error.rs
+++ b/src/db/error.rs
@@ -43,48 +43,12 @@ impl DbError {
     }
 }
 
-impl Fail for DbError {
-    fn cause(&self) -> Option<&Fail> {
-        self.inner.cause()
-    }
+failure_boilerplate!(DbError, DbErrorKind);
 
-    fn backtrace(&self) -> Option<&Backtrace> {
-        self.inner.backtrace()
-    }
-}
-
-impl fmt::Display for DbError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Display::fmt(&self.inner, f)
-    }
-}
-
-impl From<DbErrorKind> for DbError {
-    fn from(kind: DbErrorKind) -> DbError {
-        Context::new(kind).into()
-    }
-}
-
-impl From<Context<DbErrorKind>> for DbError {
-    fn from(inner: Context<DbErrorKind>) -> DbError {
-        DbError { inner }
-    }
-}
-
-impl From<diesel::result::Error> for DbError {
-    fn from(inner: diesel::result::Error) -> DbError {
-        DbErrorKind::Query(inner).into()
-    }
-}
-
-impl From<diesel::r2d2::PoolError> for DbError {
-    fn from(inner: diesel::r2d2::PoolError) -> DbError {
-        DbErrorKind::Pool(inner).into()
-    }
-}
-
-impl From<diesel_migrations::RunMigrationsError> for DbError {
-    fn from(inner: diesel_migrations::RunMigrationsError) -> DbError {
-        DbErrorKind::Migration(inner).into()
-    }
-}
+from_error!(diesel::result::Error, DbError, DbErrorKind::Query);
+from_error!(diesel::r2d2::PoolError, DbError, DbErrorKind::Pool);
+from_error!(
+    diesel_migrations::RunMigrationsError,
+    DbError,
+    DbErrorKind::Migration
+);

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,80 @@
+//! Error types and macros.
+
+use std::fmt;
+
+use actix_web::error::ResponseError;
+use failure::{Backtrace, Context, Fail};
+
+use db::error::DbError;
+use web::error::HawkError;
+
+/// Common `Result` type.
+pub type ApiResult<T> = Result<T, ApiError>;
+
+/// Top-level error type.
+#[derive(Debug)]
+pub struct ApiError {
+    inner: Context<ApiErrorKind>,
+}
+
+/// Top-level ErrorKind.
+#[derive(Debug, Fail)]
+pub enum ApiErrorKind {
+    #[fail(display = "{}", _0)]
+    Db(#[cause] DbError),
+
+    #[fail(display = "HAWK authentication error: {}", _0)]
+    Hawk(#[cause] HawkError),
+}
+
+impl ResponseError for ApiError {}
+
+// XXX: We can remove this if/when db methods return ApiError directly
+impl ResponseError for DbError {}
+
+macro_rules! failure_boilerplate {
+    ($error:ty, $kind:ty) => {
+        impl Fail for $error {
+            fn cause(&self) -> Option<&Fail> {
+                self.inner.cause()
+            }
+
+            fn backtrace(&self) -> Option<&Backtrace> {
+                self.inner.backtrace()
+            }
+        }
+
+        impl fmt::Display for $error {
+            fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                fmt::Display::fmt(&self.inner, formatter)
+            }
+        }
+
+        impl From<$kind> for $error {
+            fn from(kind: $kind) -> Self {
+                Context::new(kind).into()
+            }
+        }
+
+        impl From<Context<$kind>> for $error {
+            fn from(inner: Context<$kind>) -> Self {
+                Self { inner }
+            }
+        }
+    };
+}
+
+failure_boilerplate!(ApiError, ApiErrorKind);
+
+macro_rules! from_error {
+    ($from:ty, $to:ty, $to_kind:expr) => {
+        impl From<$from> for $to {
+            fn from(inner: $from) -> $to {
+                $to_kind(inner).into()
+            }
+        }
+    };
+}
+
+from_error!(DbError, ApiError, ApiErrorKind::Db);
+from_error!(HawkError, ApiError, ApiErrorKind::Hawk);

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,6 +41,8 @@ use std::error::Error;
 
 use docopt::Docopt;
 
+#[macro_use]
+pub mod error;
 pub mod db;
 pub mod server;
 pub mod settings;

--- a/src/web/error.rs
+++ b/src/web/error.rs
@@ -1,0 +1,82 @@
+//! Error types for `web` modules.
+
+use std::fmt;
+
+use actix_web::http::header::ToStrError;
+use base64::DecodeError;
+use failure::{Backtrace, Context, Fail, SyncFailure};
+use hawk::Error as ParseError;
+use hmac::crypto_mac::{InvalidKeyLength, MacError};
+use serde_json::Error as JsonError;
+
+use error::ApiError;
+
+/// An error occurred during HAWK authentication.
+#[derive(Debug)]
+pub struct HawkError {
+    inner: Context<HawkErrorKind>,
+}
+
+/// Causes of HAWK errors.
+#[derive(Debug, Fail)]
+pub enum HawkErrorKind {
+    #[fail(display = "{}", _0)]
+    Base64(#[cause] DecodeError),
+
+    #[fail(display = "expired payload")]
+    Expired,
+
+    #[fail(display = "{}", _0)]
+    Header(#[cause] ToStrError),
+
+    #[fail(display = "{}", _0)]
+    Hmac(MacError),
+
+    #[fail(display = "validation failed")]
+    InvalidHeader,
+
+    #[fail(display = "{}", _0)]
+    InvalidKeyLength(InvalidKeyLength),
+
+    #[fail(display = "{}", _0)]
+    Json(#[cause] JsonError),
+
+    #[fail(display = "missing header")]
+    MissingHeader,
+
+    #[fail(display = "missing id property")]
+    MissingId,
+
+    #[fail(display = "missing path")]
+    MissingPath,
+
+    #[fail(display = "missing \"Hawk \" prefix")]
+    MissingPrefix,
+
+    #[fail(display = "{}", _0)]
+    Parse(SyncFailure<ParseError>),
+
+    #[fail(display = "id property is too short")]
+    TruncatedId,
+}
+
+failure_boilerplate!(HawkError, HawkErrorKind);
+
+from_error!(DecodeError, ApiError, HawkErrorKind::Base64);
+from_error!(InvalidKeyLength, ApiError, HawkErrorKind::InvalidKeyLength);
+from_error!(JsonError, ApiError, HawkErrorKind::Json);
+from_error!(MacError, ApiError, HawkErrorKind::Hmac);
+from_error!(ToStrError, ApiError, HawkErrorKind::Header);
+
+impl From<HawkErrorKind> for ApiError {
+    fn from(kind: HawkErrorKind) -> Self {
+        let hawk_error: HawkError = Context::new(kind).into();
+        hawk_error.into()
+    }
+}
+
+impl From<ParseError> for ApiError {
+    fn from(inner: ParseError) -> Self {
+        HawkErrorKind::Parse(SyncFailure::new(inner)).into()
+    }
+}

--- a/src/web/handlers.rs
+++ b/src/web/handlers.rs
@@ -1,9 +1,9 @@
 //! API Handlers
 
-use actix_web::{error::ResponseError, FutureResponse, HttpResponse, Json, Path, State};
+use actix_web::{FutureResponse, HttpResponse, Json, Path, State};
 use futures::future::{self, Future};
 
-use db::{params, DbError};
+use db::params;
 use server::ServerState;
 use web::extractors::{
     BsoBody, BsoParams, BsoRequest, CollectionParams, CollectionRequest, HawkIdentifier,
@@ -170,5 +170,3 @@ pub fn get_configuration(
 ) -> FutureResponse<HttpResponse> {
     Box::new(future::result(Ok(HttpResponse::Ok().json(&*state.limits))))
 }
-
-impl ResponseError for DbError {}

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -1,5 +1,6 @@
 //! Web authentication, handlers, and middleware
 pub mod auth;
+pub mod error;
 pub mod extractors;
 pub mod handlers;
 pub mod middleware;


### PR DESCRIPTION
Opened as a first step to fixing #38, only affecting the db and hawk stuff for now. I started to map the validation errors too but there's a lot of code there and it'll probably take me a few attempts to get right, so this seemed worth reviewing in the meantime.

As per #67, there is a top-level `ApiError` that `DbError` and `HawkError` get mapped to. Having one top-level error means we only have to `impl ResponseError` on one thing.

I moved `ApiError` up to `src/error.rs` because it contains a couple of macros that are used in both `src/db/error.rs` and `src/web/error.rs`, so I figured it made sense. And yeah, I got busy with the macros again. 😱

I'm happy to remove them if they're not welcome, I just thought they tidied up some boring and repetitive type-related hoops that we have to jump through.

@bbangert @pjenvey r?