### PR TITLE
refactor: convert validation errors to use failure

### DIFF
--- a/src/web/error.rs
+++ b/src/web/error.rs
@@ -2,13 +2,16 @@
 
 use std::fmt;
 
-use actix_web::http::header::ToStrError;
+use actix_web::{self, http::header::ToStrError};
 use base64::DecodeError;
 use failure::{Backtrace, Context, Fail, SyncFailure};
 use hawk::Error as ParseError;
 use hmac::crypto_mac::{InvalidKeyLength, MacError};
+use serde::ser::{Serialize, SerializeMap, Serializer};
 use serde_json::Error as JsonError;
+use validator;
 
+use super::extractors::RequestErrorLocation;
 use error::ApiError;
 
 /// An error occurred during HAWK authentication.
@@ -60,13 +63,57 @@ pub enum HawkErrorKind {
     TruncatedId,
 }
 
+/// An error occurred in an Actix extractor.
+#[derive(Debug)]
+pub struct ValidationError {
+    inner: Context<ValidationErrorKind>,
+}
+
+/// Causes of extractor errors.
+#[derive(Debug, Fail)]
+pub enum ValidationErrorKind {
+    #[fail(display = "{}", _0)]
+    WithLocation(#[cause] validator::ValidationErrors, RequestErrorLocation),
+
+    #[fail(display = "Conflicting headers: {}, {}", _0, _1)]
+    HeaderConflict(String, String),
+
+    #[fail(display = "Invalid {} header: {}", _0, _1)]
+    InvalidHeader(String, String),
+
+    #[fail(display = "Invalid {} path component: {}", _0, _1)]
+    InvalidPathComponent(String, String),
+
+    #[fail(display = "Invalid query string: {}", _0)]
+    InvalidQueryString(String),
+
+    #[fail(display = "Invalid request: {}", _0)]
+    InvalidRequest(actix_web::Error),
+
+    #[fail(display = "User id in path does not match payload")]
+    MismatchedUserId,
+}
+
 failure_boilerplate!(HawkError, HawkErrorKind);
+failure_boilerplate!(ValidationError, ValidationErrorKind);
 
 from_error!(DecodeError, ApiError, HawkErrorKind::Base64);
 from_error!(InvalidKeyLength, ApiError, HawkErrorKind::InvalidKeyLength);
 from_error!(JsonError, ApiError, HawkErrorKind::Json);
 from_error!(MacError, ApiError, HawkErrorKind::Hmac);
 from_error!(ToStrError, ApiError, HawkErrorKind::Header);
+
+impl From<Context<HawkErrorKind>> for HawkError {
+    fn from(inner: Context<HawkErrorKind>) -> Self {
+        Self { inner }
+    }
+}
+
+impl From<Context<ValidationErrorKind>> for ValidationError {
+    fn from(inner: Context<ValidationErrorKind>) -> Self {
+        Self { inner }
+    }
+}
 
 impl From<HawkErrorKind> for ApiError {
     fn from(kind: HawkErrorKind) -> Self {
@@ -78,5 +125,38 @@ impl From<HawkErrorKind> for ApiError {
 impl From<ParseError> for ApiError {
     fn from(inner: ParseError) -> Self {
         HawkErrorKind::Parse(SyncFailure::new(inner)).into()
+    }
+}
+
+impl From<ValidationErrorKind> for ApiError {
+    fn from(kind: ValidationErrorKind) -> Self {
+        let validation_error: ValidationError = Context::new(kind).into();
+        validation_error.into()
+    }
+}
+
+impl Serialize for ValidationError {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        Serialize::serialize(&self.inner.get_context(), serializer)
+    }
+}
+
+impl Serialize for ValidationErrorKind {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match *self {
+            ValidationErrorKind::WithLocation(ref errors, ref location) => {
+                let mut map = serializer.serialize_map(Some(2))?;
+                map.serialize_entry("location", &location)?;
+                map.serialize_entry("errors", &errors)?;
+                map.end()
+            }
+            _ => serializer.serialize_str(&self.to_string()),
+        }
     }
 }


### PR DESCRIPTION
~~Note this branch is based off the branch for #69, so if you want to review both commits in this PR that's cool, or if it's easier to review them separately I can wait until that one is merged and then rebase this against `master`.~~ (rebased now)

Anyway, this is another step on the road to fixing #38. (I guess just the middleware is left after this?)

It updates the validation errors in `src/web/extractors.rs` to map to `ApiError`. In addition to mapping the error types, it also meant bringing across the status code and serialization stuff, hence `ApiError` has grown a `status` property and there are some implementations of `Serialize` introduced to make sure we return all the error details.

Additionally, because a couple of the db errors seemed like 400s rather than 500s, `DbError` has also grown its own `status` property to model that duality. I'm not sure, is that a layering violation, or is it okay for the db layer to know that some of its errors translate to 400s at the API boundary? I'm happy to do something different for this if you have suggestions.

The other contentious part of these changes is that the validation errors aren't strictly uniform. Some of them go through `WithLocation` and some of them are just custom error strings like the `DbError` and `HawkError` cases. This is purely a result of how I progressed through the module, I tackled the `WithLocation` stuff last and had already done the others. If it's important for them all to use the same structure, I can go back in and change them, no worries.

@bbangert @pjenvey r?