### PR TITLE
feat: plugin and cleanup various trait methods into MysqlDb:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,8 @@ script:
   - cargo fmt -- --check
   - cargo build
   - cargo test
-  - ./scripts/build-docs.sh
+  - # XXX: 1.3.0 rustdoc breakage https://github.com/rust-lang/rust/issues/54524
+  - ./scripts/build-docs.sh | true
 
 notifications:
   email: false

--- a/src/db/mock.rs
+++ b/src/db/mock.rs
@@ -30,20 +30,14 @@ impl MockDb {
 
 macro_rules! mock_db_method {
     ($name:ident, $type:ident) => {
-        fn $name(&self, _params: &params::$type) -> DbFuture<results::$type> {
-            Box::new(future::ok(results::$type::default()))
+        mock_db_method!($name, $type, results::$type);
+    };
+    ($name:ident, $type:ident, $result:ty) => {
+        fn $name(&self, _params: params::$type) -> DbFuture<$result> {
+            let result: $result = Default::default();
+            Box::new(future::ok(result))
         }
-    }
-}
-
-// XXX: temporary: takes ownership of params vs mock_db_method taking
-// a reference
-macro_rules! mock_db_method2 {
-    ($name:ident, $type:ident) => {
-        fn $name(&self, _params: params::$type) -> DbFuture<results::$type> {
-            Box::new(future::ok(results::$type::default()))
-        }
-    }
+    };
 }
 
 impl Db for MockDb {
@@ -55,22 +49,20 @@ impl Db for MockDb {
         Box::new(future::ok(()))
     }
 
-    mock_db_method2!(lock_for_read, LockCollection);
-    mock_db_method2!(lock_for_write, LockCollection);
-
-    mock_db_method!(get_collection_id, GetCollectionId);
-    mock_db_method!(get_collections, GetCollections);
+    mock_db_method!(lock_for_read, LockCollection);
+    mock_db_method!(lock_for_write, LockCollection);
+    mock_db_method!(get_collection_modifieds, GetCollectionModifieds);
     mock_db_method!(get_collection_counts, GetCollectionCounts);
     mock_db_method!(get_collection_usage, GetCollectionUsage);
     mock_db_method!(get_storage_usage, GetStorageUsage);
-    mock_db_method!(delete_all, DeleteAll);
+    mock_db_method!(delete_storage, DeleteStorage);
     mock_db_method!(delete_collection, DeleteCollection);
     mock_db_method!(get_collection, GetCollection);
     mock_db_method!(post_collection, PostCollection);
+    mock_db_method!(delete_bsos, DeleteBsos);
     mock_db_method!(delete_bso, DeleteBso);
-    mock_db_method!(get_bso, GetBso);
-
-    mock_db_method2!(put_bso, PutBso);
+    mock_db_method!(get_bso, GetBso, Option<results::GetBso>);
+    mock_db_method!(put_bso, PutBso);
 }
 
 unsafe impl Send for MockDb {}

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -51,44 +51,42 @@ pub trait Db: Send {
 
     fn rollback(&self) -> DbFuture<()>;
 
-    fn get_collection_id(
+    fn get_collection_modifieds(
         &self,
-        params: &params::GetCollectionId,
-    ) -> DbFuture<results::GetCollectionId>;
-
-    fn get_collections(&self, params: &params::GetCollections)
-        -> DbFuture<results::GetCollections>;
+        params: params::GetCollectionModifieds,
+    ) -> DbFuture<results::GetCollectionModifieds>;
 
     fn get_collection_counts(
         &self,
-        params: &params::GetCollectionCounts,
+        params: params::GetCollectionCounts,
     ) -> DbFuture<results::GetCollectionCounts>;
 
     fn get_collection_usage(
         &self,
-        params: &params::GetCollectionUsage,
+        params: params::GetCollectionUsage,
     ) -> DbFuture<results::GetCollectionUsage>;
 
     fn get_storage_usage(
         &self,
-        params: &params::GetStorageUsage,
+        params: params::GetStorageUsage,
     ) -> DbFuture<results::GetStorageUsage>;
 
-    fn delete_all(&self, params: &params::DeleteAll) -> DbFuture<results::DeleteAll>;
+    fn delete_storage(&self, params: params::DeleteStorage) -> DbFuture<results::DeleteStorage>;
 
     fn delete_collection(
         &self,
-        params: &params::DeleteCollection,
+        params: params::DeleteCollection,
     ) -> DbFuture<results::DeleteCollection>;
 
-    fn get_collection(&self, params: &params::GetCollection) -> DbFuture<results::GetCollection>;
+    fn delete_bsos(&self, params: params::DeleteBsos) -> DbFuture<results::DeleteBsos>;
 
-    fn post_collection(&self, params: &params::PostCollection)
-        -> DbFuture<results::PostCollection>;
+    fn delete_bso(&self, params: params::DeleteBso) -> DbFuture<results::DeleteBso>;
 
-    fn delete_bso(&self, params: &params::DeleteBso) -> DbFuture<results::DeleteBso>;
+    fn get_collection(&self, params: params::GetCollection) -> DbFuture<results::GetCollection>;
 
-    fn get_bso(&self, params: &params::GetBso) -> DbFuture<results::GetBso>;
+    fn post_collection(&self, params: params::PostCollection) -> DbFuture<results::PostCollection>;
+
+    fn get_bso(&self, params: params::GetBso) -> DbFuture<Option<results::GetBso>>;
 
     fn put_bso(&self, params: params::PutBso) -> DbFuture<results::PutBso>;
 }

--- a/src/db/params.rs
+++ b/src/db/params.rs
@@ -12,11 +12,7 @@ macro_rules! data {
 
 macro_rules! uid_data {
     ($($name:ident,)+) => ($(
-        data! {
-            $name {
-                user_id: HawkIdentifier,
-            }
-        }
+        pub type $name = HawkIdentifier;
     )+)
 }
 
@@ -46,19 +42,18 @@ macro_rules! bso_data {
 }
 
 uid_data! {
-    GetCollections,
+    GetCollectionModifieds,
     GetCollectionCounts,
     GetCollectionUsage,
     GetStorageUsage,
-    DeleteAll,
+    DeleteStorage,
 }
-
-pub type GetCollectionId = str;
 
 collection_data! {
     LockCollection {},
-    DeleteCollection {
-        bso_ids: Vec<String>,
+    DeleteCollection {},
+    DeleteBsos {
+        ids: Vec<String>,
     },
     GetCollection {},
     PostCollection {

--- a/src/db/results.rs
+++ b/src/db/results.rs
@@ -7,15 +7,15 @@ use std::collections::HashMap;
 use diesel::sql_types::{BigInt, Integer, Nullable, Text};
 
 pub type LockCollection = ();
-pub type GetCollectionId = i32;
-pub type GetCollections = HashMap<String, i64>;
+pub type GetCollectionModifieds = HashMap<String, i64>;
 pub type GetCollectionCounts = HashMap<String, i64>;
-pub type GetCollectionUsage = HashMap<String, u32>;
+pub type GetCollectionUsage = HashMap<String, i64>;
 pub type GetStorageUsage = u64;
-pub type DeleteAll = ();
+pub type DeleteStorage = ();
 pub type GetCollection = Vec<GetCollectionItem>;
-pub type DeleteCollection = Option<DeleteBsos>;
-pub type DeleteBso = ();
+pub type DeleteCollection = i64;
+pub type DeleteBsos = i64;
+pub type DeleteBso = i64;
 pub type PutBso = u64;
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -49,10 +49,13 @@ pub struct BSOs {
     pub offset: i64, // XXX: i64?
 }
 
-#[derive(Debug, Serialize)]
-pub struct DeleteBsos {
+// XXX: ideally only used by the handlers (could use json! instead?)
+/*
+#[derive(Debug, Default, Serialize)]
+pub struct DeleteBso {
     modified: u64,
 }
+*/
 
 #[derive(Debug, Default, Deserialize, Serialize)]
 pub struct PostCollection {

--- a/src/server/test.rs
+++ b/src/server/test.rs
@@ -177,13 +177,9 @@ fn delete_all() {
 
 #[test]
 fn delete_collection() {
-    test_endpoint(http::Method::DELETE, "/42/storage/bookmarks", "null");
-    test_endpoint(http::Method::DELETE, "/42/storage/bookmarks?ids=1,", "null");
-    test_endpoint(
-        http::Method::DELETE,
-        "/42/storage/bookmarks?ids=1,2,3",
-        "null",
-    );
+    test_endpoint(http::Method::DELETE, "/42/storage/bookmarks", "0");
+    test_endpoint(http::Method::DELETE, "/42/storage/bookmarks?ids=1,", "0");
+    test_endpoint(http::Method::DELETE, "/42/storage/bookmarks?ids=1,2,3", "0");
 }
 
 #[test]
@@ -216,7 +212,7 @@ fn post_collection() {
 
 #[test]
 fn delete_bso() {
-    test_endpoint(http::Method::DELETE, "/42/storage/bookmarks/wibble", "null");
+    test_endpoint(http::Method::DELETE, "/42/storage/bookmarks/wibble", "0");
 }
 
 #[test]

--- a/src/web/handlers.rs
+++ b/src/web/handlers.rs
@@ -16,9 +16,8 @@ pub fn get_collections(meta: MetaRequest) -> FutureResponse<HttpResponse> {
     Box::new(
         meta.state
             .db
-            .get_collections(&params::GetCollections {
-                user_id: meta.user_id,
-            }).map_err(From::from)
+            .get_collection_modifieds(meta.user_id)
+            .map_err(From::from)
             .map(|result| HttpResponse::Ok().json(result)),
     )
 }
@@ -27,9 +26,8 @@ pub fn get_collection_counts(meta: MetaRequest) -> FutureResponse<HttpResponse> 
     Box::new(
         meta.state
             .db
-            .get_collection_counts(&params::GetCollectionCounts {
-                user_id: meta.user_id,
-            }).map_err(From::from)
+            .get_collection_counts(meta.user_id)
+            .map_err(From::from)
             .map(|result| HttpResponse::Ok().json(result)),
     )
 }
@@ -38,9 +36,8 @@ pub fn get_collection_usage(meta: MetaRequest) -> FutureResponse<HttpResponse> {
     Box::new(
         meta.state
             .db
-            .get_collection_usage(&params::GetCollectionUsage {
-                user_id: meta.user_id,
-            }).map_err(From::from)
+            .get_collection_usage(meta.user_id)
+            .map_err(From::from)
             .map(|result| HttpResponse::Ok().json(result)),
     )
 }
@@ -49,9 +46,8 @@ pub fn get_quota(meta: MetaRequest) -> FutureResponse<HttpResponse> {
     Box::new(
         meta.state
             .db
-            .get_storage_usage(&params::GetStorageUsage {
-                user_id: meta.user_id,
-            }).map_err(From::from)
+            .get_storage_usage(meta.user_id)
+            .map_err(From::from)
             .map(|result| HttpResponse::Ok().json(vec![Some(result), None])),
     )
 }
@@ -60,9 +56,8 @@ pub fn delete_all(meta: MetaRequest) -> FutureResponse<HttpResponse> {
     Box::new(
         meta.state
             .db
-            .delete_all(&params::DeleteAll {
-                user_id: meta.user_id,
-            }).map_err(From::from)
+            .delete_storage(meta.user_id)
+            .map_err(From::from)
             .map(|result| HttpResponse::Ok().json(result)),
     )
 }
@@ -71,14 +66,17 @@ pub fn delete_collection(coll: CollectionRequest) -> FutureResponse<HttpResponse
     Box::new(
         coll.state
             .db
-            .delete_collection(&params::DeleteCollection {
+            .delete_collection(params::DeleteCollection {
                 user_id: coll.user_id,
                 collection: coll.collection,
-                bso_ids: coll
+                // XXX: handle both cases (delete_collection & delete_bsos also)
+                /*
+                ids: coll
                     .query
                     .ids
                     .as_ref()
                     .map_or_else(|| Vec::new(), |ids| ids.clone()),
+                */
             }).map_err(From::from)
             .map(|result| HttpResponse::Ok().json(result)),
     )
@@ -88,7 +86,7 @@ pub fn get_collection(coll: CollectionRequest) -> FutureResponse<HttpResponse> {
     Box::new(
         coll.state
             .db
-            .get_collection(&params::GetCollection {
+            .get_collection(params::GetCollection {
                 user_id: coll.user_id,
                 collection: coll.collection,
             }).map_err(From::from)
@@ -107,7 +105,7 @@ pub fn post_collection(
     Box::new(
         state
             .db
-            .post_collection(&params::PostCollection {
+            .post_collection(params::PostCollection {
                 user_id: auth,
                 collection: "tabs".to_owned(),
                 bsos: body.into_inner().into_iter().map(From::from).collect(),
@@ -121,7 +119,7 @@ pub fn delete_bso(bso_req: BsoRequest) -> FutureResponse<HttpResponse> {
         bso_req
             .state
             .db
-            .delete_bso(&params::DeleteBso {
+            .delete_bso(params::DeleteBso {
                 user_id: bso_req.user_id,
                 collection: bso_req.collection,
                 id: bso_req.bso.clone(),
@@ -135,12 +133,12 @@ pub fn get_bso(bso_req: BsoRequest) -> FutureResponse<HttpResponse> {
         bso_req
             .state
             .db
-            .get_bso(&params::GetBso {
+            .get_bso(params::GetBso {
                 user_id: bso_req.user_id,
                 collection: bso_req.collection,
                 id: bso_req.bso.clone(),
             }).map_err(From::from)
-            .map(|result| HttpResponse::Ok().json(result)),
+            .map(|_result| HttpResponse::Ok().json(::db::results::GetBso::default())),
     )
 }
 


### PR DESCRIPTION
- kills get_collection_id (only used within the db layer now)
- simplify uid_data! (just alias HawkIdentifier)
- phrasing

Issue #65