### PR TITLE
feat: add precondition check middleware and handler headers

### DIFF
--- a/src/db/mock.rs
+++ b/src/db/mock.rs
@@ -56,6 +56,7 @@ impl Db for MockDb {
     mock_db_method!(lock_for_read, LockCollection);
     mock_db_method!(lock_for_write, LockCollection);
     mock_db_method!(get_collection_modifieds, GetCollectionModifieds);
+    mock_db_method!(get_collection_modified, GetCollectionModified);
     mock_db_method!(get_collection_counts, GetCollectionCounts);
     mock_db_method!(get_collection_usage, GetCollectionUsage);
     mock_db_method!(get_storage_modified, GetStorageModified);
@@ -67,6 +68,7 @@ impl Db for MockDb {
     mock_db_method!(post_bsos, PostBsos);
     mock_db_method!(delete_bso, DeleteBso);
     mock_db_method!(get_bso, GetBso, Option<results::GetBso>);
+    mock_db_method!(get_bso_modified, GetBsoModified, results::GetBsoModified);
     mock_db_method!(put_bso, PutBso);
 }
 

--- a/src/db/params.rs
+++ b/src/db/params.rs
@@ -1,6 +1,5 @@
 //! Parameter types for database methods.
-use db::Sorting;
-use web::extractors::{BatchBsoBody, HawkIdentifier};
+use web::extractors::{BatchBsoBody, BsoQueryParams, HawkIdentifier};
 
 macro_rules! data {
     ($name:ident {$($property:ident: $type:ty,)*}) => {
@@ -54,16 +53,12 @@ uid_data! {
 collection_data! {
     LockCollection {},
     DeleteCollection {},
+    GetCollectionModified {},
     DeleteBsos {
         ids: Vec<String>,
     },
     GetBsos {
-        ids: Vec<String>,
-        older: u64,
-        newer: u64,
-        sort: Sorting,
-        limit: i64,  // XXX: limit/offset i64?
-        offset: i64,
+        params: BsoQueryParams,
     },
     PostBsos {
         bsos: Vec<PostCollectionBso>,
@@ -73,6 +68,7 @@ collection_data! {
 bso_data! {
     DeleteBso {},
     GetBso {},
+    GetBsoModified {},
 }
 
 pub struct PutBso {

--- a/src/db/util.rs
+++ b/src/db/util.rs
@@ -1,4 +1,5 @@
 #![allow(proc_macro_derive_resolution_fallback)]
+use std::u64;
 
 use chrono::offset::Utc;
 use diesel::{
@@ -35,7 +36,7 @@ impl SyncTimestamp {
         val.parse::<f64>()
             .map_err(|_| "Invalid value")
             .and_then(|v| {
-                if v < 0f64 {
+                if v < 0f64 || v > ((u64::MAX / 1_000u64) as f64) || v.is_nan() {
                     Err("Invalid value")
                 } else {
                     Ok(v)

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -65,6 +65,7 @@ pub fn build_app(state: ServerState) -> App<ServerState> {
     App::with_state(state)
         .middleware(middleware::WeaveTimestamp)
         .middleware(middleware::DbTransaction)
+        .middleware(middleware::PreConditionCheck)
         .configure(|app| init_routes!(Cors::for_app(app)).register())
 }
 
@@ -72,6 +73,7 @@ pub struct Server {}
 
 impl Server {
     pub fn with_settings(settings: Settings) -> Result<SystemRunner, DbError> {
+        env_logger::init();
         let sys = System::new("syncserver");
         let db_pool = Box::new(MysqlDbPool::new(&settings)?);
         let limits = Arc::new(settings.limits);


### PR DESCRIPTION
Most handler functions now have the appropriate header added. The
precondition middleware returns the request early if the modified
header and database differ.

Closes #78