### PR TITLE
feat: add get_bso_ids for full=false

### DIFF
--- a/src/db/mock.rs
+++ b/src/db/mock.rs
@@ -65,6 +65,7 @@ impl Db for MockDb {
     mock_db_method!(delete_collection, DeleteCollection);
     mock_db_method!(delete_bsos, DeleteBsos);
     mock_db_method!(get_bsos, GetBsos);
+    mock_db_method!(get_bso_ids, GetBsoIds);
     mock_db_method!(post_bsos, PostBsos);
     mock_db_method!(delete_bso, DeleteBso);
     mock_db_method!(get_bso, GetBso, Option<results::GetBso>);

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -7,6 +7,8 @@ pub mod params;
 pub mod results;
 pub mod util;
 
+use std::fmt::Debug;
+
 use futures::future::Future;
 
 pub use self::error::{DbError, DbErrorKind};
@@ -39,11 +41,11 @@ lazy_static! {
 
 type DbFuture<T> = Box<Future<Item = T, Error = DbError>>;
 
-pub trait DbPool: Sync {
+pub trait DbPool: Sync + Debug {
     fn get(&self) -> DbFuture<Box<dyn Db>>;
 }
 
-pub trait Db: Send {
+pub trait Db: Send + Debug {
     fn lock_for_read(&self, params: params::LockCollection) -> DbFuture<()>;
 
     fn lock_for_write(&self, params: params::LockCollection) -> DbFuture<()>;
@@ -92,6 +94,8 @@ pub trait Db: Send {
     fn delete_bsos(&self, params: params::DeleteBsos) -> DbFuture<results::DeleteBsos>;
 
     fn get_bsos(&self, params: params::GetBsos) -> DbFuture<results::GetBsos>;
+
+    fn get_bso_ids(&self, params: params::GetBsos) -> DbFuture<results::GetBsoIds>;
 
     fn post_bsos(&self, params: params::PostBsos) -> DbFuture<results::PostBsos>;
 

--- a/src/db/mysql/pool.rs
+++ b/src/db/mysql/pool.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::HashMap,
+    fmt,
     sync::{Arc, RwLock},
 };
 
@@ -88,6 +89,13 @@ impl DbPool for MysqlDbPool {
     }
 }
 
+impl fmt::Debug for MysqlDbPool {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "MysqlDbPool {{ coll_cache: {:?} }}", self.coll_cache)
+    }
+}
+
+#[derive(Debug)]
 pub struct CollectionCache {
     pub by_name: RwLock<HashMap<String, i32>>,
     pub by_id: RwLock<HashMap<i32, String>>,

--- a/src/db/params.rs
+++ b/src/db/params.rs
@@ -88,6 +88,8 @@ collection_data! {
     },
 }
 
+pub type GetBsoIds = GetBsos;
+
 bso_data! {
     DeleteBso {},
     GetBso {},
@@ -107,6 +109,7 @@ pub struct PutBso {
     pub id: String,
     pub sortindex: Option<i32>,
     pub payload: Option<String>,
+    // ttl in seconds
     pub ttl: Option<u32>,
 }
 
@@ -115,6 +118,7 @@ pub struct PostCollectionBso {
     pub id: String,
     pub sortindex: Option<i32>,
     pub payload: Option<String>,
+    // ttl in seconds
     pub ttl: Option<u32>,
 }
 

--- a/src/db/results.rs
+++ b/src/db/results.rs
@@ -48,11 +48,13 @@ pub struct GetBso {
 }
 
 #[derive(Debug, Default)]
-pub struct GetBsos {
-    pub bsos: Vec<GetBso>,
-    pub more: bool,
-    pub offset: i64, // XXX: i64?
+pub struct Paginated<T> {
+    pub items: Vec<T>,
+    pub offset: Option<i64>, // XXX: i64?
 }
+
+pub type GetBsos = Paginated<GetBso>;
+pub type GetBsoIds = Paginated<String>;
 
 #[derive(Debug, Default, Deserialize, Serialize)]
 pub struct PostBsos {

--- a/src/db/util.rs
+++ b/src/db/util.rs
@@ -69,7 +69,7 @@ impl SyncTimestamp {
         SyncTimestamp(val - (val % 10))
     }
 
-    /// Return the timestamp as an i64
+    /// Return the timestamp as an i64 milliseconds
     pub fn as_i64(&self) -> i64 {
         self.0 as i64
     }

--- a/src/web/extractors.rs
+++ b/src/web/extractors.rs
@@ -426,6 +426,7 @@ impl FromRequest<ServerState> for CollectionPostRequest {
 /// BSO Request Delete/Get extractor
 ///
 /// Extracts/validates information needed for BSO delete/get requests.
+#[derive(Debug)]
 pub struct BsoRequest {
     pub collection: String,
     pub db: Box<dyn Db>,
@@ -825,8 +826,7 @@ where
 {
     let maybe_str: Option<String> = Deserialize::deserialize(deserializer)?;
     if let Some(val) = maybe_str {
-        let result =
-            SyncTimestamp::from_header(&val).map_err(|_| SerdeError::custom("Invalid value"))?;
+        let result = SyncTimestamp::from_header(&val).map_err(|e| SerdeError::custom(e))?;
         Ok(Some(result))
     } else {
         Ok(None)


### PR DESCRIPTION
also:

- ensure db middleware rolls back errors that don't trigger the response
method being called and rolling back for us
- fix ttl handling (the come in as seconds not milliseconds)
- add Debug to db traits

Issue #18