### PR TITLE
Two tiny tweaks for Sentry

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,10 @@ authors = [
   "Phil Jenvey <pjenvey@underboss.org>",
 ]
 
+[profile.release]
+# Enables line numbers in Sentry
+debug = 1
+
 [dependencies]
 actix = "0.7"
 actix-web = "0.7.7"

--- a/src/db/error.rs
+++ b/src/db/error.rs
@@ -65,7 +65,13 @@ impl From<Context<DbErrorKind>> for DbError {
             _ => StatusCode::INTERNAL_SERVER_ERROR,
         };
 
-        Self { inner, status }
+        let error = Self { inner, status };
+
+        if status == StatusCode::INTERNAL_SERVER_ERROR {
+            sentry::integrations::failure::capture_fail(&error);
+        }
+
+        error
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -132,9 +132,7 @@ macro_rules! failure_boilerplate {
 
         impl From<$kind> for $error {
             fn from(kind: $kind) -> Self {
-                let error = Context::new(kind).into();
-                sentry::integrations::failure::capture_fail(&error);
-                error
+                Context::new(kind).into()
             }
         }
     };


### PR DESCRIPTION
Fixes #90.

These are both things I had to fix recently in fxa-email-service, I presume we want to do the same here.

* In b2935f5, I stop capturing every error in Sentry because it's too noisy. Currently the only 500 errors we return are from the db error module, so I moved the capture into there.

* In 9d99c01, I include debug symbols in the release builds so that Sentry can include line numbers in stack traces.

@bbangert @pjenvey r?