### PR TITLE
fix: 404 on deletes of non existent individual bsos

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,17 @@ API docs: https://mozilla-services.readthedocs.io/en/latest/storage/apis-1.5.htm
 Code docs: https://mozilla-services.github.io/syncstorage-rs/syncstorage/
 
 Functional tests live in https://github.com/mozilla-services/server-syncstorage/
-and can be run against a local server like this:
+and can be run against a local server, e.g.:
 
+Local server:
+```apple js
+SYNC_MASTER_SECRET=<SOMESECRET> SYNC_DATABASE_URL=mysql://scott:tiger@localhost/syncstorage cargo run
+```
+
+Test runner:
 ```apple js
 git clone https://github.com/mozilla-services/server-syncstorage/
 cd server-syncstorage
 make build
-./local/bin/python syncstorage/tests/functional/test_storage.py http://localhost:8000
+./local/bin/python syncstorage/tests/functional/test_storage.py http://localhost:8000#<SOMESECRET>
 ```

--- a/src/db/error.rs
+++ b/src/db/error.rs
@@ -60,8 +60,9 @@ impl DbError {
 impl From<Context<DbErrorKind>> for DbError {
     fn from(inner: Context<DbErrorKind>) -> Self {
         let status = match inner.get_context() {
-            DbErrorKind::CollectionNotFound => StatusCode::BAD_REQUEST,
-            DbErrorKind::BsoNotFound => StatusCode::BAD_REQUEST,
+            DbErrorKind::CollectionNotFound | DbErrorKind::BsoNotFound => StatusCode::NOT_FOUND,
+            // Matching the Python code here (a 400 vs 404)
+            DbErrorKind::BatchNotFound => StatusCode::BAD_REQUEST,
             _ => StatusCode::INTERNAL_SERVER_ERROR,
         };
 

--- a/src/db/mysql/pool.rs
+++ b/src/db/mysql/pool.rs
@@ -84,7 +84,9 @@ impl DbPool for MysqlDbPool {
     fn get(&self) -> DbFuture<Box<dyn Db>> {
         let pool = self.clone();
         Box::new(self.thread_pool.spawn_handle(lazy(move || {
-            pool.get_sync().map(|db| Box::new(db) as Box<dyn Db>)
+            pool.get_sync()
+                .map(|db| Box::new(db) as Box<dyn Db>)
+                .map_err(Into::into)
         })))
     }
 }

--- a/src/db/mysql/test.rs
+++ b/src/db/mysql/test.rs
@@ -903,8 +903,15 @@ fn delete_bsos() -> Result<()> {
         ))?;
     }
     db.delete_bso_sync(dbso(uid, coll, "b0"))?;
-    // deleting non existant bid returns no errors
-    db.delete_bso_sync(dbso(uid, coll, "bxi0"))?;
+    // deleting non existant bid errors
+    match db
+        .delete_bso_sync(dbso(uid, coll, "bxi0"))
+        .unwrap_err()
+        .kind()
+    {
+        DbErrorKind::BsoNotFound => (),
+        _ => assert!(false),
+    }
     db.delete_bsos_sync(dbsos(uid, coll, &["b1", "b2"]))?;
     for bid in bids {
         let bso = db.get_bso_sync(gbso(uid, coll, &bid))?;

--- a/src/server/test.rs
+++ b/src/server/test.rs
@@ -232,18 +232,15 @@ fn post_collection() {
 
 #[test]
 fn delete_bso() {
-    #[derive(Debug, Default, Deserialize)]
-    pub struct DeleteBso {
-        modified: SyncTimestamp,
-    }
-    let start = SyncTimestamp::default();
-    test_endpoint_with_response(
+    let mut server = setup();
+
+    let request = create_request(
+        &server,
         http::Method::DELETE,
         "/1.5/42/storage/bookmarks/wibble",
-        &move |dbso: DeleteBso| {
-            assert!(dbso.modified > start);
-        },
     );
+    let response = server.execute(request.send()).unwrap();
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }
 
 #[test]


### PR DESCRIPTION
also:

- switch Db to return ApiErrors so they're rendered correctly
- hide the awful ergonomics of matching NotFound errors behind methods (for now
at least)

Closes #93