### PR TITLE
fix: return a 415 for unsupported content-type headers

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -75,7 +75,7 @@ impl From<Context<ApiErrorKind>> for ApiError {
             ApiErrorKind::Db(error) => error.status,
             ApiErrorKind::Hawk(_) => StatusCode::UNAUTHORIZED,
             ApiErrorKind::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
-            ApiErrorKind::Validation(_) => StatusCode::BAD_REQUEST,
+            ApiErrorKind::Validation(error) => error.status,
         };
 
         Self { inner, status }

--- a/src/server/test.rs
+++ b/src/server/test.rs
@@ -271,3 +271,27 @@ fn put_bso() {
         }
     };
 }
+
+#[test]
+fn invalid_content_type() {
+    let mut server = setup();
+    let request = server
+        .client(http::Method::PUT, "/1.5/42/storage/bookmarks/wibble")
+        .set_header(
+            "Authorization",
+            create_hawk_header(
+                "PUT",
+                server.addr().port(),
+                "/1.5/42/storage/bookmarks/wibble",
+            ),
+        ).set_header("Content-Type", "application/javascript")
+        .json(BsoBody {
+            id: Some("wibble".to_string()),
+            sortindex: Some(0),
+            payload: Some("wibble".to_string()),
+            ttl: Some(31536000),
+        }).unwrap();
+
+    let response = server.execute(request.send()).unwrap();
+    assert_eq!(response.status(), StatusCode::UNSUPPORTED_MEDIA_TYPE);
+}

--- a/src/web/extractors.rs
+++ b/src/web/extractors.rs
@@ -201,12 +201,11 @@ impl FromRequest<ServerState> for BsoBody {
         match headers.get(CONTENT_TYPE).unwrap_or(&default).as_bytes() {
             b"application/json" | b"text/plain" | b"" => (),
             _ => {
-                // TODO: This is supposed to return a 415 status for unknown content-type
                 return Box::new(future::err(
                     ValidationErrorKind::FromDetails(
                         "Invalid content-type".to_owned(),
                         RequestErrorLocation::Header,
-                        Some("content-type".to_owned()),
+                        Some("Content-Type".to_owned()),
                     ).into(),
                 ));
             }


### PR DESCRIPTION
Fixes #76, returning a 415 when the `Content-Type` header is wrong.

@pjenvey @bbangert r?