### PR TITLE
feat: always set last-modified header, don't add content for 304

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -63,8 +63,8 @@ pub struct ServerState {
 
 pub fn build_app(state: ServerState) -> App<ServerState> {
     App::with_state(state)
-        .middleware(middleware::WeaveTimestamp)
         .middleware(middleware::DbTransaction)
+        .middleware(middleware::WeaveTimestamp)
         .middleware(middleware::PreConditionCheck)
         .configure(|app| init_routes!(Cors::for_app(app)).register())
 }


### PR DESCRIPTION
Fixes e2e tests that verified the X-Last-Modified header should always
be set. Also fixed issue with 304 returning content without a content
type when it shouldn't return any content at all.

Closes #96