### PR TITLE
feat: fix extractors, middleware for e2e tests

### DIFF
--- a/src/db/mysql/batch.rs
+++ b/src/db/mysql/batch.rs
@@ -94,6 +94,7 @@ pub fn commit(db: &MysqlDb, params: params::CommitBatch) -> Result<results::Comm
         user_id: params.user_id.clone(),
         collection: params.collection.clone(),
         bsos,
+        failed: Default::default(),
     });
     delete(
         db,

--- a/src/db/mysql/models.rs
+++ b/src/db/mysql/models.rs
@@ -500,7 +500,7 @@ impl MysqlDb {
         let mut result = results::PostBsos {
             modified: self.timestamp(),
             success: Default::default(),
-            failed: Default::default(),
+            failed: input.failed,
         };
 
         for pbso in input.bsos {

--- a/src/db/mysql/test.rs
+++ b/src/db/mysql/test.rs
@@ -725,6 +725,7 @@ fn post_bsos() -> Result<()> {
             postbso("b1", Some("payload 1"), Some(1000000000), None),
             postbso("b2", Some("payload 2"), Some(100), None),
         ],
+        failed: Default::default(),
     })?;
 
     assert!(result.success.contains(&"b0".to_owned()));
@@ -748,6 +749,7 @@ fn post_bsos() -> Result<()> {
             postbso("b0", Some("updated 0"), Some(11), Some(100000)),
             postbso("b2", Some("updated 2"), Some(22), Some(10000)),
         ],
+        failed: Default::default(),
     })?;
 
     assert_eq!(result2.success.len(), 2);

--- a/src/db/params.rs
+++ b/src/db/params.rs
@@ -1,6 +1,7 @@
 //! Parameter types for database methods.
 
 #![allow(proc_macro_derive_resolution_fallback)]
+use std::collections::HashMap;
 
 use web::extractors::{BatchBsoBody, BsoQueryParams, HawkIdentifier};
 
@@ -65,6 +66,7 @@ collection_data! {
     },
     PostBsos {
         bsos: Vec<PostCollectionBso>,
+        failed: HashMap<String, String>,
     },
 
     CreateBatch {

--- a/src/web/error.rs
+++ b/src/web/error.rs
@@ -71,6 +71,12 @@ pub struct ValidationError {
     pub status: StatusCode,
 }
 
+impl ValidationError {
+    pub fn kind(&self) -> &ValidationErrorKind {
+        self.inner.get_context()
+    }
+}
+
 /// Causes of extractor errors.
 #[derive(Debug, Fail)]
 pub enum ValidationErrorKind {

--- a/src/web/handlers.rs
+++ b/src/web/handlers.rs
@@ -161,6 +161,7 @@ pub fn post_collection(coll: CollectionPostRequest) -> FutureResponse<HttpRespon
                 user_id: coll.user_id,
                 collection: coll.collection,
                 bsos: coll.bsos.valid.into_iter().map(From::from).collect(),
+                failed: coll.bsos.invalid,
             }).map_err(From::from)
             .map(|result| {
                 HttpResponse::build(StatusCode::OK)

--- a/src/web/middleware.rs
+++ b/src/web/middleware.rs
@@ -155,7 +155,8 @@ impl Middleware<ServerState> for PreConditionCheck {
             match <Option<PreConditionHeader> as FromRequest<ServerState>>::from_request(&req, &())
             {
                 Ok(Some(precondition)) => precondition,
-                Ok(None) | Err(_) => return Ok(Started::Done),
+                Ok(None) => return Ok(Started::Done),
+                Err(e) => return Ok(Started::Response(e.into())),
             };
         let user_id = HawkIdentifier::from_request(&req, &())?;
         let db = <Box<dyn Db>>::from_request(&req, &())?;


### PR DESCRIPTION
Extractors now use proper limits from the state object. BSO handling
during deserialization/validation matches Python more closely.

Closes #97