### PR TITLE
fix: use SyncTimestamp for sane WeaveTimestamp comparisons

### DIFF
--- a/src/db/util.rs
+++ b/src/db/util.rs
@@ -75,9 +75,14 @@ impl SyncTimestamp {
         SyncTimestamp(val - (val % 10))
     }
 
-    /// Return the timestamp as an i64 milliseconds
+    /// Return the timestamp as an i64 milliseconds since epoch
     pub fn as_i64(&self) -> i64 {
         self.0 as i64
+    }
+
+    /// Return the timestamp as an f64 seconds since epoch
+    pub fn as_seconds(&self) -> f64 {
+        self.0 as f64 / 1000.0
     }
 }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -63,8 +63,8 @@ pub struct ServerState {
 
 pub fn build_app(state: ServerState) -> App<ServerState> {
     App::with_state(state)
-        .middleware(middleware::DbTransaction)
         .middleware(middleware::WeaveTimestamp)
+        .middleware(middleware::DbTransaction)
         .middleware(middleware::PreConditionCheck)
         .configure(|app| init_routes!(Cors::for_app(app)).register())
 }


### PR DESCRIPTION
to match the level of timestamp precision. also have its middleware run first
to match python