### PR TITLE
feat: Add debugging to track database locking failures.

### DIFF
--- a/src/web/extractors.rs
+++ b/src/web/extractors.rs
@@ -711,7 +711,10 @@ impl FromRequest<ServerState> for Box<dyn Db> {
     fn from_request(req: &HttpRequest<ServerState>, _: &Self::Config) -> Self::Result {
         req.extensions()
             .get::<(Box<dyn Db>, bool)>()
-            .ok_or_else(|| ErrorInternalServerError("Unexpected Db error"))
+            .ok_or_else(|| {
+                dbg!("No database handle associated with request, Did the lock attempt fail?");
+                ErrorInternalServerError("Unexpected DB error")
+            })
             .map(|(db, _)| db.clone())
     }
 }

--- a/src/web/middleware.rs
+++ b/src/web/middleware.rs
@@ -129,7 +129,6 @@ impl Middleware<ServerState> for DbTransaction {
                     req.extensions_mut().insert((db, in_transaction));
                     future::ok(None)
                 })
-                .map_err(Into::into)
             })
             .map_err(Into::into);
         Ok(Started::Future(Box::new(fut)))

--- a/src/web/middleware.rs
+++ b/src/web/middleware.rs
@@ -115,6 +115,7 @@ impl Middleware<ServerState> for DbTransaction {
                         }
                         .or_else(move |e| {
                             // Middleware::response won't be called: rollback immediately
+                            dbg!(format!("Failed to get database lock: {:?}", e));
                             db2.rollback().and_then(|_| future::err(e))
                         }),
                     )
@@ -128,6 +129,7 @@ impl Middleware<ServerState> for DbTransaction {
                     req.extensions_mut().insert((db, in_transaction));
                     future::ok(None)
                 })
+                .map_err(Into::into)
             })
             .map_err(Into::into);
         Ok(Started::Future(Box::new(fut)))


### PR DESCRIPTION
Database locking failures can cause intermittent integration test
failures. The errors appear to get lost on the way out and eventually
get resolved to "Unexpected Db error". This logs the locking failure at
the time of occurrence, at least.

Issue #146