### PR TITLE
fix: reject unknown fields in PUT bso

### DIFF
--- a/src/server/test.rs
+++ b/src/server/test.rs
@@ -274,6 +274,7 @@ fn put_bso() {
             sortindex: Some(0),
             payload: Some("wibble".to_string()),
             ttl: Some(31_536_000),
+            ..Default::default()
         },
         result: PutBso {
             assert!(result >= start);
@@ -300,6 +301,7 @@ fn invalid_content_type() {
             sortindex: Some(0),
             payload: Some("wibble".to_string()),
             ttl: Some(31_536_000),
+            ..Default::default()
         })
         .unwrap();
 
@@ -318,6 +320,7 @@ fn invalid_content_type() {
             sortindex: Some(0),
             payload: Some("wibble".to_string()),
             ttl: Some(31_536_000),
+            ..Default::default()
         }]))
         .unwrap();
 

--- a/src/web/extractors.rs
+++ b/src/web/extractors.rs
@@ -15,7 +15,7 @@ use lazy_static::lazy_static;
 use mime;
 use regex::Regex;
 use serde::{
-    de::{Deserializer, Error as SerdeError},
+    de::{Deserializer, Error as SerdeError, IgnoredAny},
     Deserialize, Serialize,
 };
 use serde_json::Value;
@@ -47,7 +47,7 @@ pub struct UidParam {
     uid: u64,
 }
 
-#[derive(Debug, Deserialize, Serialize, Validate)]
+#[derive(Debug, Deserialize, Validate)]
 pub struct BatchBsoBody {
     #[validate(custom = "validate_body_bso_id")]
     pub id: String,
@@ -62,8 +62,8 @@ impl BatchBsoBody {
     /// Function to convert valid raw JSON BSO body to a BatchBsoBody
     fn from_raw_bso(val: &Value) -> Result<BatchBsoBody, String> {
         let map = val.as_object().ok_or("invalid json")?;
-        // Verify all the keys are valid
-        let valid_keys = ["id", "sortindex", "payload", "ttl"];
+        // Verify all the keys are valid. modified is allowed but ignored
+        let valid_keys = ["id", "sortindex", "payload", "ttl", "modified"];
         for key_name in map.keys() {
             if !valid_keys.contains(&key_name.as_str()) {
                 return Err(format!("unknown field {}", key_name));
@@ -250,6 +250,7 @@ impl FromRequest<ServerState> for BsoBodies {
 }
 
 #[derive(Default, Deserialize, Serialize, Validate)]
+#[serde(deny_unknown_fields)]
 pub struct BsoBody {
     #[validate(custom = "validate_body_bso_id")]
     pub id: Option<String>,
@@ -258,6 +259,9 @@ pub struct BsoBody {
     pub payload: Option<String>,
     #[validate(custom = "validate_body_bso_ttl")]
     pub ttl: Option<u32>,
+    /// Any client-supplied value for this field is ignored
+    #[serde(rename(deserialize = "modified"), skip_serializing)]
+    pub _ignored_modified: Option<IgnoredAny>,
 }
 
 impl FromRequest<ServerState> for BsoBody {


### PR DESCRIPTION
but ignore modified. fix batch bsos to also ignore modified

Closes #111