### PR TITLE
fix: persist timestamps' decimal place precision through json

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ regex = "1.1.6"
 sentry = "0.15.5"
 serde = "1.0.91"
 serde_derive = "1.0.91"
-serde_json = "1.0.39"
+serde_json = { version = "1.0.39", features = ["arbitrary_precision"] }
 sha2 = "0.8.0"
 time = "0.1.42"
 tokio-threadpool = "0.1.14"

--- a/src/server/test.rs
+++ b/src/server/test.rs
@@ -186,7 +186,7 @@ fn delete_all() {
 #[test]
 fn delete_collection() {
     let start = SyncTimestamp::default();
-    test_endpoint(http::Method::DELETE, "/1.5/42/storage/bookmarks", "0.0");
+    test_endpoint(http::Method::DELETE, "/1.5/42/storage/bookmarks", "0.00");
     test_endpoint_with_response(
         http::Method::DELETE,
         "/1.5/42/storage/bookmarks?ids=1,",


### PR DESCRIPTION
via serde_json's arbitrary_precision feature

Closes #153