### PR TITLE
chore: adding initial PR template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+# Description
+
+Please include a summary of what's changed, and the [type](https://github.com/mozilla-services/syncstorage-rs/blob/master/CONTRIBUTING.md) of change this is.
+
+# How should reviewers test this PR?
+
+Please include details about how these changes should be tested.
+
+# Related issues
+
+* Closes [issue#](link).

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,11 +1,6 @@
-# Description
+Please remember to consult our [contributing guidelines](https://github.com/mozilla-services/syncstorage-rs/blob/master/CONTRIBUTING.md#sending-pull-requests) before opening your PR.
 
-Please include a summary of what's changed, and the [type](https://github.com/mozilla-services/syncstorage-rs/blob/master/CONTRIBUTING.md) of change this is.
-
-# How should reviewers test this PR?
-
-Please include details about how these changes should be tested.
-
-# Related issues
-
-* Closes [issue#](link).
+- [ ] **Title** begins with _type_ (fix, feature, doc, chore, etc) and a short description with no period
+- [ ] **Description**  outlines the change
+- [ ] **Test cases** included in the change (if appropriate)
+- [ ] **Closes** or **Issue** link to associated issue(s)


### PR DESCRIPTION
Once merged, this *should* get automatically picked up by Github when opening new PRs in this repo. Let me know if there's anything else you think would make sense to have as a default here.