### PR TITLE
docs: add info on how to connect to Sentry locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ and can be run against a local server, e.g.:
 
 ## Logging
 
-If you want to connect to the existing [Sentry project](https://sentry.prod.mozaws.net/operations/syncstorage-dev/) for local development, login to Sentry, and head to the page with [api keys](https://sentry.prod.mozaws.net/settings/operations/syncstorage-dev/keys/). Copy the `DSN` value, and `export SENTRY_DSN=DSN_VALUE_GOES_HERE` to the environment when running this project.
+If you want to connect to the existing [Sentry project](https://sentry.prod.mozaws.net/operations/syncstorage-dev/) for local development, login to Sentry, and go to the page with [api keys](https://sentry.prod.mozaws.net/settings/operations/syncstorage-dev/keys/). Copy the `DSN` value, and `export SENTRY_DSN=DSN_VALUE_GOES_HERE` to the environment when running this project.
 
 ## Running the Unit tests
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ and can be run against a local server, e.g.:
         $ export SYNC_DATABASE_URL=mysql://<YOUR_MYSQL_USERNAME>:<YOUR_MYSQL_PASSWORD>@localhost/syncstorage
         $ cargo run
 
+## Logging
+
+If you want to connect to the existing [Sentry project](https://sentry.prod.mozaws.net/operations/syncstorage-dev/) for local development, login to Sentry, and head to the page with [api keys](https://sentry.prod.mozaws.net/settings/operations/syncstorage-dev/keys/). Copy the `DSN` value, and `export SENTRY_DSN=DSN_VALUE_GOES_HERE` to the environment when running this project.
+
 ## Running the Unit tests
 
 1) Run:


### PR DESCRIPTION
- [x] **Title** docs: add info on how to connect to Sentry locally
- [x] **Description**  I figured I'd add this while I was configuring Sentry to make sure it's working.
- [x] **Test cases** See my [sample logged error here](https://sentry.prod.mozaws.net/operations/syncstorage-dev/issues/6452434/?query=is:unresolved) in Sentry dev project.
- [x] **Issue** [251](https://github.com/mozilla-services/syncstorage-rs/issues/251). Gonna keep that issue open until I verify that stg is also setup, which I've got a [bugzilla issue](https://bugzilla.mozilla.org/show_bug.cgi?id=1588172) going.

Issue [251](https://github.com/mozilla-services/syncstorage-rs/issues/251)