### PR TITLE
bug: send logging output to MozLog

### DIFF
--- a/src/logging.rs
+++ b/src/logging.rs
@@ -31,6 +31,7 @@ pub fn init_logging(json: bool) -> ApiResult<()> {
         let drain = slog_async::Async::new(drain).build().fuse();
         slog::Logger::root(drain, slog_o!())
     } else {
+        env_logger::init();
         let decorator = slog_term::TermDecorator::new().build();
         let drain = slog_term::FullFormat::new(decorator).build().fuse();
         let drain = slog_async::Async::new(drain).build().fuse();

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use log::{debug, info};
 use serde_derive::Deserialize;
 
 use syncstorage::{logging, server, settings};
+use logging::init_logging;
 
 const USAGE: &str = "
 Usage: syncstorage [options]
@@ -21,7 +22,11 @@ struct Args {
 }
 
 fn main() -> Result<(), Box<dyn Error>> {
-    env_logger::init();
+    let args: Args = Docopt::new(USAGE)
+        .and_then(|d| d.deserialize())
+        .unwrap_or_else(|e| e.exit());
+    let settings = settings::Settings::with_env_and_config_file(&args.flag_config)?;
+    init_logging(!settings.human_logs).expect("Logging failed to initialize");
     debug!("Starting up...");
     // Set SENTRY_DSN environment variable to enable Sentry.
     // Avoid its default reqwest transport for now due to issues w/
@@ -38,10 +43,6 @@ fn main() -> Result<(), Box<dyn Error>> {
         sentry::integrations::panic::register_panic_handler();
     }
 
-    let args: Args = Docopt::new(USAGE)
-        .and_then(|d| d.deserialize())
-        .unwrap_or_else(|e| e.exit());
-    let settings = settings::Settings::with_env_and_config_file(&args.flag_config)?;
     // Setup and run the server
     let banner = settings.banner();
     let sys = server::Server::with_settings(settings).unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,8 +5,8 @@ use docopt::Docopt;
 use log::{debug, info};
 use serde_derive::Deserialize;
 
-use syncstorage::{logging, server, settings};
 use logging::init_logging;
+use syncstorage::{logging, server, settings};
 
 const USAGE: &str = "
 Usage: syncstorage [options]


### PR DESCRIPTION
This fix routes logging messages through MozLog-json. The
`human_logs=TRUE` option returns human readable logs (like the previous
logging).

Closes #285

Please remember to consult our [contributing guidelines](https://github.com/mozilla-services/syncstorage-rs/blob/master/CONTRIBUTING.md#sending-pull-requests) before opening your PR.

- [x] **Title** begins with _type_ (fix, feature, doc, chore, etc) and a short description with no period
- [x] **Description**  outlines the change
- [ ] **Test cases** included in the change (if appropriate)
- [x] **Closes** or **Issue** link to associated issue(s)