### PR TITLE
feat: use actix_web header parsers

### DIFF
--- a/src/server/test.rs
+++ b/src/server/test.rs
@@ -85,7 +85,8 @@ fn create_request(
         .header(
             "Authorization",
             create_hawk_header(method.as_str(), settings.port, path),
-        );
+        )
+        .header("Accept", "application/json");
     if let Some(body) = payload {
         req = req.set_json(&body);
     };

--- a/src/web/auth.rs
+++ b/src/web/auth.rs
@@ -87,7 +87,7 @@ impl HawkPayload {
         let request = RequestBuilder::new(method, host, port, path).request();
 
         // Toggle the following comments to disable auth (useful for local integration testing)
-        // Ok(payload)
+        //Ok(payload)
         //*
         let mut duration = Duration::weeks(52)
             .to_std()

--- a/src/web/extractors.rs
+++ b/src/web/extractors.rs
@@ -98,6 +98,9 @@ impl BatchBsoBody {
 fn get_accepted(req: &HttpRequest, accepted: &[&str], default: &'static str) -> String {
     let mut candidates = Accept::parse(req)
         .unwrap_or_else(|_| Accept(vec![qitem(mime::Mime::from_str(default).unwrap())]));
+    if candidates.is_empty() {
+        return default.to_owned();
+    }
     candidates.sort_by(|a, b| {
         b.quality
             .partial_cmp(&a.quality)


### PR DESCRIPTION
This patch replaces the hand rolled header parsers with ones from
actix_web. They're not perfect, but they're also someone else's
problem.

Closes #294

Please remember to consult our [contributing guidelines](https://github.com/mozilla-services/syncstorage-rs/blob/master/CONTRIBUTING.md#sending-pull-requests) before opening your PR.

- [x] **Title** begins with _type_ (fix, feature, doc, chore, etc) and a short description with no period
- [x] **Description**  outlines the change
- [x] **Test cases** included in the change (if appropriate)
- [x] **Closes** or **Issue** link to associated issue(s)