### PR TITLE
feat: rearrange the batch impl

### DIFF
--- a/spanner-2019-10-01.ddl
+++ b/spanner-2019-10-01.ddl
@@ -62,9 +62,26 @@ INSERT INTO collections (id, name) VALUES
 CREATE TABLE batches (
   fxa_uid STRING(MAX)  NOT NULL,
   fxa_kid STRING(MAX)  NOT NULL,
-  id TIMESTAMP         NOT NULL,
   collection_id INT64  NOT NULL,
-  bsos STRING(MAX)     NOT NULL,
+  batch_id STRING(MAX) NOT NULL,
   expiry TIMESTAMP     NOT NULL,
-  timestamp TIMESTAMP,
-) PRIMARY KEY(fxa_uid, fxa_kid, collection_id, id);
+)    PRIMARY KEY(fxa_uid, fxa_kid, collection_id, batch_id),
+  INTERLEAVE IN PARENT user_collections ON DELETE CASCADE;
+
+CREATE TABLE batch_bso (
+  fxa_uid STRING(MAX)  NOT NULL,
+  fxa_kid STRING(MAX)  NOT NULL,
+  collection_id INT64  NOT NULL,
+  batch_id STRING(MAX) NOT NULL,
+  id STRING(64)        NOT NULL,
+
+  sortindex INT64,
+  payload STRING(MAX),
+  ttl INT64,
+)    PRIMARY KEY(fxa_uid, fxa_kid, collection_id, batch_id, id),
+  INTERLEAVE IN PARENT batches ON DELETE CASCADE;
+
+-- batch_bso's bso fields are nullable as the batch upload may or may
+-- not set each individual field of each item. Also note that there's
+-- no "modified" column because the modification timestamp gets set on
+-- batch commit.

--- a/src/db/mock.rs
+++ b/src/db/mock.rs
@@ -81,6 +81,10 @@ impl Db for MockDb {
     mock_db_method!(get_batch, GetBatch, Option<results::GetBatch>);
     mock_db_method!(commit_batch, CommitBatch);
 
+    fn validate_batch_id(&self, _: params::ValidateBatchId) -> Result<(), DbError> {
+        Ok(())
+    }
+
     #[cfg(any(test, feature = "db_test"))]
     mock_db_method!(get_collection_id, GetCollectionId);
     #[cfg(any(test, feature = "db_test"))]

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -143,6 +143,8 @@ pub trait Db: Send + Debug {
 
     fn commit_batch(&self, params: params::CommitBatch) -> DbFuture<results::CommitBatch>;
 
+    fn validate_batch_id(&self, params: params::ValidateBatchId) -> Result<(), DbError>;
+
     fn box_clone(&self) -> Box<dyn Db>;
 
     /// Retrieve the timestamp for an item/collection

--- a/src/db/mysql/models.rs
+++ b/src/db/mysql/models.rs
@@ -856,6 +856,9 @@ impl MysqlDb {
     batch_db_method!(validate_batch_sync, validate, ValidateBatch);
     batch_db_method!(append_to_batch_sync, append, AppendToBatch);
     batch_db_method!(commit_batch_sync, commit, CommitBatch);
+    pub fn validate_batch_id(&self, id: String) -> Result<()> {
+        batch::validate_batch_id(&id)
+    }
     #[cfg(any(test, feature = "db_test"))]
     batch_db_method!(delete_batch_sync, delete, DeleteBatch);
 
@@ -954,6 +957,10 @@ impl Db for MysqlDb {
         Option<results::GetBatch>
     );
     sync_db_method!(commit_batch, commit_batch_sync, CommitBatch);
+
+    fn validate_batch_id(&self, params: params::ValidateBatchId) -> Result<()> {
+        self.validate_batch_id(params)
+    }
 
     #[cfg(any(test, feature = "db_test"))]
     fn get_collection_id(&self, name: String) -> DbFuture<i32> {

--- a/src/db/params.rs
+++ b/src/db/params.rs
@@ -73,23 +73,24 @@ collection_data! {
         bsos: Vec<PostCollectionBso>,
     },
     ValidateBatch {
-        id: i64,
+        id: String,
     },
     AppendToBatch {
-        id: i64,
+        id: String,
         bsos: Vec<PostCollectionBso>,
     },
     CommitBatch {
         batch: Batch,
     },
     GetBatch {
-        id: i64,
+        id: String,
     },
     DeleteBatch {
-        id: i64,
+        id: String,
     },
 }
 
+pub type ValidateBatchId = String;
 pub type GetBsoIds = GetBsos;
 
 bso_data! {
@@ -100,7 +101,7 @@ bso_data! {
 
 #[derive(Debug, Default, Queryable)]
 pub struct Batch {
-    pub id: i64,
+    pub id: String,
     pub bsos: String,
     pub expiry: i64,
 }

--- a/src/db/results.rs
+++ b/src/db/results.rs
@@ -21,12 +21,13 @@ pub type DeleteBsos = SyncTimestamp;
 pub type DeleteBso = SyncTimestamp;
 pub type PutBso = SyncTimestamp;
 
-pub type CreateBatch = i64;
+pub type CreateBatch = String;
 pub type ValidateBatch = bool;
 pub type AppendToBatch = ();
 pub type GetBatch = params::Batch;
 pub type DeleteBatch = ();
 pub type CommitBatch = PostBsos;
+pub type ValidateBatchId = ();
 
 #[derive(Debug, Default, Deserialize, Queryable, QueryableByName, Serialize)]
 pub struct GetBso {

--- a/src/db/spanner/batch.rs
+++ b/src/db/spanner/batch.rs
@@ -1,284 +1,195 @@
+use std::str::FromStr;
+
+use googleapis_raw::spanner::v1::type_pb::TypeCode;
+use uuid::Uuid;
+
+use super::support::null_value;
 use super::{
-    models::{Result, SpannerDb},
+    models::{Result, SpannerDb, DEFAULT_BSO_TTL, PRETOUCH_TS},
     support::as_value,
 };
-use crate::db::{params, results, util::to_rfc3339, DbError, DbErrorKind, BATCH_LIFETIME};
-use googleapis_raw::spanner::v1::type_pb::TypeCode;
-use protobuf::well_known_types::ListValue;
-use serde_json::json;
-
-/// Serialize results into strings separated by newlines
-fn results_to_batch_string(results: Vec<ListValue>) -> String {
-    if results.is_empty() {
-        "".to_string()
-    } else {
-        let batch_strings: Vec<String> = results
-            .iter()
-            .map(|result| {
-                result.get_values().to_vec()[1]
-                    .get_string_value()
-                    .to_string()
-            })
-            .filter(|result| !result.is_empty())
-            .collect();
-        batch_strings.join("\n")
-    }
-}
-
-/// Deserialize a batch string into bsos
-fn batch_string_to_bsos(bsos: &str) -> Result<Vec<params::PostCollectionBso>> {
-    bsos.lines()
-        .map(|line| {
-            serde_json::from_str(line).map_err(|e| {
-                DbError::internal(&format!("Couldn't deserialize batch::load_bsos bso: {}", e))
-            })
-        })
-        .collect()
-}
+use crate::{
+    db::{params, results, util::to_rfc3339, DbError, DbErrorKind, BATCH_LIFETIME},
+    web::extractors::HawkIdentifier,
+};
 
 pub fn create(db: &SpannerDb, params: params::CreateBatch) -> Result<results::CreateBatch> {
-    let collection_id = db.get_collection_id(&params.collection)?.to_string();
+    let batch_id = Uuid::new_v4().to_simple().to_string();
+    let collection_id = db.get_collection_id(&params.collection)?;
     let timestamp = db.timestamp()?.as_i64();
-    if params.bsos.is_empty() {
-        db.sql(
-            "INSERT INTO batches (fxa_uid, fxa_kid, collection_id, id, bsos, expiry, timestamp)
-             VALUES (@fxa_uid, @fxa_kid, @collection_id, @bso_id, @bsos, @expiry, @timestamp)",
-        )?
-        .params(params! {
-            "fxa_uid" => params.user_id.fxa_uid.clone(),
-            "fxa_kid" => params.user_id.fxa_kid.clone(),
-            "collection_id" => collection_id.clone(),
-            "bso_id" => to_rfc3339(timestamp)?,
-            "timestamp" => to_rfc3339(timestamp)?,
-            "bsos" => "".to_string(),
-            "expiry" => to_rfc3339(timestamp + BATCH_LIFETIME)?,
-        })
-        .param_types(param_types! {
-            "bso_id" => TypeCode::TIMESTAMP,
-            "expiry" => TypeCode::TIMESTAMP,
-            "timestamp" => TypeCode::TIMESTAMP,
-        })
-        .execute(&db.conn)?;
-    }
-    for (i, bso) in (&params.bsos).iter().enumerate() {
-        let bsos = json!({
-            "id": bso.id,
-            "sortindex": bso.sortindex,
-            "payload": bso.payload,
-            "ttl": bso.ttl,
-        })
-        .to_string();
 
-        db.sql(
-            "INSERT INTO batches (fxa_uid, fxa_kid, collection_id, id, bsos, expiry, timestamp)
-             VALUES (@fxa_uid, @fxa_kid, @collection_id, @bso_id, @bsos, @expiry, @timestamp)",
-        )?
-        .params(params! {
-            "fxa_uid" => params.user_id.fxa_uid.clone(),
-            "fxa_kid" => params.user_id.fxa_kid.clone(),
-            "collection_id" => collection_id.clone(),
-            "bso_id" => to_rfc3339(timestamp + i as i64)?,
-            "timestamp" => to_rfc3339(timestamp)?,
-            "bsos" => bsos,
-            "expiry" => to_rfc3339(timestamp + BATCH_LIFETIME)?,
-        })
-        .param_types(param_types! {
-            "bso_id" => TypeCode::TIMESTAMP,
-            "expiry" => TypeCode::TIMESTAMP,
-            "timestamp" => TypeCode::TIMESTAMP,
-        })
-        .execute(&db.conn)?;
-    }
+    // Ensure a parent record exists in user_collections before writing to batches
+    // (INTERLEAVE IN PARENT user_collections)
+    pretouch_collection(db, &params.user_id, collection_id)?;
 
-    Ok(timestamp)
+    db.sql(
+        "INSERT INTO batches (fxa_uid, fxa_kid, collection_id, batch_id, expiry)
+         VALUES (@fxa_uid, @fxa_kid, @collection_id, @batch_id, @expiry)",
+    )?
+    .params(params! {
+        "fxa_uid" => params.user_id.fxa_uid.clone(),
+        "fxa_kid" => params.user_id.fxa_kid.clone(),
+        "collection_id" => collection_id.to_string(),
+        "batch_id" => batch_id.clone(),
+        "expiry" => to_rfc3339(timestamp + BATCH_LIFETIME)?,
+    })
+    .param_types(param_types! {
+        "expiry" => TypeCode::TIMESTAMP,
+    })
+    .execute(&db.conn)?;
+
+    do_append(
+        db,
+        params.user_id,
+        collection_id,
+        batch_id.clone(),
+        params.bsos,
+    )?;
+    Ok(batch_id)
 }
 
 pub fn validate(db: &SpannerDb, params: params::ValidateBatch) -> Result<bool> {
     let collection_id = db.get_collection_id(&params.collection)?;
     let exists = db
         .sql(
-            "SELECT expiry FROM batches
-              WHERE fxa_uid = @fxa_uid
-                AND fxa_kid = @fxa_kid
-                AND collection_id = @collection_id
-                AND timestamp = @timestamp
-                AND expiry > @expiry",
-        )?
-        .params(params! {
-            "fxa_uid" => params.user_id.fxa_uid,
-            "fxa_kid" => params.user_id.fxa_kid,
-            "collection_id" => collection_id.to_string(),
-            "timestamp" => to_rfc3339(params.id)?,
-            "expiry" => to_rfc3339(db.timestamp()?.as_i64())?,
-        })
-        .param_types(param_types! {
-            "timestamp" => TypeCode::TIMESTAMP,
-            "expiry" => TypeCode::TIMESTAMP,
-        })
-        .execute(&db.conn)?
-        .all_or_none();
-    Ok(exists.is_some())
-}
-
-pub fn select_max_id(db: &SpannerDb, params: params::ValidateBatch) -> Result<i64> {
-    let collection_id = db.get_collection_id(&params.collection)?;
-    let exists = db
-        .sql(
-            "SELECT UNIX_MILLIS(id)
+            "SELECT 1
                FROM batches
               WHERE fxa_uid = @fxa_uid
                 AND fxa_kid = @fxa_kid
                 AND collection_id = @collection_id
-                AND timestamp = @timestamp
-                AND expiry > @expiry
-              ORDER BY id DESC",
+                AND batch_id = @batch_id
+                AND expiry > CURRENT_TIMESTAMP()",
         )?
         .params(params! {
             "fxa_uid" => params.user_id.fxa_uid,
             "fxa_kid" => params.user_id.fxa_kid,
             "collection_id" => collection_id.to_string(),
-            "timestamp" => to_rfc3339(params.id)?,
-            "expiry" => to_rfc3339(db.timestamp()?.as_i64())?,
-        })
-        .param_types(param_types! {
-            "timestamp" => TypeCode::TIMESTAMP,
-            "expiry" => TypeCode::TIMESTAMP,
+            "batch_id" => params.id,
         })
         .execute(&db.conn)?
-        .all_or_none();
-    if let Some(exists) = exists {
-        return Ok(exists[0].get_values().to_vec()[0]
-            .get_string_value()
-            .to_string()
-            .parse::<i64>()
-            .unwrap());
-    }
-    Err(DbError::internal("No rows matched the given query."))
+        .one_or_none()?;
+    Ok(exists.is_some())
 }
 
 pub fn append(db: &SpannerDb, params: params::AppendToBatch) -> Result<()> {
     let mut timer = db.metrics.clone();
     timer.start_timer("syncstorage.storage.spanner.append_items_to_batch", None);
-    let collection_id = db.get_collection_id(&params.collection)?;
-    let timestamp = params.id;
-    if let Ok(max_id) = select_max_id(
+
+    let exists = validate(
         db,
         params::ValidateBatch {
-            id: timestamp,
             user_id: params.user_id.clone(),
             collection: params.collection.clone(),
+            id: params.id.clone(),
         },
-    ) {
-        let mut i = max_id + 1;
-        for bso in &params.bsos {
-            let bsos = json!({
-                "id": bso.id,
-                "sortindex": bso.sortindex,
-                "payload": bso.payload,
-                "ttl": bso.ttl,
-            })
-            .to_string();
-            db.sql(
-                "INSERT INTO batches (fxa_uid, fxa_kid, collection_id, id, bsos, expiry, timestamp)
-                 VALUES (@fxa_uid, @fxa_kid, @collection_id, @bso_id, @bsos, @expiry, @timestamp)",
-            )?
-            .params(params! {
-                "fxa_uid" => params.user_id.fxa_uid.clone(),
-                "fxa_kid" => params.user_id.fxa_kid.clone(),
-                "collection_id" => collection_id.to_string(),
-                "bso_id" => to_rfc3339(params.id + i)?,
-                "timestamp" => to_rfc3339(params.id)?,
-                "expiry" => to_rfc3339(timestamp + BATCH_LIFETIME)?,
-                "bsos" => bsos,
-            })
-            .param_types(param_types! {
-                "bso_id" => TypeCode::TIMESTAMP,
-                "timestamp" => TypeCode::TIMESTAMP,
-                "expiry" => TypeCode::TIMESTAMP,
-            })
-            .execute(&db.conn)?;
-            i += 1;
-        }
-        Ok(())
-    } else {
-        Err(DbErrorKind::BatchNotFound.into())
+    )?;
+    if !exists {
+        // NOTE: db_tests expects this but it doesn't seem necessary w/ the
+        // handler validating the batch before appends
+        Err(DbErrorKind::BatchNotFound)?
     }
+
+    let collection_id = db.get_collection_id(&params.collection)?;
+    do_append(db, params.user_id, collection_id, params.id, params.bsos)?;
+    Ok(())
 }
 
 pub fn get(db: &SpannerDb, params: params::GetBatch) -> Result<Option<results::GetBatch>> {
     let collection_id = db.get_collection_id(&params.collection)?;
-    let timestamp = db.timestamp()?.as_i64();
-
-    let result = db
+    let batch = db
         .sql(
-            "SELECT id, bsos, expiry
+            "SELECT 1
                FROM batches
               WHERE fxa_uid = @fxa_uid
                 AND fxa_kid = @fxa_kid
                 AND collection_id = @collection_id
-                AND timestamp = @bso_id
-                AND expiry > @expiry",
+                AND batch_id = @batch_id
+                AND expiry > CURRENT_TIMESTAMP()",
         )?
         .params(params! {
-            "fxa_uid" => params.user_id.fxa_uid,
-            "fxa_kid" => params.user_id.fxa_kid,
+            "fxa_uid" => params.user_id.fxa_uid.clone(),
+            "fxa_kid" => params.user_id.fxa_kid.clone(),
             "collection_id" => collection_id.to_string(),
-            "bso_id" => to_rfc3339(params.id)?,
-            "expiry" => to_rfc3339(timestamp)?,
-        })
-        .param_types(param_types! {
-            "bso_id" => TypeCode::TIMESTAMP,
-            "expiry" => TypeCode::TIMESTAMP,
+            "batch_id" => params.id.clone(),
         })
         .execute(&db.conn)?
-        .all_or_none();
-    if let Some(result) = result {
-        Ok(Some(params::Batch {
-            id: params.id,
-            bsos: results_to_batch_string(result),
-            // XXX: we don't really use expiry (but it's probably needed for
-            // mysql/diesel compat). converting it back to i64 is maybe
-            // suspicious
-            expiry: 0,
-        }))
-    } else {
-        Ok(None)
-    }
+        .one_or_none()?
+        .map(move |_| {
+            params::Batch {
+                id: params.id,
+                // XXX: we don't use bsos/expiry (but they're currently needed
+                // for mysql/diesel compat). converting expiry back to i64 is
+                // maybe suspicious
+                bsos: "".to_owned(),
+                expiry: 0,
+            }
+        });
+    Ok(batch)
 }
 
 pub fn delete(db: &SpannerDb, params: params::DeleteBatch) -> Result<()> {
     let collection_id = db.get_collection_id(&params.collection)?;
-
+    // Also deletes child batch_bso rows (INTERLEAVE IN PARENT batches ON
+    // DELETE CASCADE
     db.sql(
         "DELETE FROM batches
           WHERE fxa_uid = @fxa_uid
             AND fxa_kid = @fxa_kid
             AND collection_id = @collection_id
-            AND timestamp = @bso_id",
+            AND batch_id = @batch_id",
     )?
     .params(params! {
-        "fxa_uid" => params.user_id.fxa_uid,
-        "fxa_kid" => params.user_id.fxa_kid,
+        "fxa_uid" => params.user_id.fxa_uid.clone(),
+        "fxa_kid" => params.user_id.fxa_kid.clone(),
         "collection_id" => collection_id.to_string(),
-        "bso_id" => to_rfc3339(params.id)?,
-    })
-    .param_types(param_types! {
-        "bso_id" => TypeCode::TIMESTAMP,
+        "batch_id" => params.id,
     })
     .execute(&db.conn)?;
     Ok(())
 }
 
 pub fn commit(db: &SpannerDb, params: params::CommitBatch) -> Result<results::CommitBatch> {
-    let bsos = batch_string_to_bsos(&params.batch.bsos)?;
     let mut timer = db.metrics.clone();
     timer.start_timer("syncstorage.storage.spanner.apply_batch", None);
-    let result = db.post_bsos_sync(params::PostBsos {
-        user_id: params.user_id.clone(),
-        collection: params.collection.clone(),
-        bsos,
-        failed: Default::default(),
-    });
+    let collection_id = db.get_collection_id(&params.collection)?;
+
+    // Ensure a parent record exists in user_collections before writing to bso
+    // (INTERLEAVE IN PARENT user_collections)
+    let timestamp = db.touch_collection(&params.user_id, collection_id)?;
+
+    let as_rfc3339 = timestamp.as_rfc3339()?;
+    // First, UPDATE existing rows in the bso table with any new values
+    // supplied in this batch
+    db.sql(include_str!("batch_commit_update.sql"))?
+        .params(params! {
+            "fxa_uid" => params.user_id.fxa_uid.clone(),
+            "fxa_kid" => params.user_id.fxa_kid.clone(),
+            "collection_id" => collection_id.to_string(),
+            "batch_id" => params.batch.id.clone(),
+            "timestamp" => as_rfc3339.clone(),
+        })
+        .param_types(param_types! {
+            "timestamp" => TypeCode::TIMESTAMP,
+        })
+        .execute(&db.conn)?;
+
+    // Then INSERT INTO SELECT remaining rows from this batch into the bso
+    // table (that didn't already exist there)
+    db.sql(include_str!("batch_commit_insert.sql"))?
+        .params(params! {
+            "fxa_uid" => params.user_id.fxa_uid.clone(),
+            "fxa_kid" => params.user_id.fxa_kid.clone(),
+            "collection_id" => collection_id.to_string(),
+            "batch_id" => params.batch.id.clone(),
+            "timestamp" => as_rfc3339,
+            "default_bso_ttl" => DEFAULT_BSO_TTL.to_string(),
+        })
+        .param_types(param_types! {
+            "timestamp" => TypeCode::TIMESTAMP,
+            "default_bso_ttl" => TypeCode::INT64,
+        })
+        .execute(&db.conn)?;
+
     delete(
         db,
         params::DeleteBatch {
@@ -287,5 +198,101 @@ pub fn commit(db: &SpannerDb, params: params::CommitBatch) -> Result<results::Co
             id: params.batch.id,
         },
     )?;
-    result
+    // XXX: returning results::PostBsos here isn't needed
+    Ok(results::PostBsos {
+        modified: timestamp,
+        success: Default::default(),
+        failed: Default::default(),
+    })
+}
+
+pub fn do_append(
+    db: &SpannerDb,
+    user_id: HawkIdentifier,
+    collection_id: i32,
+    batch_id: String,
+    bsos: Vec<params::PostCollectionBso>,
+) -> Result<()> {
+    for bso in bsos {
+        let mut sqlparams = params! {
+            "fxa_uid" => user_id.fxa_uid.clone(),
+            "fxa_kid" => user_id.fxa_kid.clone(),
+            "collection_id" => collection_id.to_string(),
+            "batch_id" => batch_id.clone(),
+            "id" => bso.id,
+        };
+
+        sqlparams.insert(
+            "sortindex".to_string(),
+            bso.sortindex
+                .map(|sortindex| as_value(sortindex.to_string()))
+                .unwrap_or_else(null_value),
+        );
+        sqlparams.insert(
+            "payload".to_string(),
+            bso.payload.map(as_value).unwrap_or_else(null_value),
+        );
+        sqlparams.insert(
+            "ttl".to_string(),
+            bso.ttl
+                .map(|ttl| as_value(ttl.to_string()))
+                .unwrap_or_else(null_value),
+        );
+
+        db.sql(
+            "INSERT INTO batch_bso (fxa_uid, fxa_kid, collection_id, batch_id, id, sortindex,
+                                    payload, ttl)
+             VALUES (@fxa_uid, @fxa_kid, @collection_id, @batch_id, @id, @sortindex,
+                     @payload, @ttl)",
+        )?
+        .params(sqlparams)
+        .execute(&db.conn)?;
+    }
+    Ok(())
+}
+
+/// Ensure a parent row exists in user_collections prior to creating a child
+/// row in the batches table.
+///
+/// When no parent exists, a "tombstone" like ("pre birth stone"?) value for
+/// modified is inserted, which is explicitly ignored by other queries.
+///
+/// For the special case of a user creating a batch for a collection with no
+/// prior data.
+fn pretouch_collection(db: &SpannerDb, user_id: &HawkIdentifier, collection_id: i32) -> Result<()> {
+    let mut sqlparams = params! {
+        "fxa_uid" => user_id.fxa_uid.clone(),
+        "fxa_kid" => user_id.fxa_kid.clone(),
+        "collection_id" => collection_id.to_string(),
+    };
+    let result = db
+        .sql(
+            "SELECT 1
+               FROM user_collections
+              WHERE fxa_uid = @fxa_uid
+                AND fxa_kid = @fxa_kid
+                AND collection_id = @collection_id",
+        )?
+        .params(sqlparams.clone())
+        .execute(&db.conn)?
+        .one_or_none()?;
+    if result.is_none() {
+        sqlparams.insert("modified".to_owned(), as_value(PRETOUCH_TS.to_owned()));
+        db.sql(
+            "INSERT INTO user_collections (fxa_uid, fxa_kid, collection_id, modified)
+             VALUES (@fxa_uid, @fxa_kid, @collection_id, @modified)",
+        )?
+        .params(sqlparams)
+        .param_types(param_types! {
+            "modified" => TypeCode::TIMESTAMP,
+        })
+        .execute(&db.conn)?;
+    }
+    Ok(())
+}
+
+pub fn validate_batch_id(id: &str) -> Result<()> {
+    Uuid::from_str(id)
+        .map(|_| ())
+        .map_err(|e| DbError::internal(&format!("Invalid batch_id: {}", e)))
 }

--- a/src/db/spanner/batch_commit_insert.sql
+++ b/src/db/spanner/batch_commit_insert.sql
@@ -1,0 +1,27 @@
+INSERT INTO bso (fxa_uid, fxa_kid, collection_id, id, sortindex, payload, modified, expiry)
+SELECT
+       batch_bso.fxa_uid,
+       batch_bso.fxa_kid,
+       batch_bso.collection_id,
+       batch_bso.id,
+
+       batch_bso.sortindex,
+       COALESCE(batch_bso.payload, ''),
+       @timestamp,
+       COALESCE(
+           TIMESTAMP_ADD(@timestamp, INTERVAL batch_bso.ttl SECOND),
+           TIMESTAMP_ADD(@timestamp, INTERVAL @default_bso_ttl SECOND)
+       )
+  FROM batch_bso
+ WHERE fxa_uid = @fxa_uid
+   AND fxa_kid = @fxa_kid
+   AND collection_id = @collection_id
+   AND batch_id = @batch_id
+   AND id NOT in (
+       SELECT id
+         FROM bso
+        WHERE fxa_uid = @fxa_uid
+          AND fxa_kid = @fxa_kid
+          AND collection_id = @collection_id
+          AND expiry > CURRENT_TIMESTAMP()
+   )

--- a/src/db/spanner/batch_commit_update.sql
+++ b/src/db/spanner/batch_commit_update.sql
@@ -1,0 +1,51 @@
+UPDATE bso
+   SET sortindex = COALESCE(
+           (SELECT sortindex
+              FROM batch_bso
+             WHERE fxa_uid = @fxa_uid
+               AND fxa_kid = @fxa_kid
+               AND collection_id = @collection_id
+               AND batch_id = @batch_id
+               AND id = bso.id
+            ),
+            bso.sortindex
+       ),
+
+       payload = COALESCE(
+           (SELECT payload
+              FROM batch_bso
+             WHERE fxa_uid = @fxa_uid
+               AND fxa_kid = @fxa_kid
+               AND collection_id = @collection_id
+               AND batch_id = @batch_id
+               AND id = bso.id
+           ),
+           bso.payload
+       ),
+
+       modified = @timestamp,
+
+       expiry = COALESCE(
+           -- TIMESTAMP_ADD returns NULL when ttl is null
+           (SELECT TIMESTAMP_ADD(@timestamp, INTERVAL ttl SECOND)
+              FROM batch_bso
+             WHERE fxa_uid = @fxa_uid
+               AND fxa_kid = @fxa_kid
+               AND collection_id = @collection_id
+               AND batch_id = @batch_id
+               AND id = bso.id
+           ),
+           bso.expiry
+       )
+ WHERE fxa_uid = @fxa_uid
+   AND fxa_kid = @fxa_kid
+   AND collection_id = @collection_id
+   AND id in (
+       SELECT id
+         FROM batch_bso
+        WHERE fxa_uid = @fxa_uid
+          AND fxa_kid = @fxa_kid
+          AND collection_id = @collection_id
+          AND batch_id = @batch_id
+   )
+   AND expiry > CURRENT_TIMESTAMP()

--- a/src/web/handlers.rs
+++ b/src/web/handlers.rs
@@ -218,14 +218,14 @@ pub fn post_collection_batch(
         }
     };
 
-    let fut = if let Some(id) = breq.id {
+    let fut = if let Some(id) = breq.id.clone() {
         // Validate the batch before attempting a full append (for efficiency)
         Either::A(
             coll.db
                 .validate_batch(params::ValidateBatch {
                     user_id: coll.user_id.clone(),
                     collection: coll.collection.clone(),
-                    id,
+                    id: id.clone(),
                 })
                 .and_then(move |is_valid| {
                     if is_valid {
@@ -258,7 +258,7 @@ pub fn post_collection_batch(
                 .append_to_batch(params::AppendToBatch {
                     user_id: coll.user_id.clone(),
                     collection: coll.collection.clone(),
-                    id,
+                    id: id.clone(),
                     bsos: coll.bsos.valid.into_iter().map(From::from).collect(),
                 })
                 .then(move |result| {
@@ -284,7 +284,7 @@ pub fn post_collection_batch(
             });
 
             if !breq.commit {
-                resp["batch"] = json!(base64::encode(&id.to_string()));
+                resp["batch"] = json!(&id);
                 return Either::A(future::ok(HttpResponse::Accepted().json(resp)));
             }
 


### PR DESCRIPTION
mimicing the python implementation's moreso

- adds a batch_bso table for individual bsos
- batch/batch_bso now interleave in the user's split
- commit's work happens via DML statements
- special cases a new batch for a fresh collection w/ a "tombstone" like ("pre
  birth stone"?) modified timestamp in user_collections. other queries filter
  it out
- moves batch id's encoding for the client into the Db layer: mysql continues
  base64ing its numeric batch id, whereas spanner simply uses a Uuid (in
  simple/hex format)

Closes #299

Please remember to consult our [contributing guidelines](https://github.com/mozilla-services/syncstorage-rs/blob/master/CONTRIBUTING.md#sending-pull-requests) before opening your PR.

- [x] **Title** begins with _type_ (fix, feature, doc, chore, etc) and a short description with no period
- [x] **Description**  outlines the change
- [x] **Test cases** included in the change (if appropriate)
- [x] **Closes** or **Issue** link to associated issue(s)