### PR TITLE
refactor: schema renames (again)

### DIFF
--- a/src/db/spanner/batch_commit_insert.sql
+++ b/src/db/spanner/batch_commit_insert.sql
@@ -1,25 +1,25 @@
-INSERT INTO bso (fxa_uid, fxa_kid, collection_id, id, sortindex, payload, modified, expiry)
+INSERT INTO bsos (fxa_uid, fxa_kid, collection_id, bso_id, sortindex, payload, modified, expiry)
 SELECT
-       batch_bso.fxa_uid,
-       batch_bso.fxa_kid,
-       batch_bso.collection_id,
-       batch_bso.id,
+       batch_bsos.fxa_uid,
+       batch_bsos.fxa_kid,
+       batch_bsos.collection_id,
+       batch_bsos.batch_bso_id,
 
-       batch_bso.sortindex,
-       COALESCE(batch_bso.payload, ''),
+       batch_bsos.sortindex,
+       COALESCE(batch_bsos.payload, ''),
        @timestamp,
        COALESCE(
-           TIMESTAMP_ADD(@timestamp, INTERVAL batch_bso.ttl SECOND),
+           TIMESTAMP_ADD(@timestamp, INTERVAL batch_bsos.ttl SECOND),
            TIMESTAMP_ADD(@timestamp, INTERVAL @default_bso_ttl SECOND)
        )
-  FROM batch_bso
+  FROM batch_bsos
  WHERE fxa_uid = @fxa_uid
    AND fxa_kid = @fxa_kid
    AND collection_id = @collection_id
    AND batch_id = @batch_id
-   AND id NOT in (
-       SELECT id
-         FROM bso
+   AND batch_bso_id NOT in (
+       SELECT bso_id
+         FROM bsos
         WHERE fxa_uid = @fxa_uid
           AND fxa_kid = @fxa_kid
           AND collection_id = @collection_id

--- a/src/db/spanner/batch_commit_update.sql
+++ b/src/db/spanner/batch_commit_update.sql
@@ -1,26 +1,26 @@
-UPDATE bso
+UPDATE bsos
    SET sortindex = COALESCE(
            (SELECT sortindex
-              FROM batch_bso
+              FROM batch_bsos
              WHERE fxa_uid = @fxa_uid
                AND fxa_kid = @fxa_kid
                AND collection_id = @collection_id
                AND batch_id = @batch_id
-               AND id = bso.id
+               AND batch_bso_id = bsos.bso_id
             ),
-            bso.sortindex
+            bsos.sortindex
        ),
 
        payload = COALESCE(
            (SELECT payload
-              FROM batch_bso
+              FROM batch_bsos
              WHERE fxa_uid = @fxa_uid
                AND fxa_kid = @fxa_kid
                AND collection_id = @collection_id
                AND batch_id = @batch_id
-               AND id = bso.id
+               AND batch_bso_id = bsos.bso_id
            ),
-           bso.payload
+           bsos.payload
        ),
 
        modified = @timestamp,
@@ -28,21 +28,21 @@ UPDATE bso
        expiry = COALESCE(
            -- TIMESTAMP_ADD returns NULL when ttl is null
            (SELECT TIMESTAMP_ADD(@timestamp, INTERVAL ttl SECOND)
-              FROM batch_bso
+              FROM batch_bsos
              WHERE fxa_uid = @fxa_uid
                AND fxa_kid = @fxa_kid
                AND collection_id = @collection_id
                AND batch_id = @batch_id
-               AND id = bso.id
+               AND batch_bso_id = bsos.bso_id
            ),
-           bso.expiry
+           bsos.expiry
        )
  WHERE fxa_uid = @fxa_uid
    AND fxa_kid = @fxa_kid
    AND collection_id = @collection_id
-   AND id in (
-       SELECT id
-         FROM batch_bso
+   AND bso_id in (
+       SELECT batch_bso_id
+         FROM batch_bsos
         WHERE fxa_uid = @fxa_uid
           AND fxa_kid = @fxa_kid
           AND collection_id = @collection_id

--- a/src/db/spanner/support.rs
+++ b/src/db/spanner/support.rs
@@ -214,7 +214,7 @@ pub fn bso_to_update_row(
     bso: params::PostCollectionBso,
     now: SyncTimestamp,
 ) -> Result<(Vec<&'static str>, ListValue)> {
-    let mut columns = vec!["fxa_uid", "fxa_kid", "collection_id", "id"];
+    let mut columns = vec!["fxa_uid", "fxa_kid", "collection_id", "bso_id"];
     let mut values = vec![
         as_value(user_id.fxa_uid.clone()),
         as_value(user_id.fxa_kid.clone()),

--- a/tools/spanner/purge_ttl.py
+++ b/tools/spanner/purge_ttl.py
@@ -39,13 +39,14 @@ def spanner_read_data(request=None):
     outputs = []
 
     outputs.append("For {}:{}".format(instance_id, database_id))
-    # Delete Batches
+    # Delete Batches. Also deletes child batch_bsos rows (INTERLEAVE
+    # IN PARENT batches ON DELETE CASCADE)
     query = 'DELETE FROM batches WHERE expiry < CURRENT_TIMESTAMP()'
     result = database.execute_partitioned_dml(query)
     outputs.append("batches: removed {} rows".format(result))
 
     # Delete BSOs
-    query = 'DELETE FROM bso WHERE expiry < CURRENT_TIMESTAMP()'
+    query = 'DELETE FROM bsos WHERE expiry < CURRENT_TIMESTAMP()'
     result = database.execute_partitioned_dml(query)
     outputs.append("bso: removed {} rows".format(result))
     return '\n'.join(outputs)

--- a/tools/spanner/write_batch.py
+++ b/tools/spanner/write_batch.py
@@ -142,12 +142,12 @@ def load(instance, db, fxa_uid, fxa_kid, coll_id):
             records.append(record)
         with db.batch() as batch:
             batch.insert(
-                table='bso',
+                table='bsos',
                 columns=(
                     'fxa_uid',
                     'fxa_kid',
                     'collection_id',
-                    'id',
+                    'bso_id',
                     'sortindex',
                     'payload',
                     'modified',


### PR DESCRIPTION

- always prefix primary key names with their table name (id -> bso_id,
  collection_id). a best practice in spanner, as when tables
  interleave, their shared id names must always match
- bso -> bsos (every other table name's plural)
- give batches an expiry index

Closes #313

Please remember to consult our [contributing guidelines](https://github.com/mozilla-services/syncstorage-rs/blob/master/CONTRIBUTING.md#sending-pull-requests) before opening your PR.

- [ ] **Title** begins with _type_ (fix, feature, doc, chore, etc) and a short description with no period
- [ ] **Description**  outlines the change
- [ ] **Test cases** included in the change (if appropriate)
- [ ] **Closes** or **Issue** link to associated issue(s)