### PR TITLE
feat Limit max_total_records due to spanner mutation limit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,5 +23,6 @@ RUN \
 
 COPY --from=builder /app/bin /app/bin
 COPY --from=builder /app/version.json /app
+COPY --from=builder /app/spanner_config.ini /app
 
-CMD ["/app/bin/syncstorage"]
+CMD ["/app/bin/syncstorage", "--config=spanner_config.ini"]

--- a/spanner_config.ini
+++ b/spanner_config.ini
@@ -1,0 +1,2 @@
+# Temp limit on the number of incoming records (See issue #298)
+limits.max_total_records=2000


### PR DESCRIPTION
*NOTE* this introduces a configuation.ini file. Unfortunately,
the config parser does not allow a single `limit` sub-setting
to be specified from the environment or command line, but does
allow a single sub-setting from within a configuration file.

Closes #298

Please remember to consult our [contributing guidelines](https://github.com/mozilla-services/syncstorage-rs/blob/master/CONTRIBUTING.md#sending-pull-requests) before opening your PR.

- [x] **Title** begins with _type_ (fix, feature, doc, chore, etc) and a short description with no period
- [x] **Description**  outlines the change
- [ ] **Test cases** included in the change (if appropriate)
- [x] **Closes** or **Issue** link to associated issue(s)