### PR TITLE
bug: Metric timer should use millis

### DIFF
--- a/src/server/metrics.rs
+++ b/src/server/metrics.rs
@@ -30,7 +30,7 @@ impl Drop for Metrics {
     fn drop(&mut self) {
         if let Some(client) = self.client.as_ref() {
             if let Some(timer) = self.timer.as_ref() {
-                let lapse = (Instant::now() - timer.start).as_nanos() as u64;
+                let lapse = (Instant::now() - timer.start).as_millis() as u64;
                 trace!("⌚ Ending timer at nanos: {:?} : {:?}", &timer.label, lapse);
                 let mut tagged = client.time_with_tags(&timer.label, lapse);
                 // Include any "hard coded" tags.


### PR DESCRIPTION
Closes #326

Please remember to consult our [contributing guidelines](https://github.com/mozilla-services/syncstorage-rs/blob/master/CONTRIBUTING.md#sending-pull-requests) before opening your PR.

- [x] **Title** begins with _type_ (fix, feature, doc, chore, etc) and a short description with no period
- [x] **Description**  outlines the change
- [ ] **Test cases** included in the change (if appropriate)
- [x] **Closes** or **Issue** link to associated issue(s)