### PR TITLE
fix: correct max_total_records

### DIFF
--- a/spanner-2019-10-01.ddl
+++ b/spanner-2019-10-01.ddl
@@ -21,7 +21,7 @@ CREATE TABLE bsos (
   fxa_uid STRING(MAX)  NOT NULL,
   fxa_kid STRING(MAX)  NOT NULL,
   collection_id INT64  NOT NULL,
-  bso_id STRING(64)    NOT NULL,
+  bso_id STRING(MAX)   NOT NULL,
 
   sortindex INT64,
 
@@ -79,7 +79,7 @@ CREATE TABLE batch_bsos (
   fxa_kid STRING(MAX)      NOT NULL,
   collection_id INT64      NOT NULL,
   batch_id STRING(MAX)     NOT NULL,
-  batch_bso_id STRING(64)  NOT NULL,
+  batch_bso_id STRING(MAX) NOT NULL,
 
   sortindex INT64,
   payload STRING(MAX),

--- a/spanner_config.ini
+++ b/spanner_config.ini
@@ -1,2 +1,2 @@
-# Temp limit on the number of incoming records (See issue #298)
-limits.max_total_records=2000
+# Temp limit on the number of incoming records (See issue #298/#333)
+limits.max_total_records=1999

--- a/src/web/handlers.rs
+++ b/src/web/handlers.rs
@@ -270,12 +270,8 @@ pub fn post_collection_batch(
                 .then(move |result| {
                     match result {
                         Ok(_) => success.extend(bso_ids),
-                        Err(e) => {
-                            // NLL: not a guard as: (E0008) "moves value into
-                            // pattern guard"
-                            if e.is_conflict() {
-                                return future::err(e);
-                            }
+                        Err(e) if e.is_conflict() => return future::err(e),
+                        Err(_) => {
                             failed.extend(bso_ids.into_iter().map(|id| (id, "db error".to_owned())))
                         }
                     };


### PR DESCRIPTION
reduce to 1999 (19990 mutations) accounting for batch commit's extra
mutations: touch_collection (+1) and batch delete (+2: for delete +
BsoExpiry update)

schema: don't restrict bso_id in the schema (this was already applied to
stage and fakeprod)

and cleanup old NLL restriction gone in newer rust versions

Closes #333

Please remember to consult our [contributing guidelines](https://github.com/mozilla-services/syncstorage-rs/blob/master/CONTRIBUTING.md#sending-pull-requests) before opening your PR.

- [ ] **Title** begins with _type_ (fix, feature, doc, chore, etc) and a short description with no period
- [ ] **Description**  outlines the change
- [ ] **Test cases** included in the change (if appropriate)
- [ ] **Closes** or **Issue** link to associated issue(s)