### PR TITLE
fix: optimize batch commit mutations 

### DIFF
--- a/spanner-2019-10-01.ddl
+++ b/spanner-2019-10-01.ddl
@@ -37,7 +37,8 @@ CREATE TABLE bsos (
 INTERLEAVE IN user_collections;
 
     CREATE INDEX BsoExpiry
-        ON bsos(expiry);
+        ON bsos(expiry),
+INTERLEAVE IN user_collections;
 
 CREATE TABLE collections (
   collection_id INT64  NOT NULL,

--- a/src/db/spanner/support.rs
+++ b/src/db/spanner/support.rs
@@ -14,7 +14,7 @@ use crate::{
     web::extractors::HawkIdentifier,
 };
 
-use googleapis_raw::spanner::v1::type_pb::{Type, TypeCode};
+use googleapis_raw::spanner::v1::type_pb::{StructType_Field, Type, TypeCode};
 
 type ParamValue = protobuf::well_known_types::Value;
 
@@ -39,6 +39,14 @@ pub fn as_type(v: TypeCode) -> Type {
     t.set_code(v);
     t
 }
+
+pub fn struct_type_field(name: &str, field_type: TypeCode) -> StructType_Field {
+    let mut field = StructType_Field::new();
+    field.set_name(name.to_owned());
+    field.set_field_type(as_type(field_type));
+    field
+}
+
 pub fn as_list_value(
     string_values: impl Iterator<Item = String>,
 ) -> protobuf::well_known_types::Value {


### PR DESCRIPTION
write the pending bsos immediately when committing a batch instead of
queueing them in the batch_bsos, so we don't pay twice for their
mutations

also

- optimize batch append to insert all items in one write
- interleave BsoExpiry w/ user_collections

Closes #333, #318

& some minor cleanup in a separate commit