### PR TITLE
provide shell.nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,20 @@
+# Nix is a powerful package manager for Linux and other Unix systems that makes
+# package management reliable and reproducible: https://nixos.org/nix/.
+# This file is intended to be used with `nix-shell`
+# (https://nixos.org/nix/manual/#sec-nix-shell) to setup a fully-functional
+# syncstorage-rs build environment by installing all required dependencies.
+with import <nixpkgs> {};
+stdenv.mkDerivation {
+  name = "syncstorage-rs";
+  buildInputs = [
+    rustc
+    cargo
+    libmysqlclient
+    pkgconfig
+    openssl
+    cmake
+    protobuf
+    go
+  ];
+  NIX_LDFLAGS = "-L${libmysqlclient}/lib/mysql";
+}


### PR DESCRIPTION
## Description

Nix is a distribution independent package manager.
By providing this file user of nix get automatically all
required build dependencies by sourcing default.nix via a tool called
nix-shell. This should lower the entry barrier when setting up a
build environment.

Nix is also used in other places in Mozilla: https://github.com/mozilla/nixpkgs-mozilla

## Testing

```
$ nix-shell --command 'cargo build'
```

## Issue(s)

No issues related to this
