### PR TITLE
chore: tag 0.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,30 @@
+<a name="0.1.8"></a>
+### 0.1.8 (2019-12-03)
+
+
+#### Doc
+
+*   add descriptive comment ([84f25af5](https://github.com/mozilla-services/syncstorage-rs/commit/84f25af5e36c13f69d0c422c15783420051613a7))
+*   adjust PR template, finish combining READMEs ([bbe744dd](https://github.com/mozilla-services/syncstorage-rs/commit/bbe744ddba933abac5e667e5374bc35b0b1832ee), closes [#344](https://github.com/mozilla-services/syncstorage-rs/issues/344))
+*   combining setup instructions into one main doc ([a8ead778](https://github.com/mozilla-services/syncstorage-rs/commit/a8ead778b6d955b92d7d915dd72f0f78ad30bad7))
+
+#### Bug Fixes
+
+*   optimize batch commit mutations ([5dd3c651](https://github.com/mozilla-services/syncstorage-rs/commit/5dd3c65143e535a65bc99b2e22784c48d4b7cf25), closes [#318](https://github.com/mozilla-services/syncstorage-rs/issues/318))
+*   remove redundant syncstorage metric root ([a2083477](https://github.com/mozilla-services/syncstorage-rs/commit/a2083477b9ebc95787cb51fea85ed1afc43f726c), closes [#346](https://github.com/mozilla-services/syncstorage-rs/issues/346))
+*   specify the release name to sentry ([9cdfe7d7](https://github.com/mozilla-services/syncstorage-rs/commit/9cdfe7d7812281fb3c8d1c716ddd54be92edb8b4))
+
+#### Chore
+
+*   improve local logging ([d1a84219](https://github.com/mozilla-services/syncstorage-rs/commit/d1a842195849a78bcc7e8a048f65b069b85b808f), closes [#350](https://github.com/mozilla-services/syncstorage-rs/issues/350))
+*   fix syntax and make one small formatting change to PR template ([11e47545](https://github.com/mozilla-services/syncstorage-rs/commit/11e4754558b217cbfa36dcb998e96e9a1057dfcc), closes [#344](https://github.com/mozilla-services/syncstorage-rs/issues/344))
+
+#### Refactor
+
+*   minor cleanup ([8dfb0d51](https://github.com/mozilla-services/syncstorage-rs/commit/8dfb0d5123310224ffe9b50701c3efbb938ebf61))
+
+
+
 <a name="0.1.7"></a>
 ## 0.1.7 (2019-11-16)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2406,7 +2406,7 @@ dependencies = [
 
 [[package]]
 name = "syncstorage"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "actix-cors 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-http 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syncstorage"
-version = "0.1.7"
+version = "0.1.8"
 license = "MPL-2.0"
 authors = [
   "Ben Bangert <ben@groovie.org>",

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
   - [Tests](#tests)
     - [Unit tests](#unit-tests)
     - [End-to-End tests](#end-to-end-tests)
+  - [Creating Releases](#creating-releases)
   - [Troubleshooting](#troubleshooting)
   - [Related Documentation](#related-documentation)
 
@@ -133,6 +134,17 @@ Functional tests live in [server-syncstorage](https://github.com/mozilla-service
 
         $ SYNC_TEST_PREFIX=test_get_collection \
             ./local/bin/python syncstorage/tests/functional/test_storage.py http://localhost:8000#<SOMESECRET>
+
+## Creating Releases
+
+Open a PR after doing the following:
+
+1. Bump the version number in [Cargo.toml](https://github.com/mozilla-services/syncstorage-rs/blob/master/Cargo.toml).
+2. `cargo build --release` - Build with the release profile [release mode](https://doc.rust-lang.org/book/ch14-01-release-profiles.html).
+3. `clog -C CHANGELOG.md` - Generate release notes. We're using [clog](https://github.com/clog-tool/clog-cli) for release notes. Add a `-p`, `-m` or `-M` flag to denote major/minor/patch version, ie `clog -C CHANGELOG.md -p`.
+
+Once your PR merges, then go ahead and create an official [GitHub release](https://github.com/mozilla-services/syncstorage-rs/releases).
+
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Description

Creating a release so we can test out [this fix](https://github.com/mozilla-services/syncstorage-rs/pull/353) against prod. Also added releasing instructions to README (let me know if I missed anything).

## Testing

Read the bits added to README.

## Issue(s)

N/A
