### PR TITLE
 feat: Handle empty bso body on /meta/global

### DIFF
--- a/src/db/spanner/models.rs
+++ b/src/db/spanner/models.rs
@@ -739,8 +739,8 @@ impl SpannerDb {
             "INSERT INTO user_collections (fxa_uid, fxa_kid, collection_id, modified)
              VALUES (@fxa_uid, @fxa_kid, @collection_id, @modified)",
         )?
-        .params(params.clone())
-        .param_types(types.clone())
+        .params(params)
+        .param_types(types)
         .execute(&self.conn)?;
         // Return timestamp, because sometimes there's a delay between writing and
         // reading the database.
@@ -928,25 +928,25 @@ impl SpannerDb {
         let mut sqltypes = HashMap::new();
 
         if let Some(older) = older {
-            query = format!("{} AND modified < @older", query).to_string();
+            query = format!("{} AND modified < @older", query);
             sqlparams.insert("older".to_string(), as_value(older.as_rfc3339()?));
             sqltypes.insert("older".to_string(), as_type(TypeCode::TIMESTAMP));
         }
         if let Some(newer) = newer {
-            query = format!("{} AND modified > @newer", query).to_string();
+            query = format!("{} AND modified > @newer", query);
             sqlparams.insert("newer".to_string(), as_value(newer.as_rfc3339()?));
             sqltypes.insert("newer".to_string(), as_type(TypeCode::TIMESTAMP));
         }
 
         if !ids.is_empty() {
-            query = format!("{} AND bso_id IN UNNEST(@ids)", query).to_string();
+            query = format!("{} AND bso_id IN UNNEST(@ids)", query);
             sqlparams.insert("ids".to_owned(), as_list_value(ids.into_iter()));
         }
 
         query = match sort {
-            Sorting::Index => format!("{} ORDER BY sortindex DESC", query).to_string(),
-            Sorting::Newest => format!("{} ORDER BY modified DESC", query).to_string(),
-            Sorting::Oldest => format!("{} ORDER BY modified ASC", query).to_string(),
+            Sorting::Index => format!("{} ORDER BY sortindex DESC", query),
+            Sorting::Newest => format!("{} ORDER BY modified DESC", query),
+            Sorting::Oldest => format!("{} ORDER BY modified ASC", query),
             _ => query,
         };
 
@@ -967,7 +967,7 @@ impl SpannerDb {
         if offset != 0 {
             // XXX: copy over this optimization:
             // https://github.com/mozilla-services/server-syncstorage/blob/a0f8117/syncstorage/storage/sql/__init__.py#L404
-            query = format!("{} OFFSET {}", query, offset).to_string();
+            query = format!("{} OFFSET {}", query, offset);
         }
 
         self.sql(&query)?

--- a/src/db/spanner/pool.rs
+++ b/src/db/spanner/pool.rs
@@ -82,7 +82,7 @@ impl SpannerDbPool {
                     .build(),
             ),
             coll_cache: Default::default(),
-            metrics: metrics.clone(),
+            metrics,
         })
     }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -112,7 +112,7 @@ impl Settings {
             Ok(s) => {
                 // Adjust the max values if required.
                 if s.uses_spanner() {
-                    let mut ms = s.clone();
+                    let mut ms = s;
                     ms.limits.max_total_bytes =
                         min(ms.limits.max_total_bytes, MAX_SPANNER_LOAD_SIZE as u32);
                     return Ok(ms);

--- a/src/web/error.rs
+++ b/src/web/error.rs
@@ -107,6 +107,7 @@ impl From<Context<HawkErrorKind>> for HawkError {
 
 impl From<Context<ValidationErrorKind>> for ValidationError {
     fn from(inner: Context<ValidationErrorKind>) -> Self {
+        debug!("Validation Error: {:?}", inner.get_context());
         let status = match inner.get_context() {
             ValidationErrorKind::FromDetails(ref _description, ref location, Some(ref name))
                 if *location == RequestErrorLocation::Header =>

--- a/src/web/middleware.rs
+++ b/src/web/middleware.rs
@@ -402,7 +402,7 @@ where
             }
         };
         let bso = BsoParam::extrude(&sreq.uri(), &mut sreq.extensions_mut()).ok();
-        let bso_opt = bso.clone().map(|b| b.bso);
+        let bso_opt = bso.map(|b| b.bso);
 
         let mut service = Rc::clone(&self.service);
         Box::new(

--- a/tools/hawk/README.md
+++ b/tools/hawk/README.md
@@ -1,6 +1,6 @@
 # Make a Hawk compatible Auth header
 
-The best way to install this is probably to set up a python virtual
+1) The best way to install this is probably to set up a python virtual
 env.
 
 `python3 -m venv venv && venv/bin/pip install -r requirements.txt`
@@ -8,5 +8,17 @@ env.
 this will create a python virtual environment in the `/venv` directory.
 
 *Note* You may need to install `python3-venv` for the above to work.
+
+Once the virtual env is installed, run `. venv/bin/activate`. This
+will ensure that calls to python and python tools happen within this
+virutal environment.
+
+2) install the requirements using:
+
+`venv/bin/pip install -r requirements.txt`
+
+3) To create a Token Header:
+
+`venv/bin/python make_hawk_token.py`
 
 Use `-h` for help.


### PR DESCRIPTION
## Description

This adds some additional debug around handling BSOs to try and identify
the source of the server returning 400 on PUT `/1.5/xxx/storage/meta/global`.
There may be a related client bug where it's sending no BSO on a
meta/global PUT, thus the very specific fix.

* also new clippy, new crap to clean up.

## Testing

Since we don't have a lot of tests that check full path, the test I've been using is to use `/tools/hawk/make_hawk_token.py` to generate a valid `Authorization` header

then call 
```
curl -v -X PUT "http://localhost:8000/1.5/1/storage/meta/global" \
    -H "content-type: application/json" \
    -H "Authorization: $AUTH"
```

## Issue(s)

Issue #342
