### PR TITLE
Add a --method parameter to tools/hawk/make_hawk_token.py

### DIFF
--- a/tools/hawk/make_hawk_token.py
+++ b/tools/hawk/make_hawk_token.py
@@ -25,6 +25,7 @@ from webob.request import Request
 LEGACY_UID = 1
 COL = "col2"
 URI = "/1.5/{uid}/storage/{col}/".format(uid=LEGACY_UID, col=COL)
+METHOD = "GET"
 FXA_UID = "DEADBEEF00004be4ae957006c0ceb620"
 FXA_KID = "DEADBEEF00004be4ae957006c0ceb620"
 DEVICE_ID = "device1"
@@ -48,6 +49,9 @@ def get_args():
     parser.add_argument(
         '--uri', default=URI,
         help="URI path ({})".format(URI))
+    parser.add_argument(
+        '--method', default=METHOD,
+        help="The HTTP Method ({})".format(METHOD))
     parser.add_argument(
         '--fxa_uid', default=FXA_UID,
         help="FxA User ID ({})".format(FXA_UID))
@@ -108,6 +112,7 @@ def main():
             node=args.node,
             uri=args.uri)
     req = Request.blank(path)
+    req.method = args.method
     header = hawkauthlib.sign_request(req, token, key)
     if not args.as_header:
         print("Expires: ", expires)


### PR DESCRIPTION
## Description

Currently, it is possible to change the uri being signed by make_hawk_token using the --uri command line argument, but not possible to change the http method. This patch adds a --method flag.

## Testing

How should reviewers test?

`cargo run` in one terminal

`venv/bin/python make_hawk_token.py --method PUT --uri /1.5/1/storage/meta/global --secret=$SYNC_MASTER_SECRET --as_header > auth.txt`

```curl -v -X PUT "http://localhost:8000/1.5/1/storage/meta/global"     -H "content-type: application/json"     -H "Authorization: `cat auth.txt`"```
