### PR TITLE
fix: remove duplicate header key from example script

### DIFF
--- a/tools/examples/put.bash
+++ b/tools/examples/put.bash
@@ -5,7 +5,7 @@ METHOD="PUT"
 SYNC_MASTER_SECRET="INSERT_SECRET_KEY_HERE"
 AUTH=`../hawk/venv/bin/python ../hawk/make_hawk_token.py --node $NODE --uri $URI --method $METHOD --secret=$SYNC_MASTER_SECRET --as_header`
 curl -vv -X PUT "$NODE$URI" \
-    -H "Authorization: $AUTH" \
+    -H "$AUTH" \
     -H 'Content-Type: application/json' \
     -H 'Accept: application/json' \
     -d '{"id": "womble", "payload": "mary had a little lamb with a nice mint jelly", "sortindex": 0, "ttl": 86400}'


### PR DESCRIPTION
## Description

I was running this script locally and noticed it failing all of a sudden. Looks like a recent change to the [hawk header script](https://github.com/mozilla-services/syncstorage-rs/pull/364/files#diff-4e6a513ac3e7f901d7ae6713da762cafR123) added an extra key, causing this script to fail.

## Testing

1. Outside of this branch, try running the `put.bash` script following [these instructions](https://github.com/mozilla-services/syncstorage-rs/tree/master/tools/examples). See it fail, and see we're passing something like this: ` Authorization: Authorization: Hawk id=` for the Auth header.

2. Now, checkout this branch, try again. You should get a 200.

## Issue(s)

Closes [#370](https://github.com/mozilla-services/syncstorage-rs/issues/370).
