### PR TITLE
docs: add instructions on how to connect to local firefox

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
   - [Local Setup](#local-setup)
     - [MySQL](#mysql)
     - [Spanner](#spanner)
+    - [Connecting to Firefox](#connecting-to-firefox)
   - [Logging](#logging)
   - [Tests](#tests)
     - [Unit tests](#unit-tests)
@@ -96,6 +97,35 @@ RUST_LOG=warn GOOGLE_APPLICATION_CREDENTIALS=`pwd`/keys/sync-spanner.json` cargo
 ```
 
 Note, that unlike MySQL, there is no automatic migrations facility. Currently Spanner schema must be hand edited and modified.
+
+### Connecting to Firefox
+
+This will walk you through the steps to connect this project to your local copy of Firefox. 
+
+1. Follow the steps outlined above for running this project using [MySQL](https://github.com/mozilla-services/syncstorage-rs#mysql).
+
+2. Setup a local copy of [syncserver](https://github.com/mozilla-services/syncserver), with a few special changes to [syncserver.ini](https://github.com/mozilla-services/syncserver/blob/master/syncserver.ini); make sure that you're using the following values (in addition to all of the other defaults):
+
+    ```
+    [server:main]
+    port = 5000
+
+    [syncserver]
+    public_url = http://localhost:5000/
+
+    # This value needs to match your "master_secret" for syncstorage-rs!
+    secret = INSERT_SECRET_KEY_HERE
+
+    [tokenserver]
+    node_url = http://localhost:8000
+    sqluri = pymysql://sample_user:sample_password@127.0.0.1/syncstorage_rs
+
+    [endpoints]
+    sync-1.5 = "http://localhost:8000/1.5/1"```
+
+
+3. In Firefox, go to `about:config`. Change `identity.sync.tokenserver.uri` to `http://localhost:5000/token/1.0/sync/1.5`.
+4. Restart Firefox. Now, try syncing. You should see new BSOs in your local MySQL instance.
 
 ## Logging
 


### PR DESCRIPTION
## Description

In tandem with [this syncserver PR](https://github.com/mozilla-services/syncserver/pull/186), I'm working on making it easier to understand how to run syncstorage-rs locally from with Firefox.
 
I've added instructions here for running against MySQL. I'll come back and do another pass against a spanner instance in the future.

I **did** notice a few oddities about this, ie warnings in the logs, etc. I also noticed that my payload_size always gets set to "0". I figure that this is at least better than not being able to run this locally at all, hence me opening a PR now; it might be worth a future pass though to poke around there a bit more.

## Testing

1. Follow the instructions I've added here. 
2. Confirm you are also able to get this working locally. Here's [what I'm seeing](https://recordit.co/irQfFArMgL).

## Issue(s)

Closes [#21](https://github.com/mozilla-services/services-engineering/issues/21).
