### PR TITLE
fix: lower max_total_records per batch_commit_update costs

### DIFF
--- a/spanner_config.ini
+++ b/spanner_config.ini
@@ -1,2 +1,2 @@
 # Temp limit on the number of incoming records (See issue #298/#333)
-limits.max_total_records=1999
+limits.max_total_records=1666

--- a/src/web/handlers.rs
+++ b/src/web/handlers.rs
@@ -259,10 +259,6 @@ pub fn post_collection_batch(
                 // Spanner we would pay twice the mutations for those pending
                 // items (once writing them to to batch_bsos, then again
                 // writing them to bsos)
-
-                // NOTE: Unfortunately this means we make two calls to
-                // touch_collection (in post_bsos and then commit_batch). The
-                // second touch is redundant, writing the same timestamp
                 Either::A(
                     coll.db
                         .post_bsos(params::PostBsos {


### PR DESCRIPTION
and remove the potential, redundant touch_collection on batch commit

recalculating the mutations (see adca8d67):

- 4 for touch_collection: always an UPDATE on batch commit (due to
  pretouch_collection). we thought this cost 1 but it's probably 4 (see
  #333)
- 19992 (1666 max_total_records * 12, for the UPDATE case, see #333) for
  the mix of post_bsos and batch_commit
- 2 for batch delete (1 for the delete and 1 BsoExpiry update)

total: 19998

Closes #333