### PR TITLE
chore: force cargo install to use Cargo.lock

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get -q update && \
 RUN \
     cargo --version && \
     rustc --version && \
-    cargo install --path . --root /app
+    cargo install --path . --locked --root /app
 
 FROM debian:buster-slim
 WORKDIR /app


### PR DESCRIPTION
## Description

force cargo install to use Cargo.lock

## Issue(s)

Closes #378
