### PR TITLE
Add basic logging to stdout and statsd metrics for purge_ttl.py

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN \
     apt-get -q update && \
     apt-get -q install -y --no-install-recommends default-libmysqlclient-dev libssl-dev ca-certificates libcurl4 python3-venv python3-pip && \
     python3 -m pip install setuptools wheel && \
-    python3 -m pip install google-cloud-spanner && \
+    python3 -m pip install google-cloud-spanner statsd && \
     rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /app/bin /app/bin

--- a/tools/spanner/purge_ttl.py
+++ b/tools/spanner/purge_ttl.py
@@ -14,8 +14,10 @@ from urllib import parse
 from google.cloud import spanner
 
 # set up logger
-logging.basicConfig(format='{"datetime": "%(asctime)s", "message": "%(message)s"}',
-                    stream=sys.stdout,level=logging.INFO)
+logging.basicConfig(
+    format='{"datetime": "%(asctime)s", "message": "%(message)s"}',
+    stream=sys.stdout,
+    level=logging.INFO)
 
 # Change these to match your install.
 client = spanner.Client()
@@ -53,7 +55,8 @@ def spanner_read_data(request=None):
         query = 'DELETE FROM batches WHERE expiry < CURRENT_TIMESTAMP()'
         result = database.execute_partitioned_dml(query)
         batches_end = datetime.now()
-        logging.info("batches: removed {} rows, batches_duration: {}".format(result, batches_end - batches_start))
+        logging.info("batches: removed {} rows, batches_duration: {}".format(
+            result, batches_end - batches_start))
 
     # Delete BSOs
     with statsd.timer("syncstorage.purge_ttl.bso_duration"):
@@ -61,7 +64,8 @@ def spanner_read_data(request=None):
         query = 'DELETE FROM bsos WHERE expiry < CURRENT_TIMESTAMP()'
         result = database.execute_partitioned_dml(query)
         bso_end = datetime.now()
-        logging.info("bso: removed {} rows, bso_duration: {}".format(result, bso_end - bso_start))
+        logging.info("bso: removed {} rows, bso_duration: {}".format(
+            result, bso_end - bso_start))
 
 
 if __name__ == "__main__":
@@ -73,4 +77,5 @@ if __name__ == "__main__":
 
         end_time = datetime.now()
         duration = end_time - start_time
-        logging.info('Completed purge_ttl.py, total_duration: {}'.format(duration))
+        logging.info(
+            'Completed purge_ttl.py, total_duration: {}'.format(duration))

--- a/tools/spanner/purge_ttl.py
+++ b/tools/spanner/purge_ttl.py
@@ -14,12 +14,8 @@ from urllib import parse
 from google.cloud import spanner
 
 # set up logger
-logger = logging.getLogger()
-logger.setLevel(logging.INFO)
-handler = logging.StreamHandler(sys.stdout)
-formatter = logging.Formatter('{"datetime": "%(asctime)s", "message": "%(message)s"}')
-handler.setFormatter(formatter)
-logger.addHandler(handler)
+logging.basicConfig(format='{"datetime": "%(asctime)s", "message": "%(message)s"}',
+                    stream=sys.stdout,level=logging.INFO)
 
 # Change these to match your install.
 client = spanner.Client()
@@ -48,35 +44,33 @@ def spanner_read_data(request=None):
     instance = client.instance(instance_id)
     database = instance.database(database_id)
 
-    logger.info("For {}:{}".format(instance_id, database_id))
+    logging.info("For {}:{}".format(instance_id, database_id))
 
     # Delete Batches. Also deletes child batch_bsos rows (INTERLEAVE
     # IN PARENT batches ON DELETE CASCADE)
-    batches_start = datetime.now()
-    query = 'DELETE FROM batches WHERE expiry < CURRENT_TIMESTAMP()'
-    result = database.execute_partitioned_dml(query)
-    batches_end = datetime.now()
-    batches_duration = batches_end - batches_start
-    logger.info("batches: removed {} rows, batches_duration: {}".format(result, batches_duration))
-    statsd.timing("sync.purge_ttl.batches_duration", batches_duration)
+    with statsd.timer("syncstorage.purge_ttl.batches_duration"):
+        batches_start = datetime.now()
+        query = 'DELETE FROM batches WHERE expiry < CURRENT_TIMESTAMP()'
+        result = database.execute_partitioned_dml(query)
+        batches_end = datetime.now()
+        logging.info("batches: removed {} rows, batches_duration: {}".format(result, batches_end - batches_start))
 
     # Delete BSOs
-    bso_start = datetime.now()
-    query = 'DELETE FROM bsos WHERE expiry < CURRENT_TIMESTAMP()'
-    result = database.execute_partitioned_dml(query)
-    bso_end = datetime.now()
-    bso_duration = bso_end - bso_start
-    logger.info("bso: removed {} rows, bso_duration: {}".format(result, bso_duration))
-    statsd.timing("sync.purge_ttl.bso_duration", bso_duration)
+    with statsd.timer("syncstorage.purge_ttl.bso_duration"):
+        bso_start = datetime.now()
+        query = 'DELETE FROM bsos WHERE expiry < CURRENT_TIMESTAMP()'
+        result = database.execute_partitioned_dml(query)
+        bso_end = datetime.now()
+        logging.info("bso: removed {} rows, bso_duration: {}".format(result, bso_end - bso_start))
 
 
 if __name__ == "__main__":
-    start_time = datetime.now()
-    logger.info('Starting purge_ttl.py')
+    with statsd.timer("syncstorage.purge_ttl.total_duration"):
+        start_time = datetime.now()
+        logging.info('Starting purge_ttl.py')
 
-    spanner_read_data()
+        spanner_read_data()
 
-    end_time = datetime.now()
-    duration = end_time - start_time
-    logger.info('Completed purge_ttl.py, total_duration: {}'.format(duration))
-    statsd.timing("sync.purge_ttl.total_duration", duration)
+        end_time = datetime.now()
+        duration = end_time - start_time
+        logging.info('Completed purge_ttl.py, total_duration: {}'.format(duration))


### PR DESCRIPTION
## Description

Add start/stop/duration logging for the purge_ttl.py script as well as post the durations timings to a
statsd server (defaults to `localhost:8125`, overrides with env variables `STATSD_HOST:STATSD_PORT`

## Testing

set env variables for:
```
export GOOGLE_APPLICATION_CREDENTIALS=path/to/credentials.json
export SYNC_DATABASE_URL=<url-to-database>
```
[optional] Listen for statsd in another shell:
```
nc -u -l 8125
```
Then execute:
```
python3 ./tools/spanner/purge_ttl.py
```

## Issue(s)

Closes [link](link).
