### PR TITLE
bug: Don't use HttpResponse::Ok().status(status)

### DIFF
--- a/src/web/middleware/precondition.rs
+++ b/src/web/middleware/precondition.rs
@@ -176,10 +176,9 @@ where
                     if status != StatusCode::OK {
                         return Either::A(future::ok(
                             sreq.into_response(
-                                HttpResponse::Ok()
+                                HttpResponse::build(status)
                                     .content_type("application/json")
                                     .header(X_LAST_MODIFIED, resource_ts.as_header())
-                                    .status(status)
                                     .body("".to_owned())
                                     .into_body(),
                             ),


### PR DESCRIPTION
Closes #393

## Description

Use `HttpResponse::build(status)` instead, which is clearer.

## Testing

This is a code cosmetic change.

## Issue(s)

Closes #393