### PR TITLE
bug: Don't report `uri.path` to Metrics

### DIFF
--- a/src/server/metrics.rs
+++ b/src/server/metrics.rs
@@ -223,7 +223,6 @@ mod tests {
         result.insert("ua.browser.ver".to_owned(), "72.0".to_owned());
         result.insert("ua.name".to_owned(), "Firefox".to_owned());
         result.insert("ua.browser.family".to_owned(), "Firefox".to_owned());
-        result.insert("uri.path".to_owned(), path.to_owned());
         result.insert("uri.method".to_owned(), "GET".to_owned());
 
         assert_eq!(tags.tags, result)

--- a/src/web/middleware/sentry.rs
+++ b/src/web/middleware/sentry.rs
@@ -69,6 +69,7 @@ where
 
     fn call(&mut self, sreq: ServiceRequest) -> Self::Future {
         let mut tags = Tags::from_request_head(sreq.head());
+        let uri = sreq.head().uri.to_string();
         sreq.extensions_mut().insert(tags.clone());
 
         Box::new(self.service.call(sreq).and_then(move |sresp| {
@@ -94,6 +95,8 @@ where
                             tags.tags.insert(k, v);
                         }
                     };
+                    // add the uri.path (which can cause influx to puke)
+                    tags.tags.insert("uri.path".to_owned(), uri);
                     // deriving the sentry event from a fail directly from the error
                     // is not currently thread safe. Downcasting the error to an
                     // ApiError resolves this.

--- a/src/web/tags.rs
+++ b/src/web/tags.rs
@@ -57,7 +57,7 @@ impl Tags {
                 tags.insert("ua.browser.ver".to_owned(), ua_result.version.to_owned());
             }
         }
-        tags.insert("uri.path".to_owned(), req_head.uri.to_string());
+        // `uri.path` causes too much cardinality for influx.
         tags.insert("uri.method".to_owned(), req_head.method.to_string());
         Tags { tags }
     }


### PR DESCRIPTION
## Description

Remove the `uri.path` from default Tags.

## Testing

Unit tests were modified.

## Issue(s)

Closes #408
