### PR TITLE
bug: filter out variable data from URI metric

### DIFF
--- a/src/db/error.rs
+++ b/src/db/error.rs
@@ -1,4 +1,3 @@
-
 use std::fmt;
 
 use actix_web::http::StatusCode;

--- a/src/db/error.rs
+++ b/src/db/error.rs
@@ -1,3 +1,4 @@
+
 use std::fmt;
 
 use actix_web::http::StatusCode;

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,9 @@
 //! Error types and macros.
-#![allow(clippy::single_match)]
+// TODO: Currently `Validation(#[cause] ValidationError)` may trigger some
+// performance issues. The suggested fix is to Box ValidationError, however
+// this cascades into Failure requiring std::error::Error being implemented
+// which is out of scope.
+#![allow(clippy::single_match, clippy::large_enum_variant)]
 use std::fmt;
 
 use actix_web::{

--- a/src/web/middleware/sentry.rs
+++ b/src/web/middleware/sentry.rs
@@ -67,12 +67,14 @@ where
             // most values are either "=true" or a lower case hex string.
             static ref RE: regex::Regex = regex::Regex::new(r"=[a-z\d]{5,}").unwrap();
         }
+        // to satisify clippy and rustc.
+        let slash: &str = "/";
         let trimmed = uri
             .to_string()
-            .split('/')
+            .split(slash)
             .collect::<Vec<&str>>()
             .split_off(3)
-            .join('/');
+            .join(slash);
         RE.replace_all(&trimmed, "=###").to_owned().to_string()
     }
 }

--- a/src/web/middleware/sentry.rs
+++ b/src/web/middleware/sentry.rs
@@ -92,7 +92,7 @@ where
                     if let Some(t) = sresp.response().extensions().get::<Tags>() {
                         debug!("Found response tags: {:?}", &t.tags);
                         for (k, v) in t.tags.clone() {
-                            tags.extra.insert(k, v);
+                            tags.tags.insert(k, v);
                         }
                     };
                     // add the uri.path (which can cause influx to puke)

--- a/src/web/middleware/sentry.rs
+++ b/src/web/middleware/sentry.rs
@@ -69,10 +69,10 @@ where
         }
         let trimmed = uri
             .to_string()
-            .split("/")
+            .split('/')
             .collect::<Vec<&str>>()
             .split_off(3)
-            .join("/");
+            .join('/');
         RE.replace_all(&trimmed, "=###").to_owned().to_string()
     }
 }

--- a/src/web/tags.rs
+++ b/src/web/tags.rs
@@ -9,18 +9,21 @@ use serde::{
     ser::{SerializeMap, Serializer},
     Serialize,
 };
+use serde_json::value::Value;
 
 use crate::server::user_agent::parse_user_agent;
 
 #[derive(Clone, Debug)]
 pub struct Tags {
     pub tags: HashMap<String, String>,
+    pub extra: HashMap<String, String>,
 }
 
 impl Default for Tags {
     fn default() -> Tags {
         Tags {
             tags: HashMap::new(),
+            extra: HashMap::new(),
         }
     }
 }
@@ -63,14 +66,14 @@ impl Tags {
         }
         // `uri.path` causes too much cardinality for influx.
         tags.insert("uri.method".to_owned(), req_head.method.to_string());
-        Tags { tags }
+        Tags { tags, extra: HashMap::new() }
     }
 
     pub fn with_tags(tags: HashMap<String, String>) -> Tags {
         if tags.is_empty() {
             return Tags::default();
         }
-        Tags { tags }
+        Tags { tags, extra: HashMap::new() }
     }
 
     pub fn get(&self, label: &str) -> String {
@@ -81,6 +84,25 @@ impl Tags {
     pub fn extend(&mut self, tags: HashMap<String, String>) {
         self.tags.extend(tags);
     }
+
+    pub fn tag_tree(self) -> BTreeMap<String, String> {
+        let mut result = BTreeMap::new();
+
+        for (k, v) in self.tags {
+            result.insert(k.clone(), v.clone());
+        }
+        result
+    }
+
+    pub fn extra_tree(self) -> BTreeMap<String, Value> {
+        let mut result = BTreeMap::new();
+
+        for (k, v) in self.extra {
+            result.insert(k.clone(), Value::from(v));
+        }
+        result
+    }
+
 }
 
 impl FromRequest for Tags {

--- a/src/web/tags.rs
+++ b/src/web/tags.rs
@@ -66,14 +66,20 @@ impl Tags {
         }
         // `uri.path` causes too much cardinality for influx.
         tags.insert("uri.method".to_owned(), req_head.method.to_string());
-        Tags { tags, extra: HashMap::new() }
+        Tags {
+            tags,
+            extra: HashMap::new(),
+        }
     }
 
     pub fn with_tags(tags: HashMap<String, String>) -> Tags {
         if tags.is_empty() {
             return Tags::default();
         }
-        Tags { tags, extra: HashMap::new() }
+        Tags {
+            tags,
+            extra: HashMap::new(),
+        }
     }
 
     pub fn get(&self, label: &str) -> String {
@@ -102,7 +108,6 @@ impl Tags {
         }
         result
     }
-
 }
 
 impl FromRequest for Tags {


### PR DESCRIPTION
## Description

filter out UID and batch numbers from URI.

This drops the first two path elements from the URI as well as masks any large hexidecimal identifier that may appear in the URI parameters. This should retain enough diagnostic information to be useful without causing overload for sentry.

## Testing

While running normal testing note that the `uri.path` metric goes from something like:
`/1.5/135772380/storage/history?batch=5ef59eae10244edc90935bab2ffea0f0&commit=true`
to 
`storage/history?batch=###&commit=true`

## Issue(s)

Closes #420
