### PR TITLE
feat: restrict release mode logging to ERROR

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ serde_json = { version = "1.0", features = ["arbitrary_precision"] }
 serde_urlencoded = "0.6.1"
 scheduled-thread-pool = "0.2"
 sha2 = "0.8.0"
-slog = { version = "2.5", features = ["max_level_trace", "release_max_level_info"] }
+slog = { version = "2.5", features = ["max_level_trace", "release_max_level_error"] }
 slog-async = "2.3"
 slog-envlogger = "2.2.0"
 slog-mozlog-json = "0.1"


### PR DESCRIPTION
## Testing

Seeing less log messages output in `--release` mode

## Issue(s)

Closes #426