### PR TITLE
ci: rm rust dependency diff

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -237,31 +237,6 @@ jobs:
               echo "Not pushing to dockerhub for tag=${CIRCLE_TAG} branch=${CIRCLE_BRANCH}"
             fi
 
-  rust-changelog:
-    docker:
-      - image: python:3.7-buster
-    steps:
-      - setup_remote_docker:
-          version: 18.02.0-ce
-      - run:
-          name: Install Docker client
-          command: |
-            set -x
-            VER="18.06.3-ce"
-            curl -L -o /tmp/docker-$VER.tgz https://download.docker.com/linux/static/stable/x86_64/docker-$VER.tgz
-            tar -xz -C /tmp -f /tmp/docker-$VER.tgz
-            mv /tmp/docker/* /usr/bin
-      - run:
-          name: pull find-package-rugaru image
-          command: |
-            docker pull mozilla/dependencyscan:latest
-      - run:
-          name: Check Rust Dependencies
-          command: |
-            printf "{\"org\": \"mozilla-services\", \"repo\": \"syncstorage-rs\", \"ref\": {\"value\": \"master\", \"kind\": \"branch\"}, \"repo_url\": \"https://github.com/mozilla-services/syncstorage-rs.git\"}\n{\"org\": \"mozilla-services\", \"repo\": \"syncstorage-rs\", \"ref\": {\"value\": \"$CIRCLE_SHA1\", \"kind\": \"commit\"}, \"repo_url\": \"https://github.com/mozilla-services/syncstorage-rs.git\"}\n"  | \
-                docker run --rm -i -v /var/run/docker.sock:/var/run/docker.sock --name fpr-cargo_metadata mozilla/dependencyscan:latest python fpr/run_pipeline.py cargo_metadata | \
-                docker run --rm -i -v /var/run/docker.sock:/var/run/docker.sock --name fpr-rust_changelog mozilla/dependencyscan:latest python fpr/run_pipeline.py rust_changelog -m Cargo.toml
-
 workflows:
   version: 2
   build-deploy:
@@ -277,11 +252,6 @@ workflows:
       - e2e-tests:
           requires:
             - build-and-test
-          filters:
-            tags:
-              only: /.*/
-      - rust-changelog:
-        # email dependency-observatory@mozilla.com with feedback
           filters:
             tags:
               only: /.*/


### PR DESCRIPTION
reverts #204

## Description

Drop the rust changelog CI job.

We're (foxsec/secops) working on an alternative that doesn't run in CI and provides more historical and cross-repo data, but it will break the current CI job interface.

## Testing

How should reviewers test?

The rust-changelog CI job should no longer run in CI. Other tests should still pass.

## Issue(s)

None.