### PR TITLE
Fix #432 Convert trivial db functions to async/await.

### DIFF
--- a/src/web/extractors.rs
+++ b/src/web/extractors.rs
@@ -522,9 +522,7 @@ impl FromRequest for BsoParam {
 
     fn from_request(req: &HttpRequest, _: &mut Payload) -> Self::Future {
         let req = req.clone();
-        Box::pin(async move {
-            Self::extrude(req.head(), &mut req.extensions_mut())
-        })
+        Box::pin(async move { Self::extrude(req.head(), &mut req.extensions_mut()) })
     }
 }
 
@@ -655,7 +653,7 @@ impl FromRequest for MetaRequest {
             })
             //            }))
         }
-        .boxed_local()
+            .boxed_local()
     }
 }
 
@@ -731,7 +729,7 @@ impl FromRequest for CollectionRequest {
             })
             //            }))
         }
-        .boxed_local()
+            .boxed_local()
     }
 }
 
@@ -1231,9 +1229,7 @@ impl FromRequest for Box<dyn Db> {
 
     fn from_request(req: &HttpRequest, _: &mut Payload) -> Self::Future {
         let req = req.clone();
-        Box::pin(async move {
-            extrude_db(&req.extensions())
-        })
+        Box::pin(async move { extrude_db(&req.extensions()) })
     }
 }
 

--- a/src/web/extractors.rs
+++ b/src/web/extractors.rs
@@ -653,7 +653,7 @@ impl FromRequest for MetaRequest {
             })
             //            }))
         }
-            .boxed_local()
+        .boxed_local()
     }
 }
 
@@ -729,7 +729,7 @@ impl FromRequest for CollectionRequest {
             })
             //            }))
         }
-            .boxed_local()
+        .boxed_local()
     }
 }
 

--- a/src/web/middleware/db.rs
+++ b/src/web/middleware/db.rs
@@ -6,7 +6,7 @@ use actix_web::{
     http::{header::HeaderValue, Method},
     Error, HttpMessage, HttpResponse,
 };
-use futures::future::{self, Either, LocalBoxFuture, Ready, TryFutureExt};
+use futures::future::{self, Either, LocalBoxFuture, TryFutureExt};
 use std::task::Poll;
 
 use crate::db::params;
@@ -40,11 +40,13 @@ where
     type Error = Error;
     type InitError = ();
     type Transform = DbTransactionMiddleware<S>;
-    type Future = Ready<Result<Self::Transform, Self::InitError>>;
+    type Future = LocalBoxFuture<'static, Result<Self::Transform, Self::InitError>>;
 
     fn new_transform(&self, service: S) -> Self::Future {
-        future::ok(DbTransactionMiddleware {
-            service: Rc::new(RefCell::new(service)),
+        Box::pin(async {
+            Ok(DbTransactionMiddleware {
+                service: Rc::new(RefCell::new(service)),
+            })
         })
     }
 }

--- a/src/web/middleware/precondition.rs
+++ b/src/web/middleware/precondition.rs
@@ -46,10 +46,11 @@ where
     type Future = LocalBoxFuture<'static, Result<Self::Transform, Self::InitError>>;
 
     fn new_transform(&self, service: S) -> Self::Future {
-        future::ok(PreConditionCheckMiddleware {
-            service: Rc::new(RefCell::new(service)),
+        Box::pin(async {
+            Ok(PreConditionCheckMiddleware {
+                service: Rc::new(RefCell::new(service)),
+            })
         })
-        .boxed_local()
     }
 }
 

--- a/src/web/middleware/sentry.rs
+++ b/src/web/middleware/sentry.rs
@@ -39,9 +39,11 @@ where
     type Future = LocalBoxFuture<'static, Result<Self::Transform, Self::InitError>>;
 
     fn new_transform(&self, service: S) -> Self::Future {
-        Box::pin(future::ok(SentryWrapperMiddleware {
-            service: Rc::new(RefCell::new(service)),
-        }))
+        Box::pin(async {
+            Ok(SentryWrapperMiddleware {
+                service: Rc::new(RefCell::new(service)),
+            })
+        })
     }
 }
 

--- a/src/web/middleware/weave.rs
+++ b/src/web/middleware/weave.rs
@@ -109,9 +109,7 @@ where
     type Future = LocalBoxFuture<'static, Result<Self::Transform, Self::InitError>>;
 
     fn new_transform(&self, service: S) -> Self::Future {
-        Box::pin(async {
-            Ok(WeaveTimestampMiddleware { service })
-        })
+        Box::pin(async { Ok(WeaveTimestampMiddleware { service }) })
     }
 }
 

--- a/src/web/middleware/weave.rs
+++ b/src/web/middleware/weave.rs
@@ -109,7 +109,9 @@ where
     type Future = LocalBoxFuture<'static, Result<Self::Transform, Self::InitError>>;
 
     fn new_transform(&self, service: S) -> Self::Future {
-        Box::pin(future::ok(WeaveTimestampMiddleware { service }))
+        Box::pin(async {
+            Ok(WeaveTimestampMiddleware { service })
+        })
     }
 }
 

--- a/src/web/tags.rs
+++ b/src/web/tags.rs
@@ -6,7 +6,7 @@ use actix_web::{
     Error, FromRequest, HttpRequest,
 };
 
-use futures::future::{LocalBoxFuture};
+use futures::future::LocalBoxFuture;
 
 use serde::{
     ser::{SerializeMap, Serializer},


### PR DESCRIPTION
## Description

Convert the trivial spanner db functions to async/await.

## Testing

All tests should pass.

## Issue(s)

Closes #432.
