### PR TITLE
Fix #436 Convert misc db functions to async/await

### DIFF
--- a/src/db/spanner/models.rs
+++ b/src/db/spanner/models.rs
@@ -1,5 +1,4 @@
 use actix_web::web::block;
-use failure::ResultExt;
 use futures::compat::Future01CompatExt;
 use futures::future::TryFutureExt;
 
@@ -777,7 +776,8 @@ impl SpannerDb {
                 "pretouch_ts" => TypeCode::TIMESTAMP,
             })
             .execute_async(&self.conn)?
-            .one().await?;
+            .one()
+            .await?;
         if row[0].has_null_value() {
             SyncTimestamp::from_i64(0)
         } else {
@@ -895,7 +895,8 @@ impl SpannerDb {
             .param_types(param_types! {
                 "pretouch_ts" => TypeCode::TIMESTAMP,
             })
-            .execute_dml_async(&self.conn).await?;
+            .execute_dml_async(&self.conn)
+            .await?;
         if affected_rows > 0 {
             self.erect_tombstone(&params.user_id)
         } else {
@@ -1636,12 +1637,18 @@ impl Db for SpannerDb {
         })
     }
 
-    fn get_storage_timestamp(&self, param: params::GetStorageTimestamp) -> DbFuture<results::GetStorageTimestamp> {
+    fn get_storage_timestamp(
+        &self,
+        param: params::GetStorageTimestamp,
+    ) -> DbFuture<results::GetStorageTimestamp> {
         let db = self.clone();
         Box::pin(async move { db.get_storage_timestamp(param).map_err(Into::into).await })
     }
 
-    fn delete_collection(&self, param: params::DeleteCollection) -> DbFuture<results::DeleteCollection> {
+    fn delete_collection(
+        &self,
+        param: params::DeleteCollection,
+    ) -> DbFuture<results::DeleteCollection> {
         let db = self.clone();
         Box::pin(async move { db.delete_collection(param).map_err(Into::into).await })
     }

--- a/src/db/spanner/models.rs
+++ b/src/db/spanner/models.rs
@@ -1,4 +1,6 @@
 use actix_web::web::block;
+use failure::ResultExt;
+use futures::compat::Future01CompatExt;
 use futures::future::TryFutureExt;
 
 use diesel::r2d2::PooledConnection;
@@ -139,6 +141,31 @@ impl SpannerDb {
         }
     }
 
+    pub(super) async fn get_collection_id_async(&self, name: &str) -> Result<i32> {
+        if let Some(id) = self.coll_cache.get_id(name)? {
+            return Ok(id);
+        }
+        let result = self
+            .sql(
+                "SELECT collection_id
+                   FROM collections
+                  WHERE name = @name",
+            )?
+            .params(params! {"name" => name.to_string()})
+            .execute_async(&self.conn)?
+            .one_or_none()
+            .await?
+            .ok_or(DbErrorKind::CollectionNotFound)?;
+        let id = result[0]
+            .get_string_value()
+            .parse::<i32>()
+            .map_err(|e| DbErrorKind::Integrity(e.to_string()))?;
+        if !self.in_write_transaction() {
+            self.coll_cache.put(id, name.to_owned())?;
+        }
+        Ok(id)
+    }
+
     pub(super) fn get_collection_id(&self, name: &str) -> Result<i32> {
         if let Some(id) = self.coll_cache.get_id(name)? {
             return Ok(id);
@@ -202,18 +229,19 @@ impl SpannerDb {
         })
     }
 
-    pub fn lock_for_read_sync(&self, params: params::LockCollection) -> Result<()> {
+    pub async fn lock_for_read_async(&self, params: params::LockCollection) -> Result<()> {
         // Begin a transaction
-        self.begin(false)?;
+        self.begin_async(false).await?;
 
-        let collection_id =
-            self.get_collection_id(&params.collection)
-                .or_else(|e| match e.kind() {
-                    // If the collection doesn't exist, we still want to start a
-                    // transaction so it will continue to not exist.
-                    DbErrorKind::CollectionNotFound => Ok(0),
-                    _ => Err(e),
-                })?;
+        let collection_id = self
+            .get_collection_id_async(&params.collection)
+            .await
+            .or_else(|e| match e.kind() {
+                // If the collection doesn't exist, we still want to start a
+                // transaction so it will continue to not exist.
+                DbErrorKind::CollectionNotFound => Ok(0),
+                _ => Err(e),
+            })?;
         // If we already have a read or write lock then it's safe to
         // use it as-is.
         if self
@@ -235,9 +263,9 @@ impl SpannerDb {
         Ok(())
     }
 
-    pub fn lock_for_write_sync(&self, params: params::LockCollection) -> Result<()> {
+    pub async fn lock_for_write_async(&self, params: params::LockCollection) -> Result<()> {
         // Begin a transaction
-        self.begin(true)?;
+        self.begin_async(true).await?;
         let collection_id = self.get_or_create_collection_id(&params.collection)?;
         if let Some(CollectionLock::Read) = self
             .inner
@@ -324,12 +352,45 @@ impl SpannerDb {
         Ok(())
     }
 
+    pub(super) async fn begin_async(&self, for_write: bool) -> Result<()> {
+        let spanner = &self.conn;
+        let mut options = TransactionOptions::new();
+        if for_write {
+            options.set_read_write(TransactionOptions_ReadWrite::new());
+            self.session.borrow_mut().in_write_transaction = true;
+        } else {
+            options.set_read_only(TransactionOptions_ReadOnly::new());
+        }
+        let mut req = BeginTransactionRequest::new();
+        req.set_session(spanner.session.get_name().to_owned());
+        req.set_options(options);
+        let mut transaction = spanner
+            .client
+            .begin_transaction_async(&req)?
+            .compat()
+            .await?;
+
+        let mut ts = TransactionSelector::new();
+        ts.set_id(transaction.take_id());
+        self.session.borrow_mut().transaction = Some(ts);
+        Ok(())
+    }
+
     /// Return the current transaction metadata (TransactionSelector) if one is active.
     fn get_transaction(&self) -> Result<Option<TransactionSelector>> {
         Ok(if self.session.borrow().transaction.is_some() {
             self.session.borrow().transaction.clone()
         } else {
             self.begin(true)?;
+            self.session.borrow().transaction.clone()
+        })
+    }
+    /// Return the current transaction metadata (TransactionSelector) if one is active.
+    async fn get_transaction_async(&self) -> Result<Option<TransactionSelector>> {
+        Ok(if self.session.borrow().transaction.is_some() {
+            self.session.borrow().transaction.clone()
+        } else {
+            self.begin_async(true).await?;
             self.session.borrow().transaction.clone()
         })
     }
@@ -405,7 +466,7 @@ impl SpannerDb {
         self.session.borrow().in_write_transaction
     }
 
-    pub fn commit_sync(&self) -> Result<()> {
+    pub fn commit(&self) -> Result<()> {
         if !self.in_write_transaction() {
             // read-only
             return Ok(());
@@ -432,7 +493,34 @@ impl SpannerDb {
         }
     }
 
-    pub fn rollback_sync(&self) -> Result<()> {
+    pub async fn commit_async(&self) -> Result<()> {
+        if !self.in_write_transaction() {
+            // read-only
+            return Ok(());
+        }
+
+        let spanner = &self.conn;
+
+        if cfg!(any(test, feature = "db_test")) && spanner.use_test_transactions {
+            // don't commit test transactions
+            return Ok(());
+        }
+
+        if let Some(transaction) = self.get_transaction_async().await? {
+            let mut req = CommitRequest::new();
+            req.set_session(spanner.session.get_name().to_owned());
+            req.set_transaction_id(transaction.get_id().to_vec());
+            if let Some(mutations) = self.session.borrow_mut().mutations.take() {
+                req.set_mutations(RepeatedField::from_vec(mutations));
+            }
+            spanner.client.commit(&req)?;
+            Ok(())
+        } else {
+            Err(DbError::internal("No transaction to commit"))?
+        }
+    }
+
+    pub fn rollback(&self) -> Result<()> {
         if !self.in_write_transaction() {
             // read-only
             return Ok(());
@@ -450,14 +538,29 @@ impl SpannerDb {
         }
     }
 
-    pub fn get_collection_timestamp_sync(
+    pub async fn rollback_async(&self) -> Result<()> {
+        if !self.in_write_transaction() {
+            // read-only
+            return Ok(());
+        }
+
+        if let Some(transaction) = self.get_transaction_async().await? {
+            let spanner = &self.conn;
+            let mut req = RollbackRequest::new();
+            req.set_session(spanner.session.get_name().to_owned());
+            req.set_transaction_id(transaction.get_id().to_vec());
+            spanner.client.rollback(&req)?;
+            Ok(())
+        } else {
+            Err(DbError::internal("No transaction to rollback"))?
+        }
+    }
+
+    pub async fn get_collection_timestamp_async(
         &self,
         params: params::GetCollectionTimestamp,
     ) -> Result<SyncTimestamp> {
-        debug!(
-            "!!QQQ get_collection_timestamp_sync {:?}",
-            &params.collection
-        );
+        debug!("!!QQQ get_collection_timestamp {:?}", &params.collection);
 
         let collection_id = self.get_collection_id(&params.collection)?;
         if let Some(modified) = self
@@ -653,7 +756,7 @@ impl SpannerDb {
         self.map_collection_names(usages)
     }
 
-    pub fn get_storage_timestamp_sync(
+    pub async fn get_storage_timestamp(
         &self,
         user_id: params::GetStorageTimestamp,
     ) -> Result<SyncTimestamp> {
@@ -673,8 +776,8 @@ impl SpannerDb {
             .param_types(param_types! {
                 "pretouch_ts" => TypeCode::TIMESTAMP,
             })
-            .execute(&self.conn)?
-            .one()?;
+            .execute_async(&self.conn)?
+            .one().await?;
         if row[0].has_null_value() {
             SyncTimestamp::from_i64(0)
         } else {
@@ -769,7 +872,7 @@ impl SpannerDb {
             .ok_or_else(|| DbError::internal("CURRENT_TIMESTAMP() not read yet"))
     }
 
-    pub fn delete_collection_sync(
+    pub async fn delete_collection(
         &self,
         params: params::DeleteCollection,
     ) -> Result<results::DeleteCollection> {
@@ -792,11 +895,11 @@ impl SpannerDb {
             .param_types(param_types! {
                 "pretouch_ts" => TypeCode::TIMESTAMP,
             })
-            .execute_dml(&self.conn)?;
+            .execute_dml_async(&self.conn).await?;
         if affected_rows > 0 {
             self.erect_tombstone(&params.user_id)
         } else {
-            self.get_storage_timestamp_sync(params.user_id)
+            self.get_storage_timestamp(params.user_id).await
         }
     }
 
@@ -1503,12 +1606,44 @@ macro_rules! sync_db_method {
 impl Db for SpannerDb {
     fn commit(&self) -> DbFuture<()> {
         let db = self.clone();
-        Box::pin(block(move || db.commit_sync().map_err(Into::into)).map_err(Into::into))
+        Box::pin(async move { db.commit_async().map_err(Into::into).await })
     }
 
     fn rollback(&self) -> DbFuture<()> {
         let db = self.clone();
-        Box::pin(block(move || db.rollback_sync().map_err(Into::into)).map_err(Into::into))
+        Box::pin(async move { db.rollback_async().map_err(Into::into).await })
+    }
+
+    fn lock_for_read(&self, param: params::LockCollection) -> DbFuture<()> {
+        let db = self.clone();
+        Box::pin(async move { db.lock_for_read_async(param).map_err(Into::into).await })
+    }
+
+    fn lock_for_write(&self, param: params::LockCollection) -> DbFuture<()> {
+        let db = self.clone();
+        Box::pin(async move { db.lock_for_write_async(param).map_err(Into::into).await })
+    }
+
+    fn get_collection_timestamp(
+        &self,
+        param: params::GetCollectionTimestamp,
+    ) -> DbFuture<results::GetCollectionTimestamp> {
+        let db = self.clone();
+        Box::pin(async move {
+            db.get_collection_timestamp_async(param)
+                .map_err(Into::into)
+                .await
+        })
+    }
+
+    fn get_storage_timestamp(&self, param: params::GetStorageTimestamp) -> DbFuture<results::GetStorageTimestamp> {
+        let db = self.clone();
+        Box::pin(async move { db.get_storage_timestamp(param).map_err(Into::into).await })
+    }
+
+    fn delete_collection(&self, param: params::DeleteCollection) -> DbFuture<results::DeleteCollection> {
+        let db = self.clone();
+        Box::pin(async move { db.delete_collection(param).map_err(Into::into).await })
     }
 
     fn box_clone(&self) -> Box<dyn Db> {
@@ -1520,13 +1655,6 @@ impl Db for SpannerDb {
         Box::pin(block(move || db.check_sync().map_err(Into::into)).map_err(Into::into))
     }
 
-    sync_db_method!(lock_for_read, lock_for_read_sync, LockCollection);
-    sync_db_method!(lock_for_write, lock_for_write_sync, LockCollection);
-    sync_db_method!(
-        get_collection_timestamp,
-        get_collection_timestamp_sync,
-        GetCollectionTimestamp
-    );
     sync_db_method!(
         get_collection_timestamps,
         get_collection_timestamps_sync,
@@ -1542,14 +1670,8 @@ impl Db for SpannerDb {
         get_collection_usage_sync,
         GetCollectionUsage
     );
-    sync_db_method!(
-        get_storage_timestamp,
-        get_storage_timestamp_sync,
-        GetStorageTimestamp
-    );
     sync_db_method!(get_storage_usage, get_storage_usage_sync, GetStorageUsage);
     sync_db_method!(delete_storage, delete_storage_sync, DeleteStorage);
-    sync_db_method!(delete_collection, delete_collection_sync, DeleteCollection);
     sync_db_method!(delete_bso, delete_bso_sync, DeleteBso);
     sync_db_method!(delete_bsos, delete_bsos_sync, DeleteBsos);
     sync_db_method!(get_bsos, get_bsos_sync, GetBsos);

--- a/src/db/spanner/support.rs
+++ b/src/db/spanner/support.rs
@@ -6,8 +6,8 @@ use std::{
 };
 
 use actix_rt::{System, SystemRunner};
-use futures::compat::{Compat01As03, Stream01CompatExt};
-use futures::stream::{StreamExt, StreamFuture};
+use futures::compat::{Compat01As03, Stream01CompatExt, Future01CompatExt};
+use futures::stream::{Stream, StreamExt, StreamFuture};
 use googleapis_raw::spanner::v1::{
     result_set::{PartialResultSet, ResultSetMetadata, ResultSetStats},
     spanner::ExecuteSqlRequest,
@@ -112,9 +112,23 @@ impl ExecuteSqlRequestBuilder {
         Ok(StreamedResultSet::new(stream))
     }
 
+    /// Execute a SQL read statement but return a non-blocking streaming result
+    pub fn execute_async(self, conn: &Conn) -> Result<StreamedResultSetAsync> {
+        let stream = conn
+            .client
+            .execute_streaming_sql(&self.prepare_request(conn))?;
+        Ok(StreamedResultSetAsync::new(stream))
+    }
+
     /// Execute a DML statement, returning the exact count of modified rows
     pub fn execute_dml(self, conn: &Conn) -> Result<i64> {
         let rs = conn.client.execute_sql(&self.prepare_request(conn))?;
+        Ok(rs.get_stats().get_row_count_exact())
+    }
+    
+    /// Execute a DML statement, returning the exact count of modified rows
+    pub async fn execute_dml_async(self, conn: &Conn) -> Result<i64> {
+        let rs = conn.client.execute_sql_async(&self.prepare_request(conn))?.compat().await?;
         Ok(rs.get_stats().get_row_count_exact())
     }
 }
@@ -290,6 +304,149 @@ impl fmt::Debug for StreamedResultSet {
             .field("current_row", &self.current_row)
             .field("pending_chunk", &self.pending_chunk)
             .finish()
+    }
+}
+
+pub struct StreamedResultSetAsync {
+    /// Stream from execute_streaming_sql
+    stream: Option<StreamFuture<Compat01As03<ClientSStreamReceiver<PartialResultSet>>>>,
+
+    metadata: Option<ResultSetMetadata>,
+    stats: Option<ResultSetStats>,
+
+    /// Fully-processed rows
+    rows: VecDeque<Vec<Value>>,
+    /// Accumulated values for incomplete row
+    current_row: Vec<Value>,
+    /// Incomplete value
+    pending_chunk: Option<Value>,
+}
+
+impl StreamedResultSetAsync {
+    pub fn new(stream: ClientSStreamReceiver<PartialResultSet>) -> Self {
+        Self {
+            stream: Some(stream.compat().into_future()),
+            metadata: None,
+            stats: None,
+            rows: Default::default(),
+            current_row: vec![],
+            pending_chunk: None,
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn metadata(&self) -> Option<&ResultSetMetadata> {
+        self.metadata.as_ref()
+    }
+
+    #[allow(dead_code)]
+    pub fn stats(&self) -> Option<&ResultSetStats> {
+        self.stats.as_ref()
+    }
+
+    pub fn fields(&self) -> &[StructType_Field] {
+        match self.metadata {
+            Some(ref metadata) => metadata.get_row_type().get_fields(),
+            None => &[],
+        }
+    }
+
+    pub async fn one(&mut self) -> Result<Vec<Value>> {
+        if let Some(result) = self.one_or_none().await? {
+            Ok(result)
+        } else {
+            Err(DbError::internal("No rows matched the given query."))?
+        }
+    }
+
+    pub async fn one_or_none(&mut self) -> Result<Option<Vec<Value>>> {
+        let result = self.next_async().await;
+        if result.is_none() {
+            Ok(None)
+        } else if self.next_async().await.is_some() {
+            Err(DbError::internal("Execpted one result; got more."))?
+        } else {
+            result.transpose()
+        }
+    }
+
+    /// Pull and process the next values from the Stream
+    ///
+    /// Returns false when the stream is finished
+    async fn consume_next(&mut self) -> Result<bool> {
+        let (result, stream) = self
+            .stream
+            .take()
+            .expect("Could not get next stream element")
+            .await;
+
+        self.stream = Some(stream.into_future());
+        let mut partial_rs = if let Some(result) = result {
+            result?
+        } else {
+            // Stream finished
+            return Ok(false);
+        };
+
+        if self.metadata.is_none() && partial_rs.has_metadata() {
+            // first response
+            self.metadata = Some(partial_rs.take_metadata());
+        }
+        if partial_rs.has_stats() {
+            // last response
+            self.stats = Some(partial_rs.take_stats());
+        }
+
+        let mut values = partial_rs.take_values().into_vec();
+        if values.is_empty() {
+            // sanity check
+            return Ok(true);
+        }
+
+        if let Some(pending_chunk) = self.pending_chunk.take() {
+            let fields = self.fields();
+            let current_row_i = self.current_row.len();
+            if fields.len() <= current_row_i {
+                Err(DbErrorKind::Integrity(
+                    "Invalid PartialResultSet fields".to_owned(),
+                ))?;
+            }
+            let field = &fields[current_row_i];
+            values[0] = merge_by_type(pending_chunk, &values[0], field.get_field_type())?;
+        }
+        if partial_rs.get_chunked_value() {
+            self.pending_chunk = values.pop();
+        }
+
+        self.consume_values(values);
+        Ok(true)
+    }
+
+    fn consume_values(&mut self, values: Vec<Value>) {
+        let width = self.fields().len();
+        for value in values {
+            self.current_row.push(value);
+            if self.current_row.len() == width {
+                let current_row = mem::replace(&mut self.current_row, vec![]);
+                self.rows.push_back(current_row);
+            }
+        }
+    }
+
+    // We could implement Stream::poll_next instead of this, but
+    // this is easier for now and we can refactor into the trait later
+    async fn next_async(&mut self) -> Option<Result<Vec<Value>>> {
+        while self.rows.is_empty() {
+            match self.consume_next().await {
+                Ok(true) => (),
+                Ok(false) => return None,
+                // Note: Iteration may continue after an error. We may want to
+                // stop afterwards instead for safety sake (it's not really
+                // recoverable)
+                Err(e) => return Some(Err(e)),
+            }
+        }
+        Ok(self.rows.pop_front()).transpose()
     }
 }
 

--- a/src/db/spanner/support.rs
+++ b/src/db/spanner/support.rs
@@ -6,8 +6,8 @@ use std::{
 };
 
 use actix_rt::{System, SystemRunner};
-use futures::compat::{Compat01As03, Stream01CompatExt, Future01CompatExt};
-use futures::stream::{Stream, StreamExt, StreamFuture};
+use futures::compat::{Compat01As03, Future01CompatExt, Stream01CompatExt};
+use futures::stream::{StreamExt, StreamFuture};
 use googleapis_raw::spanner::v1::{
     result_set::{PartialResultSet, ResultSetMetadata, ResultSetStats},
     spanner::ExecuteSqlRequest,
@@ -125,10 +125,14 @@ impl ExecuteSqlRequestBuilder {
         let rs = conn.client.execute_sql(&self.prepare_request(conn))?;
         Ok(rs.get_stats().get_row_count_exact())
     }
-    
+
     /// Execute a DML statement, returning the exact count of modified rows
     pub async fn execute_dml_async(self, conn: &Conn) -> Result<i64> {
-        let rs = conn.client.execute_sql_async(&self.prepare_request(conn))?.compat().await?;
+        let rs = conn
+            .client
+            .execute_sql_async(&self.prepare_request(conn))?
+            .compat()
+            .await?;
         Ok(rs.get_stats().get_row_count_exact())
     }
 }

--- a/src/web/extractors.rs
+++ b/src/web/extractors.rs
@@ -652,7 +652,7 @@ impl FromRequest for MetaRequest {
             })
             //            }))
         }
-            .boxed_local()
+        .boxed_local()
     }
 }
 
@@ -728,7 +728,7 @@ impl FromRequest for CollectionRequest {
             })
             //            }))
         }
-            .boxed_local()
+        .boxed_local()
     }
 }
 

--- a/src/web/extractors.rs
+++ b/src/web/extractors.rs
@@ -652,7 +652,7 @@ impl FromRequest for MetaRequest {
             })
             //            }))
         }
-        .boxed_local()
+            .boxed_local()
     }
 }
 
@@ -728,7 +728,7 @@ impl FromRequest for CollectionRequest {
             })
             //            }))
         }
-        .boxed_local()
+            .boxed_local()
     }
 }
 


### PR DESCRIPTION
## Description

Convert miscellaneous spanner database functions to async/await, including underlying shared code like .execute(.

## Testing

All tests should pass.

## Issue(s)

Closes #436.
