### PR TITLE
refactor: Fix #433 Convert database bso calls to async await

### DIFF
--- a/src/db/spanner/models.rs
+++ b/src/db/spanner/models.rs
@@ -222,7 +222,7 @@ impl SpannerDb {
         Ok(id)
     }
 
-    #[cfg(any(test))]
+    #[allow(dead_code)]
     pub(super) fn create_collection(&self, name: &str) -> Result<i32> {
         // This should always run within a r/w transaction, so that: "If a
         // transaction successfully commits, then no other writer modified the
@@ -255,7 +255,8 @@ impl SpannerDb {
         Ok(id)
     }
 
-    #[cfg(any(test))]
+
+    #[allow(dead_code)]
     fn get_or_create_collection_id(&self, name: &str) -> Result<i32> {
         self.get_collection_id(name).or_else(|e| match e.kind() {
             DbErrorKind::CollectionNotFound => self.create_collection(name),

--- a/src/db/spanner/models.rs
+++ b/src/db/spanner/models.rs
@@ -222,6 +222,7 @@ impl SpannerDb {
         Ok(id)
     }
 
+    #[cfg(any(test))]
     pub(super) fn create_collection(&self, name: &str) -> Result<i32> {
         // This should always run within a r/w transaction, so that: "If a
         // transaction successfully commits, then no other writer modified the
@@ -254,6 +255,7 @@ impl SpannerDb {
         Ok(id)
     }
 
+    #[cfg(any(test))]
     fn get_or_create_collection_id(&self, name: &str) -> Result<i32> {
         self.get_collection_id(name).or_else(|e| match e.kind() {
             DbErrorKind::CollectionNotFound => self.create_collection(name),

--- a/src/db/spanner/models.rs
+++ b/src/db/spanner/models.rs
@@ -255,7 +255,6 @@ impl SpannerDb {
         Ok(id)
     }
 
-
     #[allow(dead_code)]
     fn get_or_create_collection_id(&self, name: &str) -> Result<i32> {
         self.get_collection_id(name).or_else(|e| match e.kind() {

--- a/src/db/spanner/support.rs
+++ b/src/db/spanner/support.rs
@@ -22,7 +22,6 @@ use protobuf::{
 use super::models::{Conn, Result};
 use crate::db::{results, util::SyncTimestamp, DbError, DbErrorKind};
 
-#[cfg(not(any(test, feature = "db_test")))]
 use crate::{
     db::{params, spanner::models::DEFAULT_BSO_TTL, util::to_rfc3339},
     web::extractors::HawkIdentifier,
@@ -510,7 +509,6 @@ pub fn bso_from_row(mut row: Vec<Value>) -> Result<results::GetBso> {
     })
 }
 
-#[cfg(not(any(test, feature = "db_test")))]
 pub fn bso_to_insert_row(
     user_id: &HawkIdentifier,
     collection_id: i32,
@@ -538,7 +536,6 @@ pub fn bso_to_insert_row(
     Ok(row)
 }
 
-#[cfg(not(any(test, feature = "db_test")))]
 pub fn bso_to_update_row(
     user_id: &HawkIdentifier,
     collection_id: i32,


### PR DESCRIPTION
## Description

Convert database bso calls to async await


-    delete_bso
-    delete_bsos
-    get_bsos
-    get_bso_ids
-    get_bso
-    get_bso_timestamp
-    put_bso
-    post_bsos
- touch_collection
- bsos_query_sync
- create_collection
- get_or_create_collection_id

## Testing

All tests should pass. (Integration tests may currently fail, but we'll fix this up after all the db async await work has landed. One more pr for that after this one.)

## Issue(s)

Closes #433.
