### PR TITLE
fix: Fix #459 db-tests on master

### DIFF
--- a/src/db/spanner/models.rs
+++ b/src/db/spanner/models.rs
@@ -1855,15 +1855,34 @@ impl Db for SpannerDb {
         Box::pin(async move { db.get_bso_timestamp_async(param).map_err(Into::into).await })
     }
 
+    #[cfg(not(any(test, feature = "db_test")))]
     fn put_bso(&self, param: params::PutBso) -> DbFuture<results::PutBso> {
         let db = self.clone();
         Box::pin(async move { db.put_bso_async(param).map_err(Into::into).await })
     }
 
+    #[cfg(any(test, feature = "db_test"))]
+    fn put_bso(&self, param: params::PutBso) -> DbFuture<results::PutBso> {
+        let db = self.clone();
+        Box::pin(block(move || {
+            db.put_bso_sync(param).map_err(Into::into)
+        }).map_err(Into::into))
+    }
+
+    #[cfg(not(any(test, feature = "db_test")))]
     fn post_bsos(&self, param: params::PostBsos) -> DbFuture<results::PostBsos> {
         let db = self.clone();
         Box::pin(async move { db.post_bsos_async(param).map_err(Into::into).await })
     }
+
+    #[cfg(any(test, feature = "db_test"))]
+    fn post_bsos(&self, param: params::PostBsos) -> DbFuture<results::PostBsos> {
+        let db = self.clone();
+        Box::pin(block(move || {
+            db.post_bsos_sync(param).map_err(Into::into)
+        }).map_err(Into::into))
+    }
+
 
     fn validate_batch_id(&self, id: String) -> Result<()> {
         batch::validate_batch_id(&id)

--- a/src/db/spanner/models.rs
+++ b/src/db/spanner/models.rs
@@ -1864,9 +1864,7 @@ impl Db for SpannerDb {
     #[cfg(any(test, feature = "db_test"))]
     fn put_bso(&self, param: params::PutBso) -> DbFuture<results::PutBso> {
         let db = self.clone();
-        Box::pin(block(move || {
-            db.put_bso_sync(param).map_err(Into::into)
-        }).map_err(Into::into))
+        Box::pin(block(move || db.put_bso_sync(param).map_err(Into::into)).map_err(Into::into))
     }
 
     #[cfg(not(any(test, feature = "db_test")))]
@@ -1878,11 +1876,8 @@ impl Db for SpannerDb {
     #[cfg(any(test, feature = "db_test"))]
     fn post_bsos(&self, param: params::PostBsos) -> DbFuture<results::PostBsos> {
         let db = self.clone();
-        Box::pin(block(move || {
-            db.post_bsos_sync(param).map_err(Into::into)
-        }).map_err(Into::into))
+        Box::pin(block(move || db.post_bsos_sync(param).map_err(Into::into)).map_err(Into::into))
     }
-
 
     fn validate_batch_id(&self, id: String) -> Result<()> {
         batch::validate_batch_id(&id)


### PR DESCRIPTION
## Description

The db tests became broken by a recent async await commit because there was a special, db-tests only function that didn't get converted to async. This uses the old synchronous implementation when running in db-tests.

## Testing

All tests should pass against spanner.

## Issue(s)

Closes #459.
