### PR TITLE
fix: Fix #444 invalid offset code that was lost in the actix 2 upgrad…

### DIFF
--- a/src/web/extractors.rs
+++ b/src/web/extractors.rs
@@ -1329,7 +1329,8 @@ impl FromRequest for BsoQueryParams {
                 )
             })?;
             if params.sort != Sorting::Index {
-                if let Some(timestamp) = params.offset.as_ref().and_then(|offset| offset.timestamp) {
+                if let Some(timestamp) = params.offset.as_ref().and_then(|offset| offset.timestamp)
+                {
                     let bound = timestamp.as_i64();
                     if let Some(newer) = params.newer {
                         if bound < newer.as_i64() {

--- a/src/web/extractors.rs
+++ b/src/web/extractors.rs
@@ -1328,6 +1328,32 @@ impl FromRequest for BsoQueryParams {
                     Some(tags.clone()),
                 )
             })?;
+            if params.sort != Sorting::Index {
+                if let Some(timestamp) = params.offset.as_ref().and_then(|offset| offset.timestamp) {
+                    let bound = timestamp.as_i64();
+                    if let Some(newer) = params.newer {
+                        if bound < newer.as_i64() {
+                            return Err(ValidationErrorKind::FromDetails(
+                                format!("Invalid Offset {} {}", bound, newer.as_i64()),
+                                RequestErrorLocation::QueryString,
+                                Some("newer".to_owned()),
+                                None,
+                            )
+                            .into());
+                        }
+                    } else if let Some(older) = params.older {
+                        if bound > older.as_i64() {
+                            return Err(ValidationErrorKind::FromDetails(
+                                "Invalid Offset".to_owned(),
+                                RequestErrorLocation::QueryString,
+                                Some("older".to_owned()),
+                                None,
+                            )
+                            .into());
+                        }
+                    }
+                }
+            }
             Ok(params)
         })
     }


### PR DESCRIPTION
…e due to a bad merge

## Description

During the actix web 2 upgrade, some invalid offset code was lost due to a bad merge. This simply adds it back in.

## Testing

All tests should pass.

## Issue(s)

Closes #444.
