### PR TITLE
fix: GETs with a limit and no sort never advance X-Weave-Next-Offset

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -237,31 +237,6 @@ jobs:
               echo "Not pushing to dockerhub for tag=${CIRCLE_TAG} branch=${CIRCLE_BRANCH}"
             fi
 
-  rust-changelog:
-    docker:
-      - image: python:3.7-buster
-    steps:
-      - setup_remote_docker:
-          version: 18.02.0-ce
-      - run:
-          name: Install Docker client
-          command: |
-            set -x
-            VER="18.06.3-ce"
-            curl -L -o /tmp/docker-$VER.tgz https://download.docker.com/linux/static/stable/x86_64/docker-$VER.tgz
-            tar -xz -C /tmp -f /tmp/docker-$VER.tgz
-            mv /tmp/docker/* /usr/bin
-      - run:
-          name: pull find-package-rugaru image
-          command: |
-            docker pull mozilla/dependencyscan:latest
-      - run:
-          name: Check Rust Dependencies
-          command: |
-            printf "{\"org\": \"mozilla-services\", \"repo\": \"syncstorage-rs\", \"ref\": {\"value\": \"master\", \"kind\": \"branch\"}, \"repo_url\": \"https://github.com/mozilla-services/syncstorage-rs.git\"}\n{\"org\": \"mozilla-services\", \"repo\": \"syncstorage-rs\", \"ref\": {\"value\": \"$CIRCLE_SHA1\", \"kind\": \"commit\"}, \"repo_url\": \"https://github.com/mozilla-services/syncstorage-rs.git\"}\n"  | \
-                docker run --rm -i -v /var/run/docker.sock:/var/run/docker.sock --name fpr-cargo_metadata mozilla/dependencyscan:latest python fpr/run_pipeline.py cargo_metadata | \
-                docker run --rm -i -v /var/run/docker.sock:/var/run/docker.sock --name fpr-rust_changelog mozilla/dependencyscan:latest python fpr/run_pipeline.py rust_changelog -m Cargo.toml
-
 workflows:
   version: 2
   build-deploy:
@@ -277,11 +252,6 @@ workflows:
       - e2e-tests:
           requires:
             - build-and-test
-          filters:
-            tags:
-              only: /.*/
-      - rust-changelog:
-        # email dependency-observatory@mozilla.com with feedback
           filters:
             tags:
               only: /.*/

--- a/src/db/mysql/models.rs
+++ b/src/db/mysql/models.rs
@@ -484,10 +484,9 @@ impl MysqlDb {
         }
 
         query = match sort {
-            Sorting::Index => query.order(bso::sortindex.desc()),
-            Sorting::Newest => query.order(bso::modified.desc()),
-            Sorting::Oldest => query.order(bso::modified.asc()),
-            _ => query,
+            Sorting::Index => query.order(bso::id.desc()).order(bso::sortindex.desc()),
+            Sorting::Newest => query.order(bso::id.desc()).order(bso::modified.desc()),
+            Sorting::Oldest | Sorting::None => query.order(bso::id.asc()).order(bso::modified.asc()),
         };
 
         let limit = limit.map(i64::from).unwrap_or(-1);

--- a/src/db/mysql/models.rs
+++ b/src/db/mysql/models.rs
@@ -485,7 +485,9 @@ impl MysqlDb {
 
         query = match sort {
             Sorting::Index => query.order(bso::id.desc()).order(bso::sortindex.desc()),
-            Sorting::Newest | Sorting::None => query.order(bso::id.desc()).order(bso::modified.desc()),
+            Sorting::Newest | Sorting::None => {
+                query.order(bso::id.desc()).order(bso::modified.desc())
+            }
             Sorting::Oldest => query.order(bso::id.asc()).order(bso::modified.asc()),
         };
 

--- a/src/db/mysql/models.rs
+++ b/src/db/mysql/models.rs
@@ -485,8 +485,8 @@ impl MysqlDb {
 
         query = match sort {
             Sorting::Index => query.order(bso::id.desc()).order(bso::sortindex.desc()),
-            Sorting::Newest => query.order(bso::id.desc()).order(bso::modified.desc()),
-            Sorting::Oldest | Sorting::None => query.order(bso::id.asc()).order(bso::modified.asc()),
+            Sorting::Newest | Sorting::None => query.order(bso::id.desc()).order(bso::modified.desc()),
+            Sorting::Oldest => query.order(bso::id.asc()).order(bso::modified.asc()),
         };
 
         let limit = limit.map(i64::from).unwrap_or(-1);

--- a/src/db/spanner/models.rs
+++ b/src/db/spanner/models.rs
@@ -976,7 +976,9 @@ impl SpannerDb {
         }
         query = match sort {
             Sorting::Index => format!("{} ORDER BY sortindex DESC, bso_id DESC", query),
-            Sorting::Newest | Sorting::None => format!("{} ORDER BY modified DESC, bso_id DESC", query),
+            Sorting::Newest | Sorting::None => {
+                format!("{} ORDER BY modified DESC, bso_id DESC", query)
+            }
             Sorting::Oldest => format!("{} ORDER BY modified ASC, bso_id ASC", query),
         };
 

--- a/src/db/spanner/models.rs
+++ b/src/db/spanner/models.rs
@@ -975,10 +975,9 @@ impl SpannerDb {
             sqltypes.insert("newer".to_string(), as_type(TypeCode::TIMESTAMP));
         }
         query = match sort {
-            Sorting::Index => format!("{} ORDER BY sortindex DESC", query),
-            Sorting::Newest => format!("{} ORDER BY modified DESC", query),
-            Sorting::Oldest => format!("{} ORDER BY modified ASC", query),
-            _ => query,
+            Sorting::Index => format!("{} ORDER BY sortindex DESC, bso_id DESC", query),
+            Sorting::Newest => format!("{} ORDER BY modified DESC, bso_id DESC", query),
+            Sorting::Oldest | Sorting::None => format!("{} ORDER BY modified ASC, bso_id ASC", query),
         };
 
         if let Some(limit) = limit {

--- a/src/db/spanner/models.rs
+++ b/src/db/spanner/models.rs
@@ -976,8 +976,8 @@ impl SpannerDb {
         }
         query = match sort {
             Sorting::Index => format!("{} ORDER BY sortindex DESC, bso_id DESC", query),
-            Sorting::Newest => format!("{} ORDER BY modified DESC, bso_id DESC", query),
-            Sorting::Oldest | Sorting::None => format!("{} ORDER BY modified ASC, bso_id ASC", query),
+            Sorting::Newest | Sorting::None => format!("{} ORDER BY modified DESC, bso_id DESC", query),
+            Sorting::Oldest => format!("{} ORDER BY modified ASC, bso_id ASC", query),
         };
 
         if let Some(limit) = limit {


### PR DESCRIPTION
## Description

When the client does not pass a sort argument, the python server defaults to sort by oldest. The rust server defaults to sort by nothing, causing bug #468.

## Testing

The STR in the bug should show that X-Weave-Next-Offset when fetching collections with more than 1000 elements. (lina should probably test it)

## Issue(s)

Closes #468.
