### PR TITLE
chore: add minumum supported rust version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ authors = [
   "Phil Jenvey <pjenvey@underboss.org>",
 ]
 edition = "2018"
+rust = "1.39.0"
 
 [profile.release]
 # Enables line numbers in Sentry


### PR DESCRIPTION
## Description

To help us avoid future issues with folks using the wrong rust version, I'm adding [this field](https://github.com/rust-lang/rfcs/pull/2495) into our cargo.toml.

## Testing

Well...the main thing to review is: did I get the version right? :) I picked 1.39.0 given that I at least know for sure that we're depending on async/await which was introduced then. Anything that rolled into Rust stable afterwards we're requiring?

## Issue(s)

Closes [#424](https://github.com/mozilla-services/syncstorage-rs/issues/424).
