### PR TITLE
fix: relax MAX_TTL to 9 digits

### DIFF
--- a/src/web/extractors.rs
+++ b/src/web/extractors.rs
@@ -39,7 +39,7 @@ use crate::web::{
 const BATCH_MAX_IDS: usize = 100;
 
 // BSO const restrictions
-const BSO_MAX_TTL: u32 = 31_536_000;
+const BSO_MAX_TTL: u32 = 999_999_999;
 const BSO_MAX_SORTINDEX_VALUE: i32 = 999_999_999;
 const BSO_MIN_SORTINDEX_VALUE: i32 = -999_999_999;
 
@@ -2278,5 +2278,20 @@ mod tests {
         assert_eq!(err["errors"][0]["location"], "path");
         assert_eq!(err["errors"][0]["name"], "uid");
         */
+    }
+
+    #[test]
+    fn test_max_ttl() {
+        let bso_body = json!([
+            {"id": "123", "payload": "xxx", "sortindex": 23, "ttl": 94_608_000},
+            {"id": "456", "payload": "xxxasdf", "sortindex": 23, "ttl": 999_999_999},
+            {"id": "789", "payload": "xxxfoo", "sortindex": 23, "ttl": 1_000_000_000}
+        ]);
+        let result = post_collection("", &bso_body).unwrap();
+        assert_eq!(result.user_id.legacy_id, *USER_ID);
+        assert_eq!(&result.collection, "tabs");
+        assert_eq!(result.bsos.valid.len(), 2);
+        assert_eq!(result.bsos.invalid.len(), 1);
+        assert!(result.bsos.invalid.contains_key("789"));
     }
 }


### PR DESCRIPTION
## Description

fix: relax MAX_TTL to 9 digits

The forms collection defaults to a 3 year TTL which we currently reject. This puts us in line with the Sync 1.5 spec's full 9 digits.

Merging this into the 0.2 release branch so we cut a 0.2.5 and ship this out ASAP w/ the 0.2.4 fix.

## Testing

new test_max_ttl unit test or test using forms.

## Issue(s)

Closes #480
