### PR TITLE
fix: revert unsupported config change

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ authors = [
   "Phil Jenvey <pjenvey@underboss.org>",
 ]
 edition = "2018"
-rust = "1.39.0"
 
 [profile.release]
 # Enables line numbers in Sentry


### PR DESCRIPTION
## Description

This reverts [a PR](https://github.com/mozilla-services/syncstorage-rs/pull/475/commits/9740221aea93f4872e6369522aa55f0a93c3742a) that added a config change that it looks like was never actually implemented in Rust. 

Looks like I was so excited to find the config value I was hoping for, I missed the fact that what was merged was [an rfc](https://github.com/rust-lang/rfcs/pull/2495) not actual [support for it](https://github.com/rust-lang/rust/issues/65262). 

## Testing

1. `make run` against master. See this warning `warning: unused manifest key: package.rust`
2. `make run` in this branch. Verify no more warning.

## Issue(s)

References #424
