### PR TITLE
fix: Convert erect_tombstone to async/await

### DIFF
--- a/src/db/mysql/models.rs
+++ b/src/db/mysql/models.rs
@@ -379,7 +379,7 @@ impl MysqlDb {
         let timestamp = self.timestamp().as_i64();
 
         self.conn.transaction(|| {
-            let payload = bso.payload.as_ref().map(Deref::deref).unwrap_or_default();
+            let payload = bso.payload.as_deref().unwrap_or_default();
             let sortindex = bso.sortindex;
             let ttl = bso.ttl.map_or(DEFAULT_BSO_TTL, |ttl| ttl);
             let q = format!(r#"


### PR DESCRIPTION
## Description

Convert erect_tombstone to async/await, nd in the process, remove all the spanner synchronous support code. The spanner backend is now truly 100% sync code free.

## Testing

All tests should pass.

## Issue(s)

Closes #463.
