### PR TITLE
Build images when PRs are merged to master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -189,7 +189,7 @@ jobs:
           name: Deploy to Dockerhub
           command: |
             if [ "${CIRCLE_BRANCH}" == "master" ]; then
-              DOCKER_TAG="latest"
+              DOCKER_TAG="${CIRCLE_SHA1}"
             fi
 
             if echo "${CIRCLE_BRANCH}" | grep '^feature\..*' > /dev/null; then


### PR DESCRIPTION
## Description

Presumably, master only changes with a PR merge.  This circleci config change causes circle to build an image for every commit on master, it makes the docker tag equal to the git commit sha1.  The downstream automation will then deploy to the development environment when the docker tag looks like a commit sha1 (matches the regex `/[0-9a-f]{40}/`).

I think the `if echo "${CIRCLE_BRANCH}" | grep '^feature\..*' > /dev/null; the` block is not used and can be deleted.

When a release is tagged, the following block will cause the docker tag to match the git tag.  The downstream automation will deploy tags that don't match the sha1 type regex to stage:
```
            if [ -n "${CIRCLE_TAG}" ]; then
              DOCKER_TAG="$CIRCLE_TAG"
            fi
```

## Testing

Merge to master and see if our deployment is triggered.

## Issue(s)

Related to [Create sync dev environment](https://bugzilla.mozilla.org/show_bug.cgi?id=1622286).
