### PR TITLE
feat: Add KV trait for Tags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ serde_json = { version = "1.0", features = ["arbitrary_precision"] }
 serde_urlencoded = "0.6.1"
 scheduled-thread-pool = "0.2"
 sha2 = "0.8.0"
-slog = { version = "2.5", features = ["max_level_trace", "release_max_level_error"] }
+slog = { version = "2.5", features = ["max_level_trace", "release_max_level_error", "dynamic-keys"] }
 slog-async = "2.3"
 slog-envlogger = "2.2.0"
 slog-mozlog-json = "0.1"

--- a/src/web/tags.rs
+++ b/src/web/tags.rs
@@ -12,7 +12,7 @@ use serde::{
     Serialize,
 };
 use serde_json::value::Value;
-use slog::{Key, KV, Record};
+use slog::{Key, Record, KV};
 
 use crate::server::user_agent::parse_user_agent;
 

--- a/src/web/tags.rs
+++ b/src/web/tags.rs
@@ -12,6 +12,7 @@ use serde::{
     Serialize,
 };
 use serde_json::value::Value;
+use slog::{Key, KV, Record};
 
 use crate::server::user_agent::parse_user_agent;
 
@@ -139,5 +140,14 @@ impl Into<BTreeMap<String, String>> for Tags {
         }
 
         result
+    }
+}
+
+impl KV for Tags {
+    fn serialize(&self, _rec: &Record<'_>, serializer: &mut dyn slog::Serializer) -> slog::Result {
+        for (key, val) in &self.tags {
+            serializer.emit_str(Key::from(key.clone()), &val)?;
+        }
+        Ok(())
     }
 }


### PR DESCRIPTION
## Description

Add `KV` trait for `Tags` struct to simplify logging its content.

## Testing

For example, in `extractors.rs` instead of 
```rust
warn!("⚠️ Missing BSO: {:?}", uri.path();
            "ua.os.family" => tags.get("ua.os.family"),
            "ua.browser.family" => tags.get("ua.browser.family"),
            "ua.name" => tags.get("ua.name"),
            "ua.os.ver" => tags.get("ua.os.ver"),
            "ua.browser.ver" => tags.get("ua.browser.ver"));
```
this snippet can be used:
```rust
warn!("⚠️ Unexpected BSO URI: {:?}", uri.path(); tags);
```

## Issue(s)

Closes #387 .
