### PR TITLE
refactor: Refactor Tags logging by utilising KV trait

### DIFF
--- a/src/web/extractors.rs
+++ b/src/web/extractors.rs
@@ -451,12 +451,7 @@ impl BsoParam {
         let elements: Vec<&str> = uri.path().split('/').collect();
         let elem = elements.get(3);
         if elem.is_none() || elem != Some(&"storage") || elements.len() != 6 {
-            warn!("⚠️ Unexpected BSO URI: {:?}", uri.path();
-            "ua.os.family" => tags.get("ua.os.family"),
-            "ua.browser.family" => tags.get("ua.browser.family"),
-            "ua.name" => tags.get("ua.name"),
-            "ua.os.ver" => tags.get("ua.os.ver"),
-            "ua.browser.ver" => tags.get("ua.browser.ver"));
+            warn!("⚠️ Unexpected BSO URI: {:?}", uri.path(); tags);
             return Err(ValidationErrorKind::FromDetails(
                 "Invalid BSO".to_owned(),
                 RequestErrorLocation::Path,
@@ -466,12 +461,7 @@ impl BsoParam {
         }
         if let Some(v) = elements.get(5) {
             let sv = String::from_str(v).map_err(|_| {
-                warn!("⚠️ Invalid BsoParam Error: {:?}", v;
-                "ua.os.family" => tags.get("ua.os.family"),
-                "ua.browser.family" => tags.get("ua.browser.family"),
-                "ua.name" => tags.get("ua.name"),
-                "ua.os.ver" => tags.get("ua.os.ver"),
-                "ua.browser.ver" => tags.get("ua.browser.ver"));
+                warn!("⚠️ Invalid BsoParam Error: {:?}", v; tags);
                 ValidationErrorKind::FromDetails(
                     "Invalid BSO".to_owned(),
                     RequestErrorLocation::Path,
@@ -481,12 +471,7 @@ impl BsoParam {
             })?;
             Ok(Self { bso: sv })
         } else {
-            warn!("⚠️ Missing BSO: {:?}", uri.path();
-            "ua.os.family" => tags.get("ua.os.family"),
-            "ua.browser.family" => tags.get("ua.browser.family"),
-            "ua.name" => tags.get("ua.name"),
-            "ua.os.ver" => tags.get("ua.os.ver"),
-            "ua.browser.ver" => tags.get("ua.browser.ver"));
+            warn!("⚠️ Missing BSO: {:?}", uri.path(); tags);
             Err(ValidationErrorKind::FromDetails(
                 "Missing BSO".to_owned(),
                 RequestErrorLocation::Path,

--- a/src/web/handlers.rs
+++ b/src/web/handlers.rs
@@ -450,16 +450,12 @@ pub fn test_error(
     // generate an error for sentry.
 
     /*  The various error log macros only can take a string.
-        Additional values can be expressed as KV (key value) after a `;`
+        Content of Tags struct can be logged as KV (key value) pairs after a `;`.
         e.g.
         ```
-        error!("Something Bad {:?}", err;
-                "ua.os.family" => wtags.get("ua.os.family"),
-                "ua.browser.family" => wtags.get("ua.browser.family"),
-                "ua.name" => wtags.get("ua.name"),
-                "ua.os.ver" => wtags.get("ua.os.ver"),
-                "ua.browser.ver" => wtags.get("ua.browser.ver"))
+        error!("Something Bad {:?}", err; wtags)
         ```
+
         TODO: find some way to transform Tags into error::KV
     */
     error!("Test Error: {:?}", &ter.tags);


### PR DESCRIPTION
## Description

Refactor how `Tags` content is logged. Due to KV trait being implemented for this struct, it can be passed to `slog` as is without need to log each of its key/value individually. See example in #493 `Testing` section.

## Testing

Nothing should change in log messages, except `uri.method` tag being added.

## Issue(s)

Closes #503 .
