### PR TITLE
fix: allow hostnames for STATSD_HOST

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,9 @@ RUN \
     cargo --version && \
     rustc --version && \
     cargo install --path . --locked --root /app && \
-    cargo install --path tools/spanner/purge_ttl --locked --root /app
+    cargo install --path tools/spanner/purge_ttl --locked --root /app && \
+    cd tools/spanner/purge_ttl && \
+    cargo clean
 
 FROM debian:buster-slim
 WORKDIR /app

--- a/tools/spanner/purge_ttl/src/main.rs
+++ b/tools/spanner/purge_ttl/src/main.rs
@@ -1,6 +1,6 @@
 use std::env;
 use std::error::Error;
-use std::net::{IpAddr, UdpSocket};
+use std::net::UdpSocket;
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -15,6 +15,8 @@ use googleapis_raw::spanner::v1::{
 };
 use grpcio::{CallOption, ChannelBuilder, ChannelCredentials, EnvBuilder, MetadataBuilder};
 use log::{info, trace, warn};
+
+const SPANNER_ADDRESS: &str = "spanner.googleapis.com:443";
 
 pub struct MetricTimer {
     pub client: StatsdClient,
@@ -46,9 +48,7 @@ pub fn start_timer(client: &StatsdClient, label: &str) -> MetricTimer {
 }
 
 pub fn statsd_from_env() -> Result<StatsdClient, Box<dyn Error>> {
-    let statsd_host = env::var("STATSD_HOST")
-        .unwrap_or_else(|_| "127.0.0.1".to_string())
-        .parse::<IpAddr>()?;
+    let statsd_host = env::var("STATSD_HOST").unwrap_or_else(|_| "127.0.0.1".to_string());
     let statsd_port = match env::var("STATSD_PORT") {
         Ok(port) => port.parse::<u16>()?,
         Err(_) => DEFAULT_PORT,
@@ -56,7 +56,7 @@ pub fn statsd_from_env() -> Result<StatsdClient, Box<dyn Error>> {
 
     let socket = UdpSocket::bind("0.0.0.0:0")?;
     socket.set_nonblocking(true)?;
-    let host = (statsd_host, statsd_port);
+    let host = (statsd_host.as_str(), statsd_port);
     let udp_sink = BufferedUdpMetricSink::from(host, socket)?;
     let sink = QueuingMetricSink::from(udp_sink);
     let builder = StatsdClient::builder("syncstorage", sink);
@@ -94,15 +94,14 @@ fn prepare_request(
 fn main() -> Result<(), Box<dyn Error>> {
     env_logger::try_init()?;
 
-    let url = env::var("SYNC_DATABASE_URL")?;
+    const DB_ENV: &str = "SYNC_DATABASE_URL";
+    let url = env::var(DB_ENV).map_err(|_| format!("Invalid or undefined {}", DB_ENV))?;
     if !url.starts_with("spanner://") {
-        return Err("Invalid SYNC_DAYABASE_URL".into());
+        return Err(format!("Invalid {}", DB_ENV).into());
     }
 
     let database = url["spanner://".len()..].to_owned();
     info!("For {}", database);
-
-    let endpoint = "spanner.googleapis.com:443";
 
     // Set up the gRPC environment.
     let env = Arc::new(EnvBuilder::new().build());
@@ -112,7 +111,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let chan = ChannelBuilder::new(env)
         .max_send_message_len(100 << 20)
         .max_receive_message_len(100 << 20)
-        .secure_connect(&endpoint, creds);
+        .secure_connect(SPANNER_ADDRESS, creds);
     let client = SpannerClient::new(chan);
 
     // Create a session


### PR DESCRIPTION
## Description

and improve the missing db env error message

also don't package purge_ttl's target/ into the docker

(merging into the 0.2b release branch)

## Testing

run w/ e.g. STATSD_HOST=localhost

## Issue(s)

Closes #548
