### PR TITLE
cherry-pick fix: relax MAX_TTL to 9 digits

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -237,31 +237,6 @@ jobs:
               echo "Not pushing to dockerhub for tag=${CIRCLE_TAG} branch=${CIRCLE_BRANCH}"
             fi
 
-  rust-changelog:
-    docker:
-      - image: python:3.7-buster
-    steps:
-      - setup_remote_docker:
-          version: 18.02.0-ce
-      - run:
-          name: Install Docker client
-          command: |
-            set -x
-            VER="18.06.3-ce"
-            curl -L -o /tmp/docker-$VER.tgz https://download.docker.com/linux/static/stable/x86_64/docker-$VER.tgz
-            tar -xz -C /tmp -f /tmp/docker-$VER.tgz
-            mv /tmp/docker/* /usr/bin
-      - run:
-          name: pull find-package-rugaru image
-          command: |
-            docker pull mozilla/dependencyscan:latest
-      - run:
-          name: Check Rust Dependencies
-          command: |
-            printf "{\"org\": \"mozilla-services\", \"repo\": \"syncstorage-rs\", \"ref\": {\"value\": \"master\", \"kind\": \"branch\"}, \"repo_url\": \"https://github.com/mozilla-services/syncstorage-rs.git\"}\n{\"org\": \"mozilla-services\", \"repo\": \"syncstorage-rs\", \"ref\": {\"value\": \"$CIRCLE_SHA1\", \"kind\": \"commit\"}, \"repo_url\": \"https://github.com/mozilla-services/syncstorage-rs.git\"}\n"  | \
-                docker run --rm -i -v /var/run/docker.sock:/var/run/docker.sock --name fpr-cargo_metadata mozilla/dependencyscan:latest python fpr/run_pipeline.py cargo_metadata | \
-                docker run --rm -i -v /var/run/docker.sock:/var/run/docker.sock --name fpr-rust_changelog mozilla/dependencyscan:latest python fpr/run_pipeline.py rust_changelog -m Cargo.toml
-
 workflows:
   version: 2
   build-deploy:
@@ -277,11 +252,6 @@ workflows:
       - e2e-tests:
           requires:
             - build-and-test
-          filters:
-            tags:
-              only: /.*/
-      - rust-changelog:
-        # email dependency-observatory@mozilla.com with feedback
           filters:
             tags:
               only: /.*/

--- a/src/db/mysql/models.rs
+++ b/src/db/mysql/models.rs
@@ -384,7 +384,7 @@ impl MysqlDb {
         let timestamp = self.timestamp().as_i64();
 
         self.conn.transaction(|| {
-            let payload = bso.payload.as_ref().map(Deref::deref).unwrap_or_default();
+            let payload = bso.payload.as_deref().unwrap_or_default();
             let sortindex = bso.sortindex;
             let ttl = bso.ttl.map_or(DEFAULT_BSO_TTL, |ttl| ttl);
             let q = format!(r#"

--- a/src/web/extractors.rs
+++ b/src/web/extractors.rs
@@ -39,7 +39,7 @@ use crate::web::{
 const BATCH_MAX_IDS: usize = 100;
 
 // BSO const restrictions
-const BSO_MAX_TTL: u32 = 31_536_000;
+const BSO_MAX_TTL: u32 = 999_999_999;
 const BSO_MAX_SORTINDEX_VALUE: i32 = 999_999_999;
 const BSO_MIN_SORTINDEX_VALUE: i32 = -999_999_999;
 
@@ -2211,5 +2211,20 @@ mod tests {
         assert_eq!(err["errors"][0]["location"], "path");
         assert_eq!(err["errors"][0]["name"], "uid");
         */
+    }
+
+    #[test]
+    fn test_max_ttl() {
+        let bso_body = json!([
+            {"id": "123", "payload": "xxx", "sortindex": 23, "ttl": 94_608_000},
+            {"id": "456", "payload": "xxxasdf", "sortindex": 23, "ttl": 999_999_999},
+            {"id": "789", "payload": "xxxfoo", "sortindex": 23, "ttl": 1_000_000_000}
+        ]);
+        let result = post_collection("", &bso_body).unwrap();
+        assert_eq!(result.user_id.legacy_id, *USER_ID);
+        assert_eq!(&result.collection, "tabs");
+        assert_eq!(result.bsos.valid.len(), 2);
+        assert_eq!(result.bsos.invalid.len(), 1);
+        assert!(result.bsos.invalid.contains_key("789"));
     }
 }


### PR DESCRIPTION
## Description

Cherry-pick the MAX_TTL fix into 0.2.1 (and ba481089 + acadfc80 for ci). We'll tag/deploy this as a 0.2.1.1 to be on the safe side, then deploy the GET collection ordering fix separately.

## Testing

test_max_ttl unit test

## Issue(s)

Closes #480
