### PR TITLE
refactor: use u64 instead of i64 for Offset.offset

### DIFF
--- a/src/db/mysql/models.rs
+++ b/src/db/mysql/models.rs
@@ -503,7 +503,7 @@ impl MysqlDb {
         // match the query conditions
         query = query.limit(if limit >= 0 { limit + 1 } else { limit });
 
-        let numeric_offset = offset.map_or(0, |offset| offset.offset);
+        let numeric_offset = offset.map_or(0, |offset| offset.offset as i64);
 
         if numeric_offset != 0 {
             // XXX: copy over this optimization:
@@ -573,7 +573,7 @@ impl MysqlDb {
         // match the query conditions
         query = query.limit(if limit >= 0 { limit + 1 } else { limit });
 
-        let numeric_offset = offset.map_or(0, |offset| offset.offset);
+        let numeric_offset = offset.map_or(0, |offset| offset.offset as i64);
         if numeric_offset != 0 {
             // XXX: copy over this optimization:
             // https://github.com/mozilla-services/server-syncstorage/blob/a0f8117/syncstorage/storage/sql/__init__.py#L404

--- a/src/db/spanner/models.rs
+++ b/src/db/spanner/models.rs
@@ -1091,7 +1091,11 @@ impl SpannerDb {
             // most databases) so we specify a max value with offset subtracted
             // to avoid overflow errors (that only occur w/ a FORCE_INDEX=
             // directive) OutOfRange: 400 int64 overflow: <INT64_MAX> + offset
-            query = format!("{} LIMIT {}", query, i64::max_value() - offset.offset);
+            query = format!(
+                "{} LIMIT {}",
+                query,
+                i64::max_value() - offset.offset as i64
+            );
         };
 
         if let Some(offset) = offset {
@@ -1106,7 +1110,7 @@ impl SpannerDb {
     pub fn encode_next_offset(
         &self,
         _sort: Sorting,
-        offset: i64,
+        offset: u64,
         _timestamp: Option<i64>,
         modifieds: Vec<i64>,
     ) -> Option<String> {
@@ -1115,7 +1119,7 @@ impl SpannerDb {
         // always equals limit
         Some(
             Offset {
-                offset: offset + modifieds.len() as i64,
+                offset: offset + modifieds.len() as u64,
                 timestamp: None,
             }
             .to_string(),
@@ -1129,7 +1133,7 @@ impl SpannerDb {
                 // Use a simple numeric offset for sortindex ordering.
                 return Some(
                     Offset {
-                        offset: offset + modifieds.len() as i64,
+                        offset: offset + modifieds.len() as u64,
                         timestamp: None,
                     }
                     .to_string(),

--- a/src/web/extractors.rs
+++ b/src/web/extractors.rs
@@ -1212,7 +1212,7 @@ impl FromRequest for Box<dyn Db> {
 #[serde(default)]
 pub struct Offset {
     pub timestamp: Option<SyncTimestamp>,
-    pub offset: i64,
+    pub offset: u64,
 }
 
 impl ToString for Offset {
@@ -1231,19 +1231,19 @@ impl FromStr for Offset {
         // previously (it was u64 previously but i64's close enough)
         let result = Offset {
             timestamp: None,
-            offset: s.parse::<i64>()?,
+            offset: s.parse::<u64>()?,
         };
         /*
         let result = match s.chars().position(|c| c == ':') {
             None => Offset {
                 timestamp: None,
-                offset: s.parse::<i64>()?,
+                offset: s.parse::<u64>()?,
             },
             Some(_colon_position) => {
                 let mut parts = s.split(':');
                 let timestamp_string = parts.next().unwrap_or("0");
                 let timestamp = SyncTimestamp::from_milliseconds(timestamp_string.parse::<u64>()?);
-                let offset = parts.next().unwrap_or("0").parse::<i64>()?;
+                let offset = parts.next().unwrap_or("0").parse::<u64>()?;
                 Offset {
                     timestamp: Some(timestamp),
                     offset,


### PR DESCRIPTION
## Description

Change struct Offset to use u64 offset instead of i64.

## Testing

?

## Issue(s)

Closes #414
