### PR TITLE
feat: revert the GET collection sort order (c95f2ff)

### DIFF
--- a/src/db/mysql/models.rs
+++ b/src/db/mysql/models.rs
@@ -484,11 +484,18 @@ impl MysqlDb {
         }
 
         query = match sort {
+            // issue559: Revert to previous sorting
+            /*
             Sorting::Index => query.order(bso::id.desc()).order(bso::sortindex.desc()),
             Sorting::Newest | Sorting::None => {
                 query.order(bso::id.desc()).order(bso::modified.desc())
             }
             Sorting::Oldest => query.order(bso::id.asc()).order(bso::modified.asc()),
+            */
+            Sorting::Index => query.order(bso::sortindex.desc()),
+            Sorting::Newest => query.order(bso::modified.desc()),
+            Sorting::Oldest => query.order(bso::modified.asc()),
+            _ => query,
         };
 
         let limit = limit.map(i64::from).unwrap_or(-1);

--- a/src/db/spanner/models.rs
+++ b/src/db/spanner/models.rs
@@ -949,6 +949,8 @@ impl SpannerDb {
             sqlparams.insert("ids".to_owned(), as_list_value(ids.into_iter()));
         }
 
+        // issue559: Dead code (timestamp always None)
+        /*
         if let Some(timestamp) = offset.clone().unwrap_or_default().timestamp {
             query = match sort {
                 Sorting::Newest => {
@@ -964,6 +966,7 @@ impl SpannerDb {
                 _ => query,
             };
         }
+        */
         if let Some(older) = older {
             query = format!("{} AND modified < @older", query);
             sqlparams.insert("older".to_string(), as_value(older.as_rfc3339()?));
@@ -975,11 +978,18 @@ impl SpannerDb {
             sqltypes.insert("newer".to_string(), as_type(TypeCode::TIMESTAMP));
         }
         query = match sort {
+            // issue559: Revert to previous sorting
+            /*
             Sorting::Index => format!("{} ORDER BY sortindex DESC, bso_id DESC", query),
             Sorting::Newest | Sorting::None => {
                 format!("{} ORDER BY modified DESC, bso_id DESC", query)
             }
             Sorting::Oldest => format!("{} ORDER BY modified ASC, bso_id ASC", query),
+            */
+            Sorting::Index => format!("{} ORDER BY sortindex DESC", query),
+            Sorting::Newest => format!("{} ORDER BY modified DESC", query),
+            Sorting::Oldest => format!("{} ORDER BY modified ASC", query),
+            _ => query,
         };
 
         if let Some(limit) = limit {
@@ -1006,11 +1016,22 @@ impl SpannerDb {
 
     pub fn encode_next_offset(
         &self,
-        sort: Sorting,
+        _sort: Sorting,
         offset: i64,
-        timestamp: Option<i64>,
+        _timestamp: Option<i64>,
         modifieds: Vec<i64>,
     ) -> Option<String> {
+        // issue559: Use a simple numeric offset everwhere as previously for
+        // now: was previously a value of "limit + offset", modifieds.len()
+        // always equals limit
+        Some(
+            Offset {
+                offset: offset + modifieds.len() as i64,
+                timestamp: None,
+            }
+            .to_string(),
+        )
+        /*
         let mut calc_offset = 1;
         let mut i = (modifieds.len() as i64) - 2;
 
@@ -1043,6 +1064,7 @@ impl SpannerDb {
         }
 
         Some(format!("{}:{}", bound, calc_offset))
+        */
     }
 
     pub fn get_bsos_sync(&self, params: params::GetBsos) -> Result<results::GetBsos> {

--- a/src/web/extractors.rs
+++ b/src/web/extractors.rs
@@ -1217,6 +1217,13 @@ impl ToString for Offset {
 impl FromStr for Offset {
     type Err = ParseIntError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // issue559: Disable ':' support for now: simply parse as i64 as
+        // previously (it was u64 previously but i64's close enough)
+        let result = Offset {
+            timestamp: None,
+            offset: s.parse::<i64>()?,
+        };
+        /*
         let result = match s.chars().position(|c| c == ':') {
             None => Offset {
                 timestamp: None,
@@ -1233,6 +1240,7 @@ impl FromStr for Offset {
                 }
             }
         };
+        */
         Ok(result)
     }
 }
@@ -1299,6 +1307,8 @@ impl FromRequest for BsoQueryParams {
                 Some(tags.clone()),
             )
         })?;
+        // issue559: Dead code (timestamp always None)
+        /*
         if params.sort != Sorting::Index {
             if let Some(timestamp) = params.offset.as_ref().and_then(|offset| offset.timestamp) {
                 let bound = timestamp.as_i64();
@@ -1325,6 +1335,7 @@ impl FromRequest for BsoQueryParams {
                 }
             }
         }
+        */
         Ok(params)
     }
 }


### PR DESCRIPTION
## Description

and disable encoded offsets (which rely on the sort order) for now

(only for the 0.2 branch)

Sorry for another round of review to get this out, I decided to go forward on top of the 0.2.8 release (release/0.2b branch) vs the older 0.2.1 tag.

## Testing

All tests, including e2e, pass

## Issue(s)

Closes #559
