### PR TITLE
Commit a skeleton for the tokenserver.

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -6,7 +6,7 @@ use crate::db::{pool_from_settings, DbPool};
 use crate::error::ApiError;
 use crate::server::metrics::Metrics;
 use crate::settings::{Secrets, ServerLimits, Settings};
-use crate::web::{handlers, middleware};
+use crate::web::{handlers, middleware, tokenserver};
 use actix_cors::Cors;
 use actix_web::{
     dev, http::StatusCode, middleware::errhandlers::ErrorHandlers, web, App, HttpRequest,
@@ -119,6 +119,10 @@ macro_rules! build_app {
                     .route(web::delete().to(handlers::delete_bso))
                     .route(web::get().to(handlers::get_bso))
                     .route(web::put().to(handlers::put_bso)),
+            )
+            // Tokenserver
+            .service(
+                web::resource(&cfg_path("/1.0/sync/1.5")).route(web::get().to(tokenserver::get)),
             )
             // Dockerflow
             // Remember to update .::web::middleware::DOCKER_FLOW_ENDPOINTS

--- a/src/web/extractors.rs
+++ b/src/web/extractors.rs
@@ -1747,6 +1747,23 @@ where
     Ok(None)
 }
 
+// Tokenserver extractor
+#[derive(Debug, Default, Clone, Deserialize)]
+pub struct TokenServerRequest {
+    // TODO extract required headers from the request into this struct.
+}
+
+impl FromRequest for TokenServerRequest {
+    type Config = ();
+    type Error = Error;
+    type Future = LocalBoxFuture<'static, Result<Self, Self::Error>>;
+
+    /// Extract and validate the precondition headers
+    fn from_request(_req: &HttpRequest, _payload: &mut Payload) -> Self::Future {
+        Box::pin(async move { Ok(Self {}) })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use actix_http::h1;

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -5,6 +5,7 @@ pub mod extractors;
 pub mod handlers;
 pub mod middleware;
 pub mod tags;
+pub mod tokenserver;
 
 // header statics must be lower case, numbers and symbols per the RFC spec. This reduces chance of error.
 pub static X_LAST_MODIFIED: &str = "x-last-modified";

--- a/src/web/tokenserver.rs
+++ b/src/web/tokenserver.rs
@@ -1,0 +1,26 @@
+use actix_web::error::BlockingError;
+use actix_web::web::block;
+use actix_web::HttpResponse;
+
+use futures::future::{Future, TryFutureExt};
+
+use crate::error::ApiError;
+use crate::web::extractors::TokenServerRequest;
+
+pub struct TokenServerResult {}
+
+pub fn get(
+    request: TokenServerRequest,
+) -> impl Future<Output = Result<HttpResponse, BlockingError<ApiError>>> {
+    block(move || get_sync(request).map_err(Into::into)).map_ok(move |_result| {
+        // TODO turn _result into a json response.
+        HttpResponse::Ok()
+            .content_type("application/json")
+            .body("{}")
+    })
+}
+
+pub fn get_sync(_request: TokenServerRequest) -> Result<TokenServerResult, ApiError> {
+    // TODO Perform any blocking calls needed to respond to the tokenserver request.
+    Ok(TokenServerResult {})
+}


### PR DESCRIPTION


## Description

This includes a route for GET /1.0/sync/1.5, an extractor for it, and an async handler as well as a blocking handler in case blocking libraries need to be used.

## Testing

Tests should pass.

## Issue(s)

This closes an issue in another repository, https://github.com/mozilla-services/tokenserver-rs/issues/8
