### PR TITLE
bug: add build_essential package to Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM rust:1.40.0-buster as builder
 WORKDIR /app
 ADD . /app
 ENV PATH=$PATH:/root/.cargo/bin
+# temp removed --no-install-recommends due to CI docker build issue
 RUN apt-get -q update && \
     apt-get -q install -y --no-install-recommends default-libmysqlclient-dev cmake golang-go && \
     rm -rf /var/lib/apt/lists/* && \
@@ -22,7 +23,9 @@ RUN \
     groupadd --gid 10001 app && \
     useradd --uid 10001 --gid 10001 --home /app --create-home app && \
     apt-get -q update && \
-    apt-get -q install -y --no-install-recommends default-libmysqlclient-dev libssl-dev ca-certificates libcurl4 python3-venv python3-pip && \
+    apt-get -q install -y \
+    build-essential \
+    default-libmysqlclient-dev libssl-dev ca-certificates libcurl4 python3-venv python3-pip && \
     python3 -m pip install setuptools wheel && \
     python3 -m pip install google-cloud-spanner statsd && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Description

Due to a change in the root image we use, the `build_essential` package was not installed. This prevented several additional modules from loading because they could not compile subcomponents.

## Testing

CircleCI tes

## Issue(s)

Closes #572