### PR TITLE
refactor: Remove python dependency from the dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,11 +23,7 @@ RUN \
     groupadd --gid 10001 app && \
     useradd --uid 10001 --gid 10001 --home /app --create-home app && \
     apt-get -q update && \
-    apt-get -q install -y \
-    build-essential \
-    default-libmysqlclient-dev libssl-dev ca-certificates libcurl4 python3-venv python3-pip && \
-    python3 -m pip install setuptools wheel && \
-    python3 -m pip install google-cloud-spanner statsd && \
+    apt-get -q install -y build-essential default-libmysqlclient-dev libssl-dev ca-certificates libcurl4 && \
     rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /app/bin /app/bin


### PR DESCRIPTION
## Description

Now that purge_ttl has been ported to rust, we may remove the python dependency from the dockerfile.

## Testing

Tests should pass.

## Issue(s)

Fixes #567
