### PR TITLE
feat: reject firefox-ios < 20 w/ a 503

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.40.0-buster as builder
+FROM rust:1.42.0-buster as builder
 WORKDIR /app
 ADD . /app
 ENV PATH=$PATH:/root/.cargo/bin

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -66,6 +66,7 @@ macro_rules! build_app {
             .wrap(middleware::db::DbTransaction::new())
             .wrap(middleware::weave::WeaveTimestamp::new())
             .wrap(middleware::sentry::SentryWrapper::new())
+            .wrap(middleware::rejectua::RejectUA::default())
             // Followed by the "official middleware" so they run first.
             .wrap(Cors::default())
             .service(

--- a/src/web/middleware/mod.rs
+++ b/src/web/middleware/mod.rs
@@ -1,5 +1,6 @@
 pub mod db;
 pub mod precondition;
+pub mod rejectua;
 pub mod sentry;
 pub mod weave;
 

--- a/src/web/middleware/rejectua.rs
+++ b/src/web/middleware/rejectua.rs
@@ -1,0 +1,118 @@
+#![allow(clippy::type_complexity)]
+use std::task::{Context, Poll};
+
+use actix_web::{
+    dev::{Service, ServiceRequest, ServiceResponse, Transform},
+    http::header::USER_AGENT,
+    Error, HttpResponse,
+};
+use futures::future::{self, Either, Ready};
+use lazy_static::lazy_static;
+use regex::Regex;
+
+use crate::server::{metrics::Metrics, ServerState};
+
+lazy_static! {
+    // e.g. "Firefox-iOS-Sync/18.0b1 (iPhone; iPhone OS 13.2.2) (Fennec (synctesting))"
+    // https://github.com/mozilla-mobile/firefox-ios/blob/v19.x/Shared/UserAgent.swift#L12
+    static ref IOS_UA_REGEX: Regex = Regex::new(
+        r"(?x)
+^
+Firefox-iOS-Sync/
+(?P<major>[0-9]+)\.[.0-9]+    # <appVersion-major>.<appVersion-minor-etc>
+b.*                           # b<buildNumber>
+\s\(.+                        #  (<deviceModel>
+;\siPhone\sOS                 # ; iPhone OS
+\s.+\)                        #  <systemVersion>)
+\s\(.*\)                      #  (<displayName>)
+$
+"
+    )
+    .unwrap();
+}
+
+#[derive(Debug, Default)]
+pub struct RejectUA;
+
+impl<S, B> Transform<S> for RejectUA
+where
+    S: Service<Request = ServiceRequest, Response = ServiceResponse<B>, Error = Error>,
+    S::Future: 'static,
+    B: 'static,
+{
+    type Request = ServiceRequest;
+    type Response = ServiceResponse<B>;
+    type Error = Error;
+    type InitError = ();
+    type Transform = RejectUAMiddleware<S>;
+    type Future = Ready<Result<Self::Transform, Self::InitError>>;
+
+    fn new_transform(&self, service: S) -> Self::Future {
+        future::ok(RejectUAMiddleware { service })
+    }
+}
+
+pub struct RejectUAMiddleware<S> {
+    service: S,
+}
+
+impl<S, B> Service for RejectUAMiddleware<S>
+where
+    S: Service<Request = ServiceRequest, Response = ServiceResponse<B>, Error = Error>,
+    S::Future: 'static,
+    B: 'static,
+{
+    type Request = ServiceRequest;
+    type Response = ServiceResponse<B>;
+    type Error = Error;
+    type Future = Either<Ready<Result<Self::Response, Self::Error>>, S::Future>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.service.poll_ready(cx)
+    }
+
+    fn call(&mut self, sreq: ServiceRequest) -> Self::Future {
+        match sreq.headers().get(USER_AGENT) {
+            Some(header) if header.to_str().map_or(false, should_reject) => {
+                let state = match &sreq.app_data::<ServerState>() {
+                    Some(v) => v.clone(),
+                    None => {
+                        return Either::Left(future::ok(
+                            sreq.into_response(
+                                HttpResponse::InternalServerError()
+                                    .body("Err: No State".to_owned())
+                                    .into_body(),
+                            ),
+                        ))
+                    }
+                };
+                debug!("Rejecting User-Agent: {:?}", header);
+                Metrics::from(&state).incr("error.rejectua");
+
+                Either::Left(future::ok(
+                    sreq.into_response(
+                        HttpResponse::ServiceUnavailable()
+                            .body("0".to_owned())
+                            .into_body(),
+                    ),
+                ))
+            }
+            _ => Either::Right(self.service.call(sreq)),
+        }
+    }
+}
+
+/// Determine if a User-Agent should be rejected w/ an error response.
+///
+/// firefox-ios < v20 suffers from a bug where our response headers
+/// can cause it to crash. They're sent an error response instead that
+/// avoids the crash.
+/// https://github.com/mozilla-services/syncstorage-rs/issues/293
+fn should_reject(ua: &str) -> bool {
+    let major = IOS_UA_REGEX
+        .captures(ua)
+        .and_then(|captures| captures.name("major"))
+        .and_then(|major| major.as_str().parse::<u32>().ok())
+        .unwrap_or(20);
+    major < 20
+}


### PR DESCRIPTION
## Description

to prevent them from triggering a bug that crashes them

and update Dockerfile builder to latest rust

## Testing

- New ios unit tests pass
- firefox-ios doesn't crash

Testing against a local syncstorage, firefox-ios in the simulator crashes without this change, log:

```
2020-04-07 11:55:35.803 [Debug] [ClientsSynchronizer.swift:195] processCommandsFromRecord(_:withServer:) > Processing commands from downloaded record.
2020-04-07 11:55:35.803 [Debug] [ClientsSynchronizer.swift:279] maybeUploadOurRecord(_:ifUnmodifiedSince:toServer:) > Should we upload our client record? Caller = false, expired = false.
2020-04-07 11:55:35.804 [Debug] [ClientsSynchronizer.swift:353] applyStorageResponse(_:toLocalClients:withServer:notifier:) > Running 0 commands.
Fatal error: Unexpectedly found nil while unwrapping an Optional value: file /Users/pjenvey/src/moz/firefox-ios/Sync/Synchronizers/ClientsSynchronizer.swift, line 357
```

Against this change, firefox-ios reports this in its log:

```
2020-04-07 16:41:27.274 [Info] [Profile.swift:1121] syncWith(synchronizers:statsSession:why:) > Syncing ["clients", "tabs", "bookmarks", "history", "logins"]
2020-04-07 16:41:27.279 [Debug] [SyncAuthState.swift:97] token(_:canBeExpired:) > Fetching token server token FROM https://token.services.mozilla.com/1.0/sync/1.5
2020-04-07 16:41:27.322 [Debug] [SyncAuthState.swift:105] token(_:canBeExpired:) > Fetching token server token.
2020-04-07 16:41:27.328 [Debug] [SyncAuthState.swift:113] token(_:canBeExpired:) > Fetched token server token!  Token expires at 1586303187274.
2020-04-07 16:41:27.328 [Info] [KeychainCache.swift:56] checkpoint() > Storing rustAccounts.syncAuthState in Keychain with label rustAccounts.syncAuthState.993FB800-0704-403C-99BF-A3819CFAF487.
2020-04-07 16:41:27.332 [Debug] [SyncStateMachine.swift:148] toReady(_:) > Got token from auth state.
2020-04-07 16:41:27.335 [Debug] [State.swift:467] unpickleV1FromPrefs(_:syncKeyBundle:) > Read keys from Keychain with label 2KZw0gQc32kq.
2020-04-07 16:41:27.336 [Info] [SyncStateMachine.swift:188] toReady(_:) > Advancing to InitialWithLiveToken.
2020-04-07 16:41:27.336 [Info] [SyncStateMachine.swift:329] init(scratchpad:token:) > Inited initialWithLiveToken
2020-04-07 16:41:27.336 [Info] [SyncStateMachine.swift:122] advanceFromState(_:) > advanceFromState: InitialWithLiveToken
2020-04-07 16:41:27.343 [Debug] [StorageClient.swift:392] failFromResponse(_:) > Status code: 503.
2020-04-07 16:41:27.344 [Debug] [StorageClient.swift:397] failFromResponse(_:) > ServerError.
2020-04-07 16:41:27.344 [Info] [Profile.swift:645] endSyncing(_:) > Ending all queued syncs.
2020-04-07 16:41:27.396 [Debug] [SyncAuthState.swift:97] token(_:canBeExpired:) > Fetching token server token FROM https://token.services.mozilla.com/1.0/sync/1.5
2020-04-07 16:41:27.401 [Debug] [SyncAuthState.swift:105] token(_:canBeExpired:) > Fetching token server token.
2020-04-07 16:41:27.407 [Debug] [SyncAuthState.swift:113] token(_:canBeExpired:) > Fetched token server token!  Token expires at 1586303187344.
2020-04-07 16:41:27.407 [Info] [KeychainCache.swift:56] checkpoint() > Storing rustAccounts.syncAuthState in Keychain with label rustAccounts.syncAuthState.993FB800-0704-403C-99BF-A3819CFAF487.
2020-04-07 16:41:27.415 [Debug] [State.swift:467] unpickleV1FromPrefs(_:syncKeyBundle:) > Read keys from Keychain with label 2KZw0gQc32kq.
2020-04-07 16:41:27.416 [Debug] [SyncTelemetry.swift:51] send(ping:docType:) > Ping URL: https://incoming.telemetry.mozilla.org/submit/telemetry/402F9410-2AE0-4C97-B530-E4F9332B4496/sync/Fennec/23.1/developer/1
2020-04-07 16:41:27.416 [Debug] [SyncTelemetry.swift:52] send(ping:docType:) > Ping payload: {"why":"schedule","uid":"7d6e1d77d0bf839f1052419a6c8066c2","os":{"name":"iOS","locale":"en_US","version":"13.4"},"events":[],"version":1,"deviceID":"3df6853a44dd9e93d0d76b2271351dbd63a035a08d01acdb45777280ec3a84d4","syncs":[{}]}
2020-04-07 16:41:27.493 [Debug] [SyncTelemetry.swift:82] send(ping:docType:) > Ping response: 200.
```

It fails to sync but doesn't crash. Nothing's indicated to the user. It then retries after 15 minutes.

## Issue(s)

Closes #293
