### PR TITLE
chore: default-run syncstorage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ authors = [
   "Mozilla Services Engineering <services-engineering+code@mozilla.com>"
 ]
 edition = "2018"
+default-run = "syncstorage"
 
 [profile.release]
 # Enables line numbers in Sentry


### PR DESCRIPTION
## Description

Followup to #583 otherwise:

``
error: `cargo run` could not determine which binary to run. Use the `--bin` option to specify a binary, or the `default-run` manifest key.
available binaries: purge_ttl, syncstorage
``

## Testing

cargo run
