### PR TITLE
Fix purge ttl timeout

### DIFF
--- a/src/bin/purge_ttl.rs
+++ b/src/bin/purge_ttl.rs
@@ -167,7 +167,7 @@ fn delete_incremental(
     chunk_size: u64,
     max_to_delete: u64,
 ) -> Result<(), Box<dyn Error>> {
-    let mut total: usize = 1;
+    let mut total: u64 = 1;
     let (mut req, mut txn) = begin_transaction(&client, &session, RequestType::ReadWrite)?;
     loop {
         let select_sql = format!("SELECT fxa_uid, fxa_kid, collection_id, {} FROM {} WHERE expiry < CURRENT_TIMESTAMP() LIMIT {}", column, table, chunk_size);

--- a/src/bin/purge_ttl.rs
+++ b/src/bin/purge_ttl.rs
@@ -7,17 +7,27 @@ use std::time::Instant;
 use cadence::{
     BufferedUdpMetricSink, Metric, QueuingMetricSink, StatsdClient, Timed, DEFAULT_PORT,
 };
-use env_logger;
+
 use googleapis_raw::spanner::v1::{
-    spanner::{BeginTransactionRequest, CreateSessionRequest, ExecuteSqlRequest, Session},
+    spanner::{
+        BeginTransactionRequest, CommitRequest, CreateSessionRequest, ExecuteSqlRequest, Session,
+    },
     spanner_grpc::SpannerClient,
-    transaction::{TransactionOptions, TransactionOptions_PartitionedDml, TransactionSelector},
+    transaction::{
+        TransactionOptions, TransactionOptions_PartitionedDml, TransactionOptions_ReadOnly,
+        TransactionOptions_ReadWrite, TransactionSelector,
+    },
 };
 use grpcio::{CallOption, ChannelBuilder, ChannelCredentials, EnvBuilder, MetadataBuilder};
 use log::{info, trace, warn};
 use url::{Host, Url};
 
 const SPANNER_ADDRESS: &str = "spanner.googleapis.com:443";
+
+type ResultSet = googleapis_raw::spanner::v1::result_set::ResultSet;
+type ResultSetStats = googleapis_raw::spanner::v1::result_set::ResultSetStats;
+
+use protobuf::well_known_types::Value;
 
 pub struct MetricTimer {
     pub client: StatsdClient,
@@ -69,31 +79,193 @@ pub fn statsd_from_env() -> Result<StatsdClient, Box<dyn Error>> {
         .build())
 }
 
+pub enum RequestType {
+    ReadOnly,
+    ReadWrite,
+    PartitionedDml,
+}
+
 fn prepare_request(
     client: &SpannerClient,
     session: &Session,
-) -> Result<ExecuteSqlRequest, Box<dyn Error>> {
-    // Create a transaction
-    let mut opt = TransactionOptions::new();
-    opt.set_partitioned_dml(TransactionOptions_PartitionedDml::new());
-    let mut req = BeginTransactionRequest::new();
-    req.set_session(session.get_name().to_owned());
-    req.set_options(opt);
-    let mut txn = client.begin_transaction(&req)?;
+    request_type: RequestType,
+    transaction_id: Option<Vec<u8>>,
+) -> Result<(ExecuteSqlRequest, Vec<u8>), Box<dyn Error>> {
+    let id = match transaction_id {
+        Some(id) => id,
+        None => {
+            // Create a transaction
+            let mut opt = TransactionOptions::new();
+            match request_type {
+                RequestType::ReadWrite => {
+                    opt.set_read_write(TransactionOptions_ReadWrite::new());
+                }
+                RequestType::ReadOnly => {
+                    opt.set_read_only(TransactionOptions_ReadOnly::new());
+                }
+                RequestType::PartitionedDml => {
+                    opt.set_partitioned_dml(TransactionOptions_PartitionedDml::new())
+                }
+            }
 
+            let mut req = BeginTransactionRequest::new();
+            req.set_session(session.get_name().to_owned());
+            req.set_options(opt);
+            let mut txn = client.begin_transaction(&req)?;
+
+            txn.take_id()
+        }
+    };
     let mut ts = TransactionSelector::new();
-    ts.set_id(txn.take_id());
+    ts.set_id(id.clone());
 
     // Create an SQL request
     let mut req = ExecuteSqlRequest::new();
     req.set_session(session.get_name().to_string());
     req.set_transaction(ts);
 
-    Ok(req)
+    Ok((req, id))
+}
+
+fn commit_request(
+    client: &SpannerClient,
+    session: &Session,
+    txn: Vec<u8>,
+) -> Result<(), Box<dyn Error>> {
+    let mut req = CommitRequest::new();
+    req.set_session(session.get_name().to_owned());
+    req.set_transaction_id(txn);
+    client.commit(&req)?;
+    Ok(())
+}
+
+pub struct SyncResultSet {
+    result: ResultSet,
+}
+
+impl SyncResultSet {
+    pub fn stats(&self) -> Option<&ResultSetStats> {
+        self.result.stats.as_ref()
+    }
+}
+
+impl Iterator for SyncResultSet {
+    type Item = Vec<Value>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let rows = &mut self.result.rows;
+        if rows.is_empty() {
+            None
+        } else {
+            let row = rows.remove(0);
+            Some(row.get_values().to_vec())
+        }
+    }
+}
+
+fn delete_incremental(
+    client: &SpannerClient,
+    session: &Session,
+    table: String,
+    column: String,
+    chunk_size: u64,
+) -> Result<(), Box<dyn Error>> {
+    let (mut req, mut txn) = prepare_request(&client, &session, RequestType::ReadWrite, None)?;
+    let select_sql = format!("SELECT fxa_uid, fxa_kid, collection_id, {} FROM {} WHERE expiry < CURRENT_TIMESTAMP() LIMIT {}", column, table, chunk_size);
+    trace!("Selecting rows to delete: {}", select_sql);
+    req.set_sql(select_sql.clone());
+    let mut result = SyncResultSet {
+        result: client.execute_sql(&req)?,
+    };
+
+    let mut total: usize = 1;
+    while total < 1_000_000 {
+        if result.result.rows.is_empty() {
+            info!("{}: done", table);
+            break;
+        }
+        let mut delete_sql = format!(
+            "DELETE FROM {} WHERE (fxa_uid, fxa_kid, collection_id, {}) IN (",
+            table, column,
+        );
+        for row in &mut result {
+            // Count starting at 1 so that i % chunk_size is false when on the first row
+            let fxa_uid = row[0].get_string_value().to_owned();
+            let fxa_kid = row[1].get_string_value().to_owned();
+            let collection_id = row[2].get_string_value().parse::<i32>().unwrap();
+            let id = row[3].get_string_value().to_owned();
+            trace!(
+                "Selected row for delete: i={} collection_id={} fxa_kid={} fxa_uid={} {}={}",
+                total,
+                collection_id,
+                fxa_kid,
+                fxa_uid,
+                column,
+                id
+            );
+            delete_sql = format!(
+                "{}('{}', '{}', {}, '{}'), ",
+                delete_sql, fxa_uid, fxa_kid, collection_id, id
+            );
+
+            total += 1;
+        }
+        delete_sql = format!("{}('', '', 0, ''))", delete_sql);
+        trace!("Deleting chunk with: {}", delete_sql);
+        let (mut delete_req, _txn2) =
+            prepare_request(&client, &session, RequestType::ReadWrite, Some(txn.clone()))?;
+        delete_req.set_sql(delete_sql);
+        client.execute_sql(&delete_req)?;
+        info!("{}: removed {} rows", table, total);
+        commit_request(&client, &session, txn)?;
+
+        let (newreq, newtxn) = prepare_request(&client, &session, RequestType::ReadWrite, None)?;
+        req = newreq;
+        txn = newtxn;
+
+        req.set_sql(select_sql.clone());
+        result = SyncResultSet {
+            result: client.execute_sql(&req)?,
+        };
+    }
+
+    info!("{}: removed {} rows in total.", table, total);
+    commit_request(&client, &session, txn)?;
+    Ok(())
+}
+
+fn delete_all(
+    client: &SpannerClient,
+    session: &Session,
+    table: String,
+) -> Result<(), Box<dyn Error>> {
+    let (mut req, _txn) = prepare_request(client, session, RequestType::PartitionedDml, None)?;
+    req.set_sql(format!(
+        "DELETE FROM {} WHERE expiry < CURRENT_TIMESTAMP()",
+        table
+    ));
+    let result = client.execute_sql(&req)?;
+    info!(
+        "{}: removed {} rows",
+        table,
+        result.get_stats().get_row_count_lower_bound()
+    );
+    Ok(())
 }
 
 fn main() -> Result<(), Box<dyn Error>> {
     env_logger::try_init()?;
+
+    let chunk_size: u64 = env::var("PURGE_TTL_BATCH_SIZE")
+        .unwrap_or_else(|_| "1000".to_string())
+        .parse()
+        .unwrap();
+
+    const INCREMENTAL_ENV: &str = "SYNC_INCREMENTAL";
+    let incremental = env::var(INCREMENTAL_ENV)
+        .map(|x| x == "1" || x == "true")
+        .unwrap_or(false);
+    info!("INCREMENTAL: {:?}", incremental);
 
     const DB_ENV: &str = "SYNC_DATABASE_URL";
     let db_url = env::var(DB_ENV).map_err(|_| format!("Invalid or undefined {}", DB_ENV))?;
@@ -131,23 +303,33 @@ fn main() -> Result<(), Box<dyn Error>> {
         let _timer_total = start_timer(&statsd, "purge_ttl.total_duration");
         {
             let _timer_batches = start_timer(&statsd, "purge_ttl.batches_duration");
-            let mut req = prepare_request(&client, &session)?;
-            req.set_sql("DELETE FROM batches WHERE expiry < CURRENT_TIMESTAMP()".to_string());
-            let result = client.execute_sql(&req)?;
-            info!(
-                "batches: removed {} rows",
-                result.get_stats().get_row_count_lower_bound()
-            )
+
+            if incremental {
+                delete_incremental(
+                    &client,
+                    &session,
+                    "batches".to_owned(),
+                    "batch_id".to_owned(),
+                    chunk_size,
+                )?;
+            } else {
+                delete_all(&client, &session, "batches".to_owned())?;
+            }
         }
         {
             let _timer_bso = start_timer(&statsd, "purge_ttl.bso_duration");
-            let mut req = prepare_request(&client, &session)?;
-            req.set_sql("DELETE FROM bsos WHERE expiry < CURRENT_TIMESTAMP()".to_string());
-            let result = client.execute_sql(&req)?;
-            info!(
-                "bso: removed {} rows",
-                result.get_stats().get_row_count_lower_bound()
-            )
+
+            if incremental {
+                delete_incremental(
+                    &client,
+                    &session,
+                    "bsos".to_owned(),
+                    "bso_id".to_owned(),
+                    chunk_size,
+                )?;
+            } else {
+                delete_all(&client, &session, "bsos".to_owned())?;
+            }
         }
         info!("Completed purge_ttl")
     }

--- a/src/bin/purge_ttl.rs
+++ b/src/bin/purge_ttl.rs
@@ -167,7 +167,7 @@ fn delete_incremental(
     chunk_size: u64,
     max_to_delete: u64,
 ) -> Result<(), Box<dyn Error>> {
-    let mut total: u64 = 1;
+    let mut total: u64 = 0;
     let (mut req, mut txn) = begin_transaction(&client, &session, RequestType::ReadWrite)?;
     loop {
         let select_sql = format!("SELECT fxa_uid, fxa_kid, collection_id, {} FROM {} WHERE expiry < CURRENT_TIMESTAMP() LIMIT {}", column, table, chunk_size);
@@ -177,7 +177,7 @@ fn delete_incremental(
             result: client.execute_sql(&req)?,
         };
 
-        if result.result.rows.is_empty() || total > max_to_delete {
+        if result.result.rows.is_empty() || total >= max_to_delete {
             info!("{}: done", table);
             break;
         }

--- a/src/bin/purge_ttl.rs
+++ b/src/bin/purge_ttl.rs
@@ -206,7 +206,7 @@ fn delete_incremental(
 
             total += 1;
         }
-        delete_sql = delete_sql.trim_end_matches(&", ".to_string()).to_string();
+        delete_sql = format!("{})", delete_sql.trim_end_matches(&", ".to_string()).to_string());
         trace!("Deleting chunk with: {}", delete_sql);
         let mut delete_req = continue_transaction(&session, txn.clone())?;
         delete_req.set_sql(delete_sql);

--- a/src/bin/purge_ttl.rs
+++ b/src/bin/purge_ttl.rs
@@ -176,7 +176,7 @@ fn delete_incremental(
         let mut result = SyncResultSet {
             result: client.execute_sql(&req)?,
         };
-    
+
         if result.result.rows.is_empty() || total > max_to_delete {
             info!("{}: done", table);
             break;
@@ -207,7 +207,10 @@ fn delete_incremental(
 
             total += 1;
         }
-        delete_sql = format!("{})", delete_sql.trim_end_matches(&", ".to_string()).to_string());
+        delete_sql = format!(
+            "{})",
+            delete_sql.trim_end_matches(&", ".to_string()).to_string()
+        );
         trace!("Deleting chunk with: {}", delete_sql);
         let mut delete_req = continue_transaction(&session, txn.clone())?;
         delete_req.set_sql(delete_sql);

--- a/src/bin/purge_ttl.rs
+++ b/src/bin/purge_ttl.rs
@@ -24,9 +24,6 @@ use url::{Host, Url};
 
 const SPANNER_ADDRESS: &str = "spanner.googleapis.com:443";
 
-type ResultSet = googleapis_raw::spanner::v1::result_set::ResultSet;
-type ResultSetStats = googleapis_raw::spanner::v1::result_set::ResultSetStats;
-
 use protobuf::well_known_types::Value;
 
 pub struct MetricTimer {
@@ -145,13 +142,7 @@ fn commit_transaction(
 }
 
 pub struct SyncResultSet {
-    result: ResultSet,
-}
-
-impl SyncResultSet {
-    pub fn stats(&self) -> Option<&ResultSetStats> {
-        self.result.stats.as_ref()
-    }
+    result: googleapis_raw::spanner::v1::result_set::ResultSet,
 }
 
 impl Iterator for SyncResultSet {

--- a/src/db/error.rs
+++ b/src/db/error.rs
@@ -1,8 +1,6 @@
 use std::fmt;
 
 use actix_web::http::StatusCode;
-use diesel;
-use diesel_migrations;
 use failure::{Backtrace, Context, Fail};
 
 #[derive(Debug)]

--- a/src/db/mysql/batch.rs
+++ b/src/db/mysql/batch.rs
@@ -6,7 +6,6 @@ use diesel::{
     sql_types::Integer,
     update, ExpressionMethods, OptionalExtension, QueryDsl, RunQueryDsl, TextExpressionMethods,
 };
-use serde_json;
 
 use super::{
     models::{MysqlDb, Result},
@@ -184,5 +183,5 @@ macro_rules! batch_db_method {
         pub fn $name(&self, params: params::$type) -> Result<results::$type> {
             batch::$batch_name(self, params)
         }
-    }
+    };
 }

--- a/src/db/mysql/models.rs
+++ b/src/db/mysql/models.rs
@@ -895,9 +895,7 @@ macro_rules! sync_db_method {
     ($name:ident, $sync_name:ident, $type:ident, $result:ty) => {
         fn $name(&self, params: params::$type) -> DbFuture<$result> {
             let db = self.clone();
-            Box::pin(block(move || {
-                db.$sync_name(params).map_err(Into::into)
-            }).map_err(Into::into))
+            Box::pin(block(move || db.$sync_name(params).map_err(Into::into)).map_err(Into::into))
         }
     };
 }

--- a/src/db/mysql/test.rs
+++ b/src/db/mysql/test.rs
@@ -6,7 +6,7 @@ use diesel::{
     r2d2::{CustomizeConnection, Error as PoolError},
     Connection, ExpressionMethods, QueryDsl, RunQueryDsl,
 };
-use env_logger;
+
 use url::Url;
 
 use crate::db::mysql::{

--- a/src/db/tests/support.rs
+++ b/src/db/tests/support.rs
@@ -1,7 +1,5 @@
 use std::str::FromStr;
 
-use env_logger;
-
 use crate::{
     db::{params, pool_from_settings, util::SyncTimestamp, Db, Sorting},
     error::ApiError,

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -4,11 +4,7 @@ use crate::error::{ApiErrorKind, ApiResult};
 
 use mozsvc_common::{aws::get_ec2_instance_id, get_hostname};
 use slog::{self, slog_o, Drain};
-use slog_async;
 use slog_mozlog_json::MozLogJson;
-use slog_scope;
-use slog_stdlog;
-use slog_term;
 
 pub fn init_logging(json: bool) -> ApiResult<()> {
     let logger = if json {

--- a/src/server/test.rs
+++ b/src/server/test.rs
@@ -5,7 +5,6 @@ use actix_web::{
     http::{self, HeaderName, HeaderValue, StatusCode},
     test,
 };
-use base64;
 use bytes::Bytes;
 use chrono::offset::Utc;
 use futures::executor::block_on;
@@ -15,7 +14,6 @@ use hkdf::Hkdf;
 use hmac::{Hmac, Mac};
 use lazy_static::lazy_static;
 use serde::de::DeserializeOwned;
-use serde_json;
 use serde_json::json;
 use sha2::Sha256;
 use std::str::FromStr;

--- a/src/web/auth.rs
+++ b/src/web/auth.rs
@@ -8,13 +8,11 @@
 
 use std::convert::TryInto;
 
-use base64;
 use chrono::offset::Utc;
 use hawk::{self, Header as HawkHeader, Key, RequestBuilder};
 use hkdf::Hkdf;
 use hmac::{Hmac, Mac};
 use serde::{Deserialize, Serialize};
-use serde_json;
 use sha2::Sha256;
 use time::Duration;
 

--- a/src/web/error.rs
+++ b/src/web/error.rs
@@ -13,7 +13,6 @@ use serde::{
     Serialize,
 };
 use serde_json::{Error as JsonError, Value};
-use validator;
 
 use super::extractors::RequestErrorLocation;
 use super::tags::Tags;

--- a/src/web/extractors.rs
+++ b/src/web/extractors.rs
@@ -1778,7 +1778,6 @@ mod tests {
         test::{self, TestRequest},
         Error, HttpResponse,
     };
-    use base64;
     use hawk::{Credentials, Key, RequestBuilder};
     use hmac::{Hmac, Mac};
     use rand::{thread_rng, Rng};


### PR DESCRIPTION
## Description

This code attempts to fix the purge_ttl timeout by grabbing all the ids to delete and chunking them up into batches of 1000.

## Testing

For testing this, build it with:

`cargo install --path . --bin purge_ttl --locked --root output`

Then run it with:

`RUST_LOG=info GOOGLE_APPLICATION_CREDENTIALS=... SYNC_DATABASE_URL=... output/bin/purge_ttl`

You will need an appropriate credentials file and database url to a spanner database. First of all, it should be able to run and not have any errors deleting 0 items.

Then, if some records are added to the bsos and batches tables, with expired expires timestamps, running it should print info about how many records were deleted. Examining spanner should show that they were actually deleted.

To add records to the tables, I modified the load tester to have a 100% chance of doing a PUT, then ran it for 1000 iterations. I also modified the load tester to pass a ttl of 1, meaning the records expire in 1 second. Here is the patch against the load tester:

```
diff --git a/loadtest.py b/loadtest.py
index 867b579..dbbd143 100644
--- a/loadtest.py
+++ b/loadtest.py
@@ -20,7 +20,7 @@ _WEIGHTS = {'metaglobal': [40, 60, 0, 0, 0],
             'post_count_distribution': [67, 18, 9, 4, 2],
             'delete_count_distribution': [99, 1, 0, 0, 0]}
 
-_PROBS = {'get': .1, 'post': .2, 'deleteall': 0.01}
+_PROBS = {'get': 0, 'post': 1, 'deleteall': 0}
 _COLLS = ['bookmarks', 'forms', 'passwords', 'history', 'prefs']
 _BATCH_MAX_COUNT = 100
 
@@ -103,7 +103,7 @@ async def test(session):
     if should_do('post'):
         cid = str(get_num_requests('distribution'))
         url = "/storage/clients"
-        wbo = {'id': 'client' + cid, 'payload': cid * 300}
+        wbo = {'id': 'client' + cid, 'payload': cid * 300, 'ttl': 1}
         data = json.dumps([wbo])
         resp, result = await storage.post(url, data=data, statuses=(200,))
         assert len(result["success"]) == 1, "No success records"
@@ -153,7 +153,7 @@ async def test(session):
             token = storage.auth_token.decode('utf8')
             payload_chunks = int((payload_length / len(token)) + 1)
             payload = (token * payload_chunks)[:payload_length]
-            wbo = {'id': id, 'payload': payload}
+            wbo = {'id': id, 'payload': payload, 'ttl': 1}
             data.append(wbo)
 
         data = json.dumps(data)

```

By default, the purge_ttl script deletes everything. If instead you want to use the incremental delete, necessary in cases where the normal delete takes too long and is killed, pass `SYNC_INCREMENTAL=1` to purge_ttl. It will report every 1000 records on progress, and delete at most `1000000` rows. ⏹ Run it again to delete more.

It would be useful to test more than 1000 records, since some of the logic splits on that, and also more than 1000000 records. In incremental mode, the script will only delete one million 💯 0️⃣᠈ 0️⃣ 0️⃣ 0️⃣ rows, so if there are more than that before you run the script, there should be some left.

## Issue(s)

Closes #570.
