### PR TITLE
fix: restore delete_bso's handling of errors

### DIFF
--- a/src/web/handlers.rs
+++ b/src/web/handlers.rs
@@ -362,10 +362,7 @@ pub fn delete_bso(bso_req: BsoRequest) -> impl Future<Output = Result<HttpRespon
             id: bso_req.bso,
         })
         .map_err(From::from)
-        .map(|result: Result<SyncTimestamp, Error>| match result {
-            Ok(result) => Ok(HttpResponse::Ok().json(json!({ "modified": result }))),
-            Err(_e) => Ok(HttpResponse::NotFound().finish()),
-        })
+        .map_ok(|result| HttpResponse::Ok().json(json!({ "modified": result })))
 }
 
 pub fn get_bso(bso_req: BsoRequest) -> impl Future<Output = Result<HttpResponse, Error>> {


### PR DESCRIPTION
## Description

don't turn them into 404s

Merging into release/0.3 branch, then I'll cut a 0.3.1 for solely this.

## Testing

Difficult to test this behavior (requires generating an error from the db layer other than BsoNotFound)

## Issue(s)

Closes #599
