### PR TITLE
feat: log messages from middleware to sentry

### DIFF
--- a/src/bin/purge_ttl.rs
+++ b/src/bin/purge_ttl.rs
@@ -8,7 +8,6 @@ use std::time::{Duration, Instant};
 use cadence::{
     BufferedUdpMetricSink, Metric, QueuingMetricSink, StatsdClient, Timed, DEFAULT_PORT,
 };
-
 use googleapis_raw::spanner::v1::{
     spanner::{
         BeginTransactionRequest, CommitRequest, CreateSessionRequest, ExecuteSqlRequest, Session,

--- a/src/db/mysql/test.rs
+++ b/src/db/mysql/test.rs
@@ -6,7 +6,6 @@ use diesel::{
     r2d2::{CustomizeConnection, Error as PoolError},
     Connection, ExpressionMethods, QueryDsl, RunQueryDsl,
 };
-
 use url::Url;
 
 use crate::db::mysql::{

--- a/src/web/middleware/mod.rs
+++ b/src/web/middleware/mod.rs
@@ -8,8 +8,7 @@ pub mod weave;
 //
 // Matches the [Sync Storage middleware](https://github.com/mozilla-services/server-syncstorage/blob/master/syncstorage/tweens.py) (tweens).
 
-use actix_web::dev::ServiceRequest;
-use actix_web::Error;
+use actix_web::{dev::ServiceRequest, Error};
 
 use crate::db::util::SyncTimestamp;
 use crate::error::{ApiError, ApiErrorKind};

--- a/src/web/middleware/precondition.rs
+++ b/src/web/middleware/precondition.rs
@@ -1,6 +1,7 @@
 use std::task::Context;
 use std::{cell::RefCell, rc::Rc};
 
+use crate::web::middleware::sentry::queue_report;
 use crate::web::{
     extractors::{
         extrude_db, BsoParam, CollectionParam, PreConditionHeader, PreConditionHeaderOpt,
@@ -9,6 +10,7 @@ use crate::web::{
     tags::Tags,
     DOCKER_FLOW_ENDPOINTS, X_LAST_MODIFIED,
 };
+
 use actix_web::{
     dev::{Service, ServiceRequest, ServiceResponse, Transform},
     http::{header, StatusCode},
@@ -95,6 +97,7 @@ where
             },
             Err(e) => {
                 warn!("⚠️ Precondition error {:?}", e);
+                queue_report(sreq.extensions_mut(), &e);
                 return Box::pin(future::ok(
                     sreq.into_response(
                         HttpResponse::BadRequest()
@@ -109,6 +112,7 @@ where
             Ok(v) => v,
             Err(e) => {
                 warn!("⚠️ Hawk header error {:?}", e);
+                queue_report(sreq.extensions_mut(), &e);
                 return Box::pin(future::ok(
                     sreq.into_response(
                         HttpResponse::Unauthorized()
@@ -124,6 +128,7 @@ where
             Ok(v) => v,
             Err(e) => {
                 error!("⚠️ Database access error {:?}", e);
+                queue_report(sreq.extensions_mut(), &e);
                 return Box::pin(future::ok(
                     sreq.into_response(
                         HttpResponse::InternalServerError()
@@ -140,6 +145,7 @@ where
             Ok(v) => v.map(|c| c.collection),
             Err(e) => {
                 warn!("⚠️ Collection Error:  {:?}", e);
+                queue_report(sreq.extensions_mut(), &e);
                 return Box::pin(future::ok(
                     sreq.into_response(
                         HttpResponse::InternalServerError()


### PR DESCRIPTION
## Description

Actix currently discards any errors generated in the middleware. You are
supposed to pass them in the body or some similar sub-optimal means.

Not a super fan of this approach, but basically, this patch attaches a
the error to the request or response extensions bucket. Since sentry is
also a middleware and gets run on every response, it sweeps the
request/response extension buckets and reports any errors it finds.

This has the downside that some context may be lost from the error (e.g.
I STRONGLY suspect the backtrace will be useless)

WIP:
Need to verify all middleware errors are being stored to extensions. 

Describe these changes.

## Testing

`debug!` statements have been added in the sentry middleware to note if an error has been detected and logged. You can trigger one such error (Bad Hawk Id) by starting a server and trying to fetch from `http://localhost:8000/test`

## Issue(s)

Closes #504