### PR TITLE
feat: emit Db pool metrics periodically

### DIFF
--- a/src/db/mock.rs
+++ b/src/db/mock.rs
@@ -18,6 +18,10 @@ impl DbPool for MockDbPool {
         Box::pin(future::ok(Box::new(MockDb::new()) as Box<dyn Db>))
     }
 
+    fn state(&self) -> results::PoolState {
+        results::PoolState::default()
+    }
+
     fn box_clone(&self) -> Box<dyn DbPool> {
         Box::new(self.clone())
     }

--- a/src/db/mysql/pool.rs
+++ b/src/db/mysql/pool.rs
@@ -17,7 +17,7 @@ use diesel::{
 use super::models::{MysqlDb, Result};
 #[cfg(test)]
 use super::test::TestTransactionCustomizer;
-use crate::db::{error::DbError, Db, DbFuture, DbPool, STD_COLLS};
+use crate::db::{error::DbError, results, Db, DbFuture, DbPool, STD_COLLS};
 use crate::server::metrics::Metrics;
 use crate::settings::Settings;
 
@@ -90,6 +90,10 @@ impl DbPool for MysqlDbPool {
             })
             .map_err(Into::into),
         )
+    }
+
+    fn state(&self) -> results::PoolState {
+        self.pool.state().into()
     }
 
     fn box_clone(&self) -> Box<dyn DbPool> {

--- a/src/db/results.rs
+++ b/src/db/results.rs
@@ -69,6 +69,22 @@ pub struct PostBsos {
     pub failed: HashMap<String, String>,
 }
 
+#[derive(Debug, Default)]
+/// A mockable r2d2::State
+pub struct PoolState {
+    pub connections: u32,
+    pub idle_connections: u32,
+}
+
+impl From<diesel::r2d2::State> for PoolState {
+    fn from(state: diesel::r2d2::State) -> PoolState {
+        PoolState {
+            connections: state.connections,
+            idle_connections: state.idle_connections,
+        }
+    }
+}
+
 #[cfg(test)]
 pub type GetCollectionId = i32;
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,8 +1,8 @@
 //! Main application server
 
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
-use crate::db::{pool_from_settings, DbPool};
+use crate::db::{pool_from_settings, spawn_pool_periodic_reporter, DbPool};
 use crate::error::ApiError;
 use crate::server::metrics::Metrics;
 use crate::settings::{Secrets, ServerLimits, Settings};
@@ -157,6 +157,8 @@ impl Server {
         let limits = Arc::new(settings.limits);
         let secrets = Arc::new(settings.master_secret);
         let port = settings.port;
+
+        spawn_pool_periodic_reporter(Duration::from_secs(10), metrics.clone(), db_pool.clone());
 
         let server = HttpServer::new(move || {
             // Setup the server state


### PR DESCRIPTION
kill the mislabeled pool get metric for now (fixes it repeatedly
emitting)



## Description

Describe these changes.

## Testing

Run `nc -lu -p 8125` alongside syncstorage-rs 

## Issue(s)

Closes #555, #406
