### PR TITLE
feat: Don't report Conflict errors to sentry

### DIFF
--- a/src/db/error.rs
+++ b/src/db/error.rs
@@ -99,6 +99,11 @@ from_error!(grpcio::Error, DbError, |inner: grpcio::Error| {
         {
             DbErrorKind::Conflict
         }
+        grpcio::Error::RpcFailure(ref status)
+            if status.status == grpcio::RpcStatusCode::ALREADY_EXISTS =>
+        {
+            DbErrorKind::Conflict
+        }
         _ => DbErrorKind::SpannerGrpc(inner),
     }
 });

--- a/src/db/mysql/models.rs
+++ b/src/db/mysql/models.rs
@@ -211,6 +211,7 @@ impl MysqlDb {
             let modified = SyncTimestamp::from_i64(modified)?;
             // Forbid the write if it would not properly incr the timestamp
             if modified >= self.timestamp() {
+                self.metrics.clone().incr("db.conflict");
                 Err(DbErrorKind::Conflict)?
             }
             self.session

--- a/src/db/spanner/models.rs
+++ b/src/db/spanner/models.rs
@@ -276,6 +276,7 @@ impl SpannerDb {
             // Forbid the write if it would not properly incr the modified
             // timestamp
             if modified >= now {
+                self.metrics.clone().incr("db.conflict");
                 Err(DbErrorKind::Conflict)?
             }
             self.session

--- a/src/error.rs
+++ b/src/error.rs
@@ -104,8 +104,8 @@ impl ApiError {
     }
 
     pub fn is_conflict(&self) -> bool {
-    // Is this error a record conflict?
-    match self.kind() {
+        // Is this error a record conflict?
+        match self.kind() {
             ApiErrorKind::Db(dbe) => match dbe.kind() {
                 DbErrorKind::Conflict => return true,
                 _ => (),
@@ -116,8 +116,8 @@ impl ApiError {
     }
 
     pub fn is_reportable(&self) -> bool {
-    // Should we report this error to sentry?
-    match self.kind() {
+        // Should we report this error to sentry?
+        match self.kind() {
             ApiErrorKind::Db(dbe) => match dbe.kind() {
                 DbErrorKind::Conflict => return false,
                 _ => (),

--- a/src/error.rs
+++ b/src/error.rs
@@ -104,7 +104,8 @@ impl ApiError {
     }
 
     pub fn is_conflict(&self) -> bool {
-        match self.kind() {
+    // Is this error a record conflict?
+    match self.kind() {
             ApiErrorKind::Db(dbe) => match dbe.kind() {
                 DbErrorKind::Conflict => return true,
                 _ => (),
@@ -112,6 +113,18 @@ impl ApiError {
             _ => (),
         }
         false
+    }
+
+    pub fn is_reportable(&self) -> bool {
+    // Should we report this error to sentry?
+    match self.kind() {
+            ApiErrorKind::Db(dbe) => match dbe.kind() {
+                DbErrorKind::Conflict => return false,
+                _ => (),
+            },
+            _ => (),
+        }
+        true
     }
 
     fn weave_error_code(&self) -> WeaveError {


### PR DESCRIPTION
## Description

* Added new metric "db.conflict"
* Added new error method `is_reportable()` for future error filtering.

Describe these changes.

## Testing

Unfortunately, testing requires  a db conflict write and, metrics and sentry reporting. A `debug!()` line does include the error that is not being directly reported to Sentry.

## Issue(s)
Closes #614
