### PR TITLE
feat: include a hostname tag w/ pool metrics

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -158,7 +158,7 @@ impl Server {
         let secrets = Arc::new(settings.master_secret);
         let port = settings.port;
 
-        spawn_pool_periodic_reporter(Duration::from_secs(10), metrics.clone(), db_pool.clone());
+        spawn_pool_periodic_reporter(Duration::from_secs(10), metrics.clone(), db_pool.clone())?;
 
         let server = HttpServer::new(move || {
             // Setup the server state


### PR DESCRIPTION
## Description

include a hostname tag w/ pool metrics

so we can distinguish between nodes

Against the `release/0.3` branch

## Testing

Run `nc -lu -p 8125` alongside syncstorage-rs 

## Issue(s)

Closes #555
