### PR TITLE
fix: don't consider expiry during batch commit

### DIFF
--- a/src/db/spanner/batch_commit_insert.sql
+++ b/src/db/spanner/batch_commit_insert.sql
@@ -23,5 +23,4 @@ SELECT
         WHERE fxa_uid = @fxa_uid
           AND fxa_kid = @fxa_kid
           AND collection_id = @collection_id
-          AND expiry > CURRENT_TIMESTAMP()
    )

--- a/src/db/spanner/batch_commit_update.sql
+++ b/src/db/spanner/batch_commit_update.sql
@@ -48,4 +48,3 @@ UPDATE bsos
           AND collection_id = @collection_id
           AND batch_id = @batch_id
    )
-   AND expiry > CURRENT_TIMESTAMP()


### PR DESCRIPTION
## Description

- considering expiry causes potential AlreadyExists errors (as we
  attempt to INSERT new records that already exist albeit in an expired
  state), though these errors are only temporary until the expired data
  is purged

- *not* considering expiry seems less correct: we can resurrect expired
  data. but this matches Python syncstorage's behavior

- in practice the AlreadyExists errors mostly happen on the history
  collection

## Testing

unit/e2e tests passing

## Issue(s)

Issue #625
