### PR TITLE
fix: don't classify AlreadyExists as a ConflictError

### DIFF
--- a/src/db/error.rs
+++ b/src/db/error.rs
@@ -99,11 +99,6 @@ from_error!(grpcio::Error, DbError, |inner: grpcio::Error| {
         {
             DbErrorKind::Conflict
         }
-        grpcio::Error::RpcFailure(ref status)
-            if status.status == grpcio::RpcStatusCode::ALREADY_EXISTS =>
-        {
-            DbErrorKind::Conflict
-        }
         _ => DbErrorKind::SpannerGrpc(inner),
     }
 });


### PR DESCRIPTION
## Description

as of #632 they should no longer occur. In case they do for whatever
reason, they should go to sentry

## Testing

Unit/e2e tests pass

## Issue(s)

Closes #633
