### PR TITLE
bug: Make `bso_num` in migrate_node less truthy

### DIFF
--- a/tools/user_migration/migrate_node.py
+++ b/tools/user_migration/migrate_node.py
@@ -776,7 +776,7 @@ def main():
         args.user = user_list
     elif args.wipe_user:
         raise RuntimeError("--wipe_user requires --user")
-    if args.bso_num:
+    if args.bso_num is not None:
         args.start_bso = args.end_bso = args.bso_num
     for line in dsns:
         dsn = urlparse(line.strip())


### PR DESCRIPTION
Closes #636

## Description
Check if `bso_num` is not empty, not just `false`

## Testing

`migrate_node.py --bso_num=0` should only run data for users in the `bso0` database.

## Issue(s)

Closes #636
