### PR TITLE
fix: python image build needs stable docker git container

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -212,7 +212,7 @@ jobs:
 
   deploy-python-utils:
     docker:
-      - image: docker:18.02.0-ce
+      - image: docker:stable-git
     steps:
       - setup_remote_docker
       - checkout


### PR DESCRIPTION
## Description

Fix build errors for python spanner utils image

## Testing

Run circleci

