### PR TITLE
feat: add conditions, args to purge_ttl script

### DIFF
--- a/tools/spanner/purge_ttl.py
+++ b/tools/spanner/purge_ttl.py
@@ -68,10 +68,7 @@ def spanner_purge(args, request=None):
     database = instance.database(args.database_id)
 
     logging.info("For {}:{}".format(args.instance_id, args.database_id))
-    batch_query = add_conditions(
-            args,
-            'DELETE FROM batches WHERE expiry < CURRENT_TIMESTAMP()'
-        )
+    batch_query = 'DELETE FROM batches WHERE expiry < CURRENT_TIMESTAMP()'
     bso_query = add_conditions(
             args,
             'DELETE FROM bsos WHERE expiry < CURRENT_TIMESTAMP()'

--- a/tools/spanner/requirements.txt
+++ b/tools/spanner/requirements.txt
@@ -1,2 +1,2 @@
-google-cloud-spanner >=1.16.0
+google-cloud-spanner >= 1.16.0
 statsd


### PR DESCRIPTION
## Description

attempt to try and provide a way to allow the purge_ttl script to complete.

Adds arguments (ENV VARS):

  --instance_id (INSTANCE_ID)  Spanner instance id
  --database_id (DATABASE_ID)  Spanner database id
  --sync_database_url (SYNC_DATABASE_URL) Spanner DSN
        `spanner://instance/database`
  --collection_ids (COLLECTION_IDS)
        JSON formatted list of collections to limit deletions
        e.g. `--collection_ids=123` limits to just collection 123
             `--collection_ids=[123,456]` limits to both 123 & 456
             default is all collections

## Testing

May be used with the stage spanner database instance

## Issue(s)

Issue #631
