### PR TITLE
fix: don't call begin twice for mysql's delete_all

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3017,6 +3017,7 @@ dependencies = [
  "log",
  "mime",
  "mozsvc-common",
+ "num_cpus",
  "protobuf",
  "rand 0.7.3",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ hmac = "0.7"
 log = { version = "0.4.8", features = ["max_level_info", "release_max_level_info"] }
 mime = "0.3"
 mozsvc-common = "0.1"
+num_cpus = "1"
 # must match what's used by googleapis-raw
 protobuf = "2.12"
 rand = "0.7"

--- a/src/db/mysql/models.rs
+++ b/src/db/mysql/models.rs
@@ -278,7 +278,6 @@ impl MysqlDb {
 
     pub fn delete_storage_sync(&self, user_id: HawkIdentifier) -> Result<()> {
         let user_id = user_id.legacy_id as i64;
-        self.begin(true)?;
         // Delete user data.
         delete(bso::table)
             .filter(bso::user_id.eq(user_id))

--- a/src/web/handlers.rs
+++ b/src/web/handlers.rs
@@ -67,14 +67,14 @@ pub async fn get_quota(meta: MetaRequest) -> Result<HttpResponse, Error> {
 }
 
 pub async fn delete_all(meta: MetaRequest) -> Result<HttpResponse, Error> {
-    #![allow(clippy::unit_arg)]
     meta.metrics.incr("request.delete_all");
     let db = meta.db;
+    // The db middleware won't implicitly begin a write transaction
+    // for DELETE /storage because it lacks a collection. So it's done
+    // manually here, partly to not further complicate the unit test's
+    // transactions
     db.begin(true).await?;
-    match db.delete_storage(meta.user_id).await {
-        Ok(r) => Ok(HttpResponse::Ok().json(r)),
-        Err(e) => Err(e.into()),
-    }
+    Ok(HttpResponse::Ok().json(db.delete_storage(meta.user_id).await?))
 }
 
 pub fn delete_collection(


### PR DESCRIPTION
## Description

and adjust ACTIX_THREADPOOL per the database_pool_max_size on mysql

## Testing

tests pass under mysql

## Issue(s)

Closes #639
Closes #441
