### PR TITLE
Fix performance issues in bb8 branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -391,16 +391,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "backtrace-sys"
-version = "0.1.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fbebbe1c9d1f383a9cc7e8ccdb471b91c8d024ee9c2ca5b5346121fe8b4399"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
 name = "base-x"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -435,7 +425,7 @@ checksum = "374bba43fc924d90393ee7768e6f75d223a98307a488fe5bc34b66c3e96932a6"
 dependencies = [
  "async-trait",
  "futures 0.3.5",
- "tokio 0.2.13",
+ "tokio 0.2.21",
 ]
 
 [[package]]

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -78,7 +78,7 @@ impl Clone for Box<dyn DbPool> {
     }
 }
 
-pub trait Db<'a>: Send + Debug + 'a {
+pub trait Db<'a>: Debug + 'a {
     fn lock_for_read(&self, params: params::LockCollection) -> DbFuture<'_, ()>;
 
     fn lock_for_write(&self, params: params::LockCollection) -> DbFuture<'_, ()>;

--- a/src/db/spanner/manager.rs
+++ b/src/db/spanner/manager.rs
@@ -95,7 +95,7 @@ impl<T: std::marker::Send + std::marker::Sync + 'static> ManageConnection
     async fn is_valid(&self, conn: Self::Connection) -> Result<Self::Connection, Self::Error> {
         let mut req = GetSessionRequest::new();
         req.set_name(conn.session.get_name().to_owned());
-        if let Err(e) = conn.client.get_session(&req) {
+        if let Err(e) = conn.client.get_session_async(&req)?.await {
             return Err(e);
         }
         Ok(conn)

--- a/src/db/spanner/models.rs
+++ b/src/db/spanner/models.rs
@@ -1609,8 +1609,6 @@ impl<'a> SpannerDb<'a> {
     }
 }
 
-unsafe impl Send for SpannerDb<'_> {}
-
 impl<'a> Db<'a> for SpannerDb<'a> {
     fn commit(&self) -> DbFuture<'_, ()> {
         let db = self.clone();

--- a/src/db/transaction.rs
+++ b/src/db/transaction.rs
@@ -24,49 +24,112 @@ pub struct DbTransactionPool {
 }
 
 impl DbTransactionPool {
-    pub async fn transaction<'a, A, F>(&'a self, action: A) -> Result<HttpResponse, Error>
+    /// Perform an action inside of a DB transaction. If the action fails, the
+    /// transaction is rolled back. If the action succeeds, the transaction is
+    /// NOT committed. Further processing is required before we are sure the
+    /// action has succeeded (ex. check HTTP response for internal error).
+    async fn transaction_internal<'a, A, R, F>(
+        &'a self,
+        action: A,
+    ) -> Result<(R, Box<dyn Db<'a>>), Error>
     where
         A: FnOnce(Box<dyn Db<'a>>) -> F,
-        F: Future<Output = Result<HttpResponse, Error>> + 'a,
+        F: Future<Output = Result<R, Error>> + 'a,
     {
+        // Get connection from pool
         let db = self.pool.get().await?;
         let db2 = db.clone();
 
+        // Lock for transaction
         let result = match (self.lock_collection.clone(), self.is_read) {
             (Some(lc), true) => db.lock_for_read(lc).await,
             (Some(lc), false) => db.lock_for_write(lc).await,
             _ => Ok(()),
         };
 
+        // Handle lock error
         if let Err(e) = result {
             db.rollback().await?;
             return Err(e.into());
         }
 
-        let resp = action(db).await?;
+        // Perform the action
+        let resp = action(db).await;
 
         // XXX: lock_for_x usually begins transactions but Dbs
         // may also implicitly create them, so commit/rollback
         // are always called to finish them. They noop when no
         // implicit transaction was created (maybe rename them
         // to maybe_commit/rollback?)
+        match resp {
+            Ok(resp) => Ok((resp, db2)),
+            Err(e) => {
+                let result = db2.rollback().await;
+
+                // Handle rollback error
+                if let Err(e) = result {
+                    self.report_error(&e);
+                    Err(e.into())
+                } else {
+                    Err(e)
+                }
+            }
+        }
+    }
+
+    /// Perform an action inside of a DB transaction.
+    pub async fn transaction<'a, A, R, F>(&'a self, action: A) -> Result<R, Error>
+    where
+        A: FnOnce(Box<dyn Db<'a>>) -> F,
+        F: Future<Output = Result<R, Error>> + 'a,
+    {
+        let (resp, db) = self.transaction_internal(action).await?;
+
+        // No further processing before commit is possible
+        let result = db.commit().await;
+
+        // Handle commit error
+        if let Err(e) = result {
+            self.report_error(&e);
+            return Err(e.into());
+        }
+
+        Ok(resp)
+    }
+
+    /// Report an error to sentry, if possible
+    fn report_error(&self, error: &ApiError) {
+        // we can't queue_report here (no access to extensions)
+        // so just report it immediately with tags on hand
+        if error.is_reportable() {
+            report(
+                &self.tags,
+                sentry::integrations::failure::event_from_fail(error),
+            );
+        } else {
+            debug!("Not reporting error: {:?}", error);
+        }
+    }
+
+    /// Perform an action inside of a DB transaction. This method will rollback
+    /// if the HTTP response is an error.
+    pub async fn transaction_http<'a, A, F>(&'a self, action: A) -> Result<HttpResponse, Error>
+    where
+        A: FnOnce(Box<dyn Db<'a>>) -> F,
+        F: Future<Output = Result<HttpResponse, Error>> + 'a,
+    {
+        let (resp, db) = self.transaction_internal(action).await?;
+
+        // HttpResponse can contain an internal error
         let result = match resp.error() {
-            None => db2.commit().await,
-            Some(_) => db2.rollback().await,
+            None => db.commit().await,
+            Some(_) => db.rollback().await,
         };
 
-        if let Err(apie) = result {
-            // we can't queue_report here (no access to extensions)
-            // so just report it immediately with tags on hand
-            if apie.is_reportable() {
-                report(
-                    &self.tags,
-                    sentry::integrations::failure::event_from_fail(&apie),
-                );
-            } else {
-                debug!("Not reporting error: {:?}", apie);
-            }
-            return Err(apie.into());
+        // Handle commit/rollback error
+        if let Err(e) = result {
+            self.report_error(&e);
+            return Err(e.into());
         }
 
         Ok(resp)

--- a/src/web/extractors.rs
+++ b/src/web/extractors.rs
@@ -847,7 +847,6 @@ impl FromRequest for BsoRequest {
 /// Extracts/validates information needed for BSO put requests.
 pub struct BsoPutRequest {
     pub collection: String,
-    pub db_pool: Box<dyn DbPool>,
     pub user_id: HawkIdentifier,
     pub query: BsoQueryParams,
     pub bso: String,
@@ -867,7 +866,6 @@ impl FromRequest for BsoPutRequest {
 
         async move {
             let user_id = HawkIdentifier::from_request(&req, &mut payload).await?;
-            let db_pool = extrude_db_pool(&req).await?;
             let collection = CollectionParam::from_request(&req, &mut payload).await?;
             let query = BsoQueryParams::from_request(&req, &mut payload).await?;
             let bso = BsoParam::from_request(&req, &mut payload).await?;
@@ -891,7 +889,6 @@ impl FromRequest for BsoPutRequest {
             }
             Ok(BsoPutRequest {
                 collection,
-                db_pool,
                 user_id,
                 query,
                 bso: bso.bso,

--- a/src/web/extractors.rs
+++ b/src/web/extractors.rs
@@ -1475,8 +1475,7 @@ impl FromRequest for BatchRequestOpt {
                 None => None,
                 Some(ref batch) if batch == "" || TRUE_REGEX.is_match(&batch) => None,
                 Some(batch) => {
-                    let transaction_pool: DbTransactionPool =
-                        DbTransactionPool::extract(&req).await?;
+                    let transaction_pool = DbTransactionPool::extract(&req).await?;
 
                     transaction_pool
                         .transaction(|db| async move {

--- a/src/web/handlers.rs
+++ b/src/web/handlers.rs
@@ -22,7 +22,7 @@ pub async fn get_collections(
     db_pool: DbTransactionPool,
 ) -> Result<HttpResponse, Error> {
     db_pool
-        .transaction(|db| async move {
+        .transaction_http(|db| async move {
             meta.metrics.incr("request.get_collections");
             let result = db.get_collection_timestamps(meta.user_id).await?;
 
@@ -38,7 +38,7 @@ pub async fn get_collection_counts(
     db_pool: DbTransactionPool,
 ) -> Result<HttpResponse, Error> {
     db_pool
-        .transaction(|db| async move {
+        .transaction_http(|db| async move {
             meta.metrics.incr("request.get_collection_counts");
             let result = db.get_collection_counts(meta.user_id).await?;
 
@@ -54,7 +54,7 @@ pub async fn get_collection_usage(
     db_pool: DbTransactionPool,
 ) -> Result<HttpResponse, Error> {
     db_pool
-        .transaction(|db| async move {
+        .transaction_http(|db| async move {
             meta.metrics.incr("request.get_collection_usage");
             let usage: HashMap<_, _> = db
                 .get_collection_usage(meta.user_id)
@@ -75,7 +75,7 @@ pub async fn get_quota(
     db_pool: DbTransactionPool,
 ) -> Result<HttpResponse, Error> {
     db_pool
-        .transaction(|db| async move {
+        .transaction_http(|db| async move {
             meta.metrics.incr("request.get_quota");
             let usage = db.get_storage_usage(meta.user_id).await?;
             Ok(HttpResponse::Ok().json(vec![Some(usage as f64 / ONE_KB), None]))
@@ -88,7 +88,7 @@ pub async fn delete_all(
     db_pool: DbTransactionPool,
 ) -> Result<HttpResponse, Error> {
     db_pool
-        .transaction(|db| async move {
+        .transaction_http(|db| async move {
             meta.metrics.incr("request.delete_all");
             // The db middleware won't implicitly begin a write transaction
             // for DELETE /storage because it lacks a collection. So it's done
@@ -105,7 +105,7 @@ pub async fn delete_collection(
     db_pool: DbTransactionPool,
 ) -> Result<HttpResponse, Error> {
     db_pool
-        .transaction(|db| async move {
+        .transaction_http(|db| async move {
             let delete_bsos = !coll.query.ids.is_empty();
             let metrics = coll.metrics.clone();
             let timestamp: ApiResult<SyncTimestamp> = if delete_bsos {
@@ -150,7 +150,7 @@ pub async fn get_collection(
     db_pool: DbTransactionPool,
 ) -> Result<HttpResponse, Error> {
     db_pool
-        .transaction(|db| async move {
+        .transaction_http(|db| async move {
             coll.metrics.clone().incr("request.get_collection");
             let params = params::GetBsos {
                 user_id: coll.user_id.clone(),
@@ -226,7 +226,7 @@ pub async fn post_collection(
     db_pool: DbTransactionPool,
 ) -> Result<HttpResponse, Error> {
     db_pool
-        .transaction(|db| async move {
+        .transaction_http(|db| async move {
             coll.metrics.clone().incr("request.post_collection");
 
             if coll.batch.is_some() {
@@ -389,7 +389,7 @@ pub async fn delete_bso(
     db_pool: DbTransactionPool,
 ) -> Result<HttpResponse, Error> {
     db_pool
-        .transaction(|db| async move {
+        .transaction_http(|db| async move {
             bso_req.metrics.incr("request.delete_bso");
             let result = db
                 .delete_bso(params::DeleteBso {
@@ -408,7 +408,7 @@ pub async fn get_bso(
     db_pool: DbTransactionPool,
 ) -> Result<HttpResponse, Error> {
     db_pool
-        .transaction(|db| async move {
+        .transaction_http(|db| async move {
             bso_req.metrics.incr("request.get_bso");
             let result = db
                 .get_bso(params::GetBso {
@@ -431,7 +431,7 @@ pub async fn put_bso(
     db_pool: DbTransactionPool,
 ) -> Result<HttpResponse, Error> {
     db_pool
-        .transaction(|db| async move {
+        .transaction_http(|db| async move {
             bso_req.metrics.incr("request.put_bso");
             let result = db
                 .put_bso(params::PutBso {

--- a/src/web/middleware/precondition.rs
+++ b/src/web/middleware/precondition.rs
@@ -140,7 +140,7 @@ where
             let bso_opt = bso.map(|b| b.bso);
 
             let (req, payload) = sreq.into_parts();
-            let transaction_pool: DbTransactionPool = DbTransactionPool::extract(&req).await?;
+            let transaction_pool = DbTransactionPool::extract(&req).await?;
             let resource_ts = transaction_pool
                 .transaction(|db| async move {
                     db.extract_resource(user_id, collection, bso_opt)


### PR DESCRIPTION
## Description

#692 was experiencing some very surprising performance regressions in some integration tests. These regressions have been narrowed down to a change in how DB transactions are handled in the branch. Previously the whole request was in one DB transaction. This was changed to only running the DB transaction in the handler. There were some middlewares/extractors directly accessing the DB pool, which is believed to be the cause of the performance regressions. This PR wraps those non-handler DB interactions in transactions, along with a few other fixes (ex. remove unsafe Send impl for SpannerDb).

## Testing

All requests made during the `test_batch_ttl_update` integration test should take < 4 seconds. Previously, some requests took 15-20 seconds. Make sure you are using Spanner for this test.

## Issue(s)

N/A