### PR TITLE
feat: Allow client debugging using `Client-Debug:` header

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2315,39 +2315,94 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "sentry"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b01b723fc1b0a0f9394ca1a8451daec6e20206d47f96c3dceea7fd11ec9eec0"
+checksum = "9bf0d1227e6b2cf0a4787c6ba7deed5156ab19fba88e00ffc009bfca8f84812b"
+dependencies = [
+ "curl",
+ "httpdate",
+ "log",
+ "reqwest",
+ "sentry-backtrace",
+ "sentry-contexts",
+ "sentry-core",
+ "sentry-failure",
+ "sentry-panic",
+ "serde_json",
+]
+
+[[package]]
+name = "sentry-backtrace"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d80067b3c23a24ea12696bb6abeb0ae1c107cbc711ccceb93b1157e4efc219e9"
 dependencies = [
  "backtrace",
- "curl",
- "failure",
+ "lazy_static",
+ "regex",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-contexts"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f4367379c4799edf477172cf0964274ae0bb5760ded72779503e64f7c54103"
+dependencies = [
  "hostname",
- "httpdate",
- "im",
  "lazy_static",
  "libc",
- "rand",
  "regex",
- "reqwest",
  "rustc_version",
- "sentry-types",
- "serde_json",
+ "sentry-core",
  "uname",
- "url 2.1.1",
+]
+
+[[package]]
+name = "sentry-core"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44ecd107ce94c346da806dd5ec7afe4aa1b9ff60067b7ea63de499921c990b5d"
+dependencies = [
+ "im",
+ "lazy_static",
+ "log",
+ "rand",
+ "sentry-types",
+]
+
+[[package]]
+name = "sentry-failure"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fc8d591ebd58fff637fa7e8fdb308d22be3596cec02909233920c75333b8f8a"
+dependencies = [
+ "failure",
+ "sentry-backtrace",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-panic"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ee9d1cbab974ec95ba450856115108ce3726ecbdc5316e17b165b527704d1b"
+dependencies = [
+ "sentry-backtrace",
+ "sentry-core",
 ]
 
 [[package]]
 name = "sentry-types"
-version = "0.14.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12ec406c11c060c8a7d5d67fc6f4beb2888338dcb12b9af409451995f124749d"
+checksum = "127fa240592798721c87d025ff7652101a492a38462f5a126f7fec43931aeeb1"
 dependencies = [
  "chrono",
  "debugid",
- "failure",
  "serde 1.0.114",
  "serde_json",
+ "thiserror",
  "url 2.1.1",
  "uuid",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,10 +44,10 @@ log = { version = "0.4.8", features = ["max_level_info", "release_max_level_info
 mime = "0.3"
 num_cpus = "1"
 # must match what's used by googleapis-raw
-protobuf = "2.15"
+protobuf = "2.16.2"
 rand = "0.7"
 regex = "1.3"
-sentry = { version = "0.18", features = ["with_curl_transport"] }
+sentry = { version = "0.19", features = ["debug-logs", "with_curl_transport"] }
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = { version = "1.0", features = ["arbitrary_precision"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@
 extern crate slog_scope;
 
 use std::error::Error;
+use std::sync::Arc;
 
 use docopt::Docopt;
 use serde_derive::Deserialize;
@@ -36,18 +37,19 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // likely grpcio's boringssl
     let curl_transport_factory = |options: &sentry::ClientOptions| {
         // Note: set options.debug = true when diagnosing sentry issues.
-        Box::new(sentry::transports::CurlHttpTransport::new(&options))
-            as Box<dyn sentry::internals::Transport>
+        Arc::new(sentry::transports::CurlHttpTransport::new(&options))
+            as Arc<dyn sentry::internals::Transport>
     };
-    let sentry = sentry::init(sentry::ClientOptions {
-        transport: Box::new(curl_transport_factory),
+    let _sentry = sentry::init(sentry::ClientOptions {
+        transport: Some(Arc::new(curl_transport_factory)),
         release: sentry::release_name!(),
         ..sentry::ClientOptions::default()
     });
+    /*
     if sentry.is_enabled() {
         sentry::integrations::panic::register_panic_handler();
     }
-
+    */
     // Setup and run the server
     let banner = settings.banner();
     let server = server::Server::with_settings(settings).await.unwrap();

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -62,10 +62,10 @@ macro_rules! build_app {
             // These will wrap all outbound responses with matching status codes.
             .wrap(ErrorHandlers::new().handler(StatusCode::NOT_FOUND, ApiError::render_404))
             // These are our wrappers
-            // .wrap(middleware::db::DbTransaction::new())
             .wrap(middleware::weave::WeaveTimestamp::new())
             .wrap(middleware::sentry::SentryWrapper::new())
             .wrap(middleware::rejectua::RejectUA::default())
+            .wrap(middleware::debug_client::DebugClient::default())
             // Followed by the "official middleware" so they run first.
             .wrap(Cors::default())
             .service(

--- a/src/web/middleware/debug_client.rs
+++ b/src/web/middleware/debug_client.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::type_complexity)]
 use std::collections::HashMap;
 use std::task::{Context, Poll};
 

--- a/src/web/middleware/debug_client.rs
+++ b/src/web/middleware/debug_client.rs
@@ -37,7 +37,7 @@ pub struct RespondWith {
     status: u16,
     code: Option<u8>,
     message: Option<String>,
-    headers: Option<HashMap<String,String>>,
+    headers: Option<HashMap<String, String>>,
 }
 
 impl Default for RespondWith {
@@ -72,7 +72,7 @@ where
 
     fn call(&mut self, sreq: ServiceRequest) -> Self::Future {
         if let Some(header) = sreq.headers().get("Client-Debug".to_owned()) {
-            info!("### Header: {:?} {:?}", &header, &header.to_str());
+            debug!("### Providing debug header {:?}", header);
             let resp_data: RespondWith =
                 serde_json::from_str(header.to_str().unwrap_or_default()).expect("Invalid header");
             let mut builder = HttpResponse::build(
@@ -90,10 +90,10 @@ where
                     .body(format!("{:?}", code))
                     .into_body()
             } else if let Some(message) = resp_data.message {
-                    builder
-                        .content_type("application/json")
-                        .body(format!("{:?}", message))
-                        .into_body()
+                builder
+                    .content_type("application/json")
+                    .body(format!("{:?}", message))
+                    .into_body()
             } else {
                 builder.body("").into_body()
             };

--- a/src/web/middleware/debug_client.rs
+++ b/src/web/middleware/debug_client.rs
@@ -1,0 +1,104 @@
+use std::collections::HashMap;
+use std::task::{Context, Poll};
+
+use actix_web::{
+    dev::{Service, ServiceRequest, ServiceResponse, Transform},
+    http::StatusCode,
+    Error, HttpResponse,
+};
+use futures::future::{self, Either, Ready};
+use serde::{Deserialize, Serialize};
+
+// Respond to "x-debug-return" header requests.
+
+#[derive(Debug, Default)]
+pub struct DebugClient;
+
+impl<S, B> Transform<S> for DebugClient
+where
+    S: Service<Request = ServiceRequest, Response = ServiceResponse<B>, Error = Error>,
+    S::Future: 'static,
+    B: 'static,
+{
+    type Request = ServiceRequest;
+    type Response = ServiceResponse<B>;
+    type Error = Error;
+    type InitError = ();
+    type Transform = DebugClientMiddleware<S>;
+    type Future = Ready<Result<Self::Transform, Self::InitError>>;
+
+    fn new_transform(&self, service: S) -> Self::Future {
+        future::ok(DebugClientMiddleware { service })
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RespondWith {
+    status: u16,
+    code: Option<u8>,
+    message: Option<String>,
+    headers: Option<HashMap<String,String>>,
+}
+
+impl Default for RespondWith {
+    fn default() -> Self {
+        Self {
+            status: 200,
+            code: None,
+            message: None,
+            headers: None,
+        }
+    }
+}
+
+pub struct DebugClientMiddleware<S> {
+    service: S,
+}
+
+impl<S, B> Service for DebugClientMiddleware<S>
+where
+    S: Service<Request = ServiceRequest, Response = ServiceResponse<B>, Error = Error>,
+    S::Future: 'static,
+    B: 'static,
+{
+    type Request = ServiceRequest;
+    type Response = ServiceResponse<B>;
+    type Error = Error;
+    type Future = Either<Ready<Result<Self::Response, Self::Error>>, S::Future>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.service.poll_ready(cx)
+    }
+
+    fn call(&mut self, sreq: ServiceRequest) -> Self::Future {
+        if let Some(header) = sreq.headers().get("Client-Debug".to_owned()) {
+            info!("### Header: {:?} {:?}", &header, &header.to_str());
+            let resp_data: RespondWith =
+                serde_json::from_str(header.to_str().unwrap_or_default()).expect("Invalid header");
+            let mut builder = HttpResponse::build(
+                StatusCode::from_u16(resp_data.status).unwrap_or(StatusCode::BAD_REQUEST),
+            );
+            if let Some(headers) = resp_data.headers {
+                for (key, value) in headers {
+                    builder.set_header(&key, value);
+                }
+            }
+            builder.set_header("debug", "client");
+            let response = if let Some(code) = resp_data.code {
+                builder
+                    .content_type("application/json")
+                    .body(format!("{:?}", code))
+                    .into_body()
+            } else if let Some(message) = resp_data.message {
+                    builder
+                        .content_type("application/json")
+                        .body(format!("{:?}", message))
+                        .into_body()
+            } else {
+                builder.body("").into_body()
+            };
+            return Either::Left(future::ok(sreq.into_response(response)));
+        }
+        Either::Right(self.service.call(sreq))
+    }
+}

--- a/src/web/middleware/mod.rs
+++ b/src/web/middleware/mod.rs
@@ -2,6 +2,8 @@
 pub mod rejectua;
 pub mod sentry;
 pub mod weave;
+pub mod debug_client;
+
 
 // # Web Middleware
 //

--- a/src/web/middleware/mod.rs
+++ b/src/web/middleware/mod.rs
@@ -1,9 +1,8 @@
 // pub mod db;
+pub mod debug_client;
 pub mod rejectua;
 pub mod sentry;
 pub mod weave;
-pub mod debug_client;
-
 
 // # Web Middleware
 //


### PR DESCRIPTION
Closes: #746

## Description
`Client-Debug` header is a JSON blob that contains what to return.
```json
{
   "status": HTTP_Status_code,
   "code": Optional Sync Error Code as body,
   "message": "Optional message content",
   "headers": {"Header": "Value",...},
}
```

Please note that `code` and `message` are exclusive. Code is a numeric,
message is a string. If code is present, message will not be dumped into
the body. Also: Responses include "debug: client" headers, to help 
prevent potential abuse. 

While this PR is not intended for production, clients are encouraged to monitor for this.

## Testing

*Example*
```
> curl -v --header 'Client-Debug: {"status":418, "headers":{"foo":"bar"}, "code": 16}' http://localhost:8000/__version__
*   Trying 127.0.0.1:8000...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 8000 (#0)
> GET /__version__ HTTP/1.1
> Host: localhost:8000
> User-Agent: curl/7.68.0
> Accept: */*
> Client-Debug: {"status":418, "headers":{"foo":"bar"}, "code": 16}
>
* Mark bundle as not supporting multiuse
< HTTP/1.1 418 I'm a teapot
< content-length: 2
< content-type: application/json
< foo: bar
< debug: client
< date: Thu, 30 Jul 2020 18:18:46 GMT
<
* Connection #0 to host localhost left intact
16
```

## Issue(s)

Closes: #746

