### PR TITLE
fix: defer grpc auth to actix-web's thread pool

### DIFF
--- a/src/db/error.rs
+++ b/src/db/error.rs
@@ -52,9 +52,6 @@ pub enum DbErrorKind {
 
     #[fail(display = "Unexpected error: {}", _0)]
     Internal(String),
-
-    #[fail(display = "bb8 error: {}", _0)]
-    Bb8Error(bb8::RunError<grpcio::Error>),
 }
 
 impl DbError {
@@ -111,4 +108,3 @@ from_error!(
     DbError,
     DbErrorKind::Migration
 );
-from_error!(bb8::RunError<grpcio::Error>, DbError, DbErrorKind::Bb8Error);

--- a/src/db/spanner/models.rs
+++ b/src/db/spanner/models.rs
@@ -1,13 +1,24 @@
-use futures::future::TryFutureExt;
+use std::{
+    cell::RefCell,
+    collections::{HashMap, HashSet},
+    convert::TryInto,
+    fmt,
+    ops::Deref,
+    sync::Arc,
+};
 
 use bb8::PooledConnection;
-
-use std::cell::RefCell;
-use std::collections::HashMap;
-use std::convert::TryInto;
-use std::fmt;
-use std::ops::Deref;
-use std::sync::Arc;
+use futures::future::TryFutureExt;
+use googleapis_raw::spanner::v1::transaction::{
+    self, TransactionOptions, TransactionOptions_ReadOnly, TransactionOptions_ReadWrite,
+};
+use googleapis_raw::spanner::v1::{
+    mutation::{Mutation, Mutation_Write},
+    spanner::{BeginTransactionRequest, CommitRequest, ExecuteSqlRequest, RollbackRequest},
+    type_pb::TypeCode,
+};
+#[allow(unused_imports)]
+use protobuf::{well_known_types::ListValue, Message, RepeatedField};
 
 use super::manager::{SpannerConnectionManager, SpannerSession};
 use super::pool::CollectionCache;
@@ -20,7 +31,6 @@ use crate::db::{
     Db, DbFuture, Sorting, FIRST_CUSTOM_COLLECTION_ID,
 };
 use crate::server::metrics::Metrics;
-
 use crate::web::extractors::{BsoQueryParams, HawkIdentifier, Offset};
 
 use super::support::{bso_to_insert_row, bso_to_update_row};
@@ -28,19 +38,6 @@ use super::{
     batch,
     support::{as_list_value, as_value, bso_from_row, ExecuteSqlRequestBuilder},
 };
-
-use googleapis_raw::spanner::v1::transaction;
-use googleapis_raw::spanner::v1::transaction::{
-    TransactionOptions, TransactionOptions_ReadOnly, TransactionOptions_ReadWrite,
-};
-use googleapis_raw::spanner::v1::{
-    mutation::{Mutation, Mutation_Write},
-    spanner::{BeginTransactionRequest, CommitRequest, ExecuteSqlRequest, RollbackRequest},
-    type_pb::TypeCode,
-};
-
-#[allow(unused_imports)]
-use protobuf::{well_known_types::ListValue, Message, RepeatedField};
 
 pub type TransactionSelector = transaction::TransactionSelector;
 
@@ -1342,10 +1339,10 @@ impl<'a> SpannerDb<'a> {
             )?
             .params(sqlparams)
             .execute_async(&self.conn)?;
-        let mut existing = vec![];
+        let mut existing = HashSet::new();
         while let Some(row) = streaming.next_async().await {
             let mut row = row?;
-            existing.push(row[0].take_string_value());
+            existing.insert(row[0].take_string_value());
         }
 
         let mut inserts = vec![];

--- a/src/web/handlers.rs
+++ b/src/web/handlers.rs
@@ -2,7 +2,6 @@
 use std::collections::HashMap;
 
 use actix_web::{http::StatusCode, Error, HttpRequest, HttpResponse};
-use futures::future::{self, Future};
 use serde::Serialize;
 use serde_json::{json, Value};
 
@@ -444,8 +443,8 @@ pub async fn put_bso(
         .await
 }
 
-pub fn get_configuration(creq: ConfigRequest) -> impl Future<Output = Result<HttpResponse, Error>> {
-    future::ready(Ok(HttpResponse::Ok().json(creq.limits)))
+pub async fn get_configuration(creq: ConfigRequest) -> Result<HttpResponse, Error> {
+    Ok(HttpResponse::Ok().json(creq.limits))
 }
 
 /** Returns a status message indicating the state of the current server


### PR DESCRIPTION
## Description

- prefer a set vs vec of the existing bso_ids
- /info/configuration -> async fn

## Testing

Further load testing

## Issue(s)

Closes #745
Issue #732

After implmenting this I'm a little less convinced it's actually needed as we *don't* establish connections that frequently with the Pooling, but it shouldn't hurt we can confirm its metric timings.

Also we discussed recycling connections after a certain number of uses but I recalled both r2d2 & bb8 default to a 30 minute Connection lifetime -- so they're pretty much doing something similar for us already.