### PR TITLE
dereference Data<> before calling `on_response()`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,9 @@ validator = "0.10"
 validator_derive = "0.10"
 woothee = "0.11"
 
+[target.'cfg(target_vendor="ubuntu")'.dependencies]
+grpcio = { version="0.6", features=["openssl"] }
+
 [dev-dependencies]
 tokio = { version = "0.2", features = ["macros"] }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -13,7 +13,6 @@ use actix_web::{
     error::ResponseError,
     http::StatusCode,
     middleware::errhandlers::ErrorHandlerResponse,
-    web::Data,
     HttpResponse, Result,
 };
 use failure::{Backtrace, Context, Fail};
@@ -130,9 +129,9 @@ impl ApiError {
         true
     }
 
-    pub fn on_response(&self, state: &Data<ServerState>) {
+    pub fn on_response(&self, state: &ServerState) {
         if self.is_conflict() {
-            Metrics::from(state.as_ref()).incr("storage.confict")
+            Metrics::from(state).incr("storage.confict")
         }
     }
 

--- a/src/web/middleware/sentry.rs
+++ b/src/web/middleware/sentry.rs
@@ -149,7 +149,7 @@ where
                 Some(e) => {
                     if let Some(apie) = e.as_error::<ApiError>() {
                         if let Some(state) = sresp.request().app_data::<Data<ServerState>>() {
-                            apie.on_response(state);
+                            apie.on_response(state.as_ref());
                         };
                         if !apie.is_reportable() {
                             debug!("Not reporting error to sentry: {:?}", apie);


### PR DESCRIPTION
## Description

* Set grpcio feature `"openssl"` on ubuntu platforms to address seg faulting on startup due to combination of openssl and boringssl.

## Testing

N/A

## Issue(s)

Issue #742