### PR TITLE
bug: set config env separator to double underscore.

### DIFF
--- a/src/settings.rs
+++ b/src/settings.rs
@@ -108,7 +108,12 @@ impl Settings {
         }
 
         // Merge the environment overrides
-        s.merge(Environment::with_prefix(PREFIX))?;
+        // While the prefix is currently case insensitive, it's traditional that
+        // environment vars be UPPERCASE, this ensures that will continue should
+        // Environment ever change their policy about case insensitivity.
+        // This will accept environment variables specified as
+        // `SYNC_FOO__BAR_VALUE="gorp"` as `foo.bar_value = "gorp"`
+        s.merge(Environment::with_prefix(&PREFIX.to_uppercase()).separator("__"))?;
 
         Ok(match s.try_into::<Self>() {
             Ok(s) => {

--- a/src/web/extractors.rs
+++ b/src/web/extractors.rs
@@ -1045,7 +1045,7 @@ impl FromRequest for ConfigRequest {
                 max_request_bytes: data.max_request_bytes,
                 max_total_bytes: data.max_total_bytes,
                 max_total_records: data.max_total_records,
-                debug_client: None,
+                debug_client: data.debug_client.clone(),
             },
         }))
     }


### PR DESCRIPTION
Closes #762

## Description
Passing the default separator of "." can cause problems with some shells. It's better to use something like a double underscrore, which is more widely accepted.

## Testing
run the application, specifying the `limits.max_post_records` set to some value, e.g.
`SYNC_LIMITS__MAX_POST_RECORDS=99 cargo run -- --config sync.ini`

You should now be able to see the "debug_client" value appear in the `/info/configuration` response:
```
> curl http://localhost:8000/1.5/1/info/configuration
{"max_post_bytes":2097152,"max_post_records":99,"max_record_payload_bytes":2097152,"max_request_bytes":2101248,"max_total_bytes":100000000,"max_total_records":10000,"debug_client":"1,123"}
```

## Issue(s)

Closes #762.
