### PR TITLE
wip: Add `cargo tree` to see if openssl is the problem

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,8 @@ RUN \
     cargo --version && \
     rustc --version && \
     cargo install --path . --locked --root /app && \
-    cargo install --path . --bin purge_ttl --locked --root /app
+    cargo install --path . --bin purge_ttl --locked --root /app && \
+    cargo tree -e features -i -p grpcio
 
 FROM debian:buster-slim
 WORKDIR /app


### PR DESCRIPTION
Issue #766

## Description

WIP: This is to test to see if the docker image being pushed to stage has the grpcio "openssl" feature set.

## Testing

look for  "openssl" in the cargo tree result.

## Issue(s)

Issue #766
