### PR TITLE
bug: Return WeaveError::OverQuota for over quota responses

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -147,8 +147,10 @@ impl ApiError {
                     name,
                     ref _tags,
                 ) => {
-                    if description == "size-limit-exceeded" {
-                        return WeaveError::SizeLimitExceeded;
+                    match description.as_ref() {
+                        "over-quota" => return WeaveError::OverQuota,
+                        "size-limit-exceeded" => return WeaveError::SizeLimitExceeded,
+                        _ => {}
                     }
                     let name = name.clone().unwrap_or_else(|| "".to_owned());
                     if *location == RequestErrorLocation::Body

--- a/src/web/extractors.rs
+++ b/src/web/extractors.rs
@@ -255,9 +255,9 @@ impl FromRequest for BsoBodies {
                             error!("Returning over quota for {:?}", v);
                             return Box::pin(future::err(
                                 ValidationErrorKind::FromDetails(
-                                    "size-limit-exceeded".to_owned(),
+                                    "over-quota".to_owned(),
                                     RequestErrorLocation::Unknown,
-                                    Some("size-limit-exceeded".to_owned()),
+                                    Some("over-quota".to_owned()),
                                     None,
                                 )
                                 .into(),
@@ -460,9 +460,9 @@ impl FromRequest for BsoBody {
                             error!("Returning over quota for {:?}", v);
                             return Box::pin(future::err(
                                 ValidationErrorKind::FromDetails(
-                                    "size-limit-exceeded".to_owned(),
+                                    "over-quota".to_owned(),
                                     RequestErrorLocation::Unknown,
-                                    Some("size-limit-exceeded".to_owned()),
+                                    Some("over-quota".to_owned()),
                                     None,
                                 )
                                 .into(),


### PR DESCRIPTION
Closes #769

## Description

We were returning "17", we should return "14"

## Testing

see https://github.com/mozilla-services/syncstorage-rs/pull/751

## Issue(s)

Closes #769.
