### PR TITLE
bug: remove ubuntu target for grpcio 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,9 @@ env_logger = "0.7.1"
 failure = "0.1.8"
 futures = { version = "0.3", features = ["compat"] }
 googleapis-raw = { version = "0", path = "vendor/mozilla-rust-sdk/googleapis-raw" }
+# Some versions of OpenSSL 1.1.1 conflict with grpcio's built-in boringssl which can cause
+# syncserver to either fail to either compile, or start. In those cases, try
+# `cargo build --features grpcio/openssl ...`
 grpcio = { version = "0.6.0" }
 lazy_static = "1.4.0"
 hawk = "3.2"
@@ -67,9 +70,6 @@ uuid = { version = "0.8.1", features = ["serde", "v4"] }
 validator = "0.10"
 validator_derive = "0.10"
 woothee = "0.11"
-
-[target.'cfg(target_vendor="ubuntu")'.dependencies]
-grpcio = { version="0.6", features=["openssl"] }
 
 [dev-dependencies]
 tokio = { version = "0.2", features = ["macros"] }

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ This requires access to the mozilla-rust-sdk which is now available at `/vendor/
 
 ### Connecting to Firefox
 
-This will walk you through the steps to connect this project to your local copy of Firefox. 
+This will walk you through the steps to connect this project to your local copy of Firefox.
 
 1. Follow the steps outlined above for running this project using [MySQL](https://github.com/mozilla-services/syncstorage-rs#mysql).
 
@@ -201,10 +201,12 @@ Open a PR after doing the following:
 
 Once your PR merges, then go ahead and create an official [GitHub release](https://github.com/mozilla-services/syncstorage-rs/releases).
 
-
 ## Troubleshooting
 
 - `rm Cargo.lock; cargo clean;` - Try this if you're having problems compiling.
+
+- Some versions of OpenSSL 1.1.1 can conflict with grpcio's built in BoringSSL. These errors can cause syncstorage to fail to run or compile.
+If you see a problem related to `libssl` you may need to specify the `cargo` option `--features grpcio/openssl`  to force grpcio to use OpenSSL.
 
 ## Related Documentation
 


### PR DESCRIPTION
## Description

removed Cargo's automagic feature detection that was less magical than expected.

Added comment to `.toml` and `README.md` addressing fix resolution for folks that hit the same error that required the feature detection.

## Testing

Does it ~blend~ build and run?

## Issue(s)

Closes #774.
