### PR TITLE
fix: Avoid implicit transactions in DbTransactionPool

### DIFF
--- a/src/db/transaction.rs
+++ b/src/db/transaction.rs
@@ -51,7 +51,7 @@ impl DbTransactionPool {
         let result = match (self.lock_collection.clone(), self.is_read) {
             (Some(lc), true) => db.lock_for_read(lc).await,
             (Some(lc), false) => db.lock_for_write(lc).await,
-            _ => Ok(()),
+            (None, is_read) => db.begin(!is_read).await,
         };
 
         // Handle lock error

--- a/src/web/handlers.rs
+++ b/src/web/handlers.rs
@@ -96,11 +96,6 @@ pub async fn delete_all(
     db_pool
         .transaction_http(|db| async move {
             meta.metrics.incr("request.delete_all");
-            // transaction_http won't implicitly begin a write transaction
-            // for DELETE /storage because it lacks a collection. So it's done
-            // manually here, partly to not further complicate the unit test's
-            // transactions
-            db.begin(true).await?;
             Ok(HttpResponse::Ok().json(db.delete_storage(meta.user_id).await?))
         })
         .await


### PR DESCRIPTION
## Description

 Always create a transaction when using `DbTransactionPool`. This avoids implicit transactions.

## Testing

Not sure how the issue is/was detected, so not sure on testing.

## Issue(s)

Potential fix for #768
