### PR TITLE
Feat/772

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -24,7 +24,7 @@ use serde::{
 use crate::db::error::{DbError, DbErrorKind};
 use crate::server::metrics::Metrics;
 use crate::server::ServerState;
-use crate::web::error::{HawkError, ValidationError, ValidationErrorKind};
+use crate::web::error::{HawkError, HawkErrorKind, ValidationError, ValidationErrorKind};
 use crate::web::extractors::RequestErrorLocation;
 
 /// Legacy Sync 1.1 error codes, which Sync 1.5 also returns by replacing the descriptive JSON
@@ -125,6 +125,11 @@ impl ApiError {
         match self.kind() {
             ApiErrorKind::Db(dbe) => match dbe.kind() {
                 DbErrorKind::Conflict => return false,
+                _ => (),
+            },
+            ApiErrorKind::Hawk(hawke) => match hawke.kind() {
+                HawkErrorKind::MissingHeader => return false,
+                HawkErrorKind::InvalidHeader => return false,
                 _ => (),
             },
             _ => (),

--- a/src/web/error.rs
+++ b/src/web/error.rs
@@ -24,6 +24,12 @@ pub struct HawkError {
     inner: Context<HawkErrorKind>,
 }
 
+impl HawkError {
+    pub fn kind(&self) -> &HawkErrorKind {
+        return self.inner.get_context();
+    }
+}
+
 /// Causes of HAWK errors.
 #[derive(Debug, Fail)]
 pub enum HawkErrorKind {

--- a/src/web/error.rs
+++ b/src/web/error.rs
@@ -26,7 +26,7 @@ pub struct HawkError {
 
 impl HawkError {
     pub fn kind(&self) -> &HawkErrorKind {
-        return self.inner.get_context();
+        self.inner.get_context()
     }
 }
 

--- a/src/web/extractors.rs
+++ b/src/web/extractors.rs
@@ -788,7 +788,7 @@ impl FromRequest for CollectionRequest {
                 "application/json" | "" => ReplyFormat::Json,
                 _ => {
                     return Err(ValidationErrorKind::FromDetails(
-                        "Invalid accept".to_string(),
+                        format!("Invalid Accept header specified: {:?}", accept),
                         RequestErrorLocation::Header,
                         Some("accept".to_string()),
                         Some(tags),


### PR DESCRIPTION
Closes: #771, #772

## Description

* Improve the "invalid archive" error message
* don't report some of the potentially more common HAWK client errors
  (missing header, malformed header, these would happen due to skript kiddies hitting the server)

## Testing

* Verify that requests made with missing or invalid HAWK headers are not reported to Sentry
* Verify that a message with an invalid "Accept" header value (e.g. `foo/bar`) reports to Sentry as "Invalid Accept header specified: foo/bar" *

 * we may want to limit these in the future for the same reason that we drop the missing / invalid HAWK headers, but they may be useful in debugging clients. 


## Issue(s)

Closes #771, #772.
