### PR TITLE
feat: emit internal bb8 Pool errors to logs/sentry

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -76,9 +76,6 @@ pub enum ApiErrorKind {
 
     #[fail(display = "{}", _0)]
     Validation(#[cause] ValidationError),
-
-    #[fail(display = "Invalid Submission: {}", _0)]
-    InvalidSubmission(String),
 }
 
 impl ApiError {
@@ -221,7 +218,6 @@ impl From<Context<ApiErrorKind>> for ApiError {
                 StatusCode::INTERNAL_SERVER_ERROR
             }
             ApiErrorKind::Validation(error) => error.status,
-            ApiErrorKind::InvalidSubmission(_) => StatusCode::BAD_REQUEST,
         };
 
         Self { inner, status }
@@ -275,8 +271,7 @@ impl Serialize for ApiErrorKind {
         match *self {
             ApiErrorKind::Db(ref error) => serialize_string_to_array(serializer, error),
             ApiErrorKind::Hawk(ref error) => serialize_string_to_array(serializer, error),
-            ApiErrorKind::Internal(ref description)
-            | ApiErrorKind::InvalidSubmission(ref description) => {
+            ApiErrorKind::Internal(ref description) => {
                 serialize_string_to_array(serializer, description)
             }
             ApiErrorKind::Validation(ref error) => Serialize::serialize(error, serializer),

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -32,6 +32,8 @@ pub struct Settings {
     #[cfg(test)]
     pub database_use_test_transactions: bool,
 
+    pub actix_keep_alive: Option<u32>,
+
     /// Server-enforced limits for request payloads.
     pub limits: ServerLimits,
 
@@ -57,6 +59,7 @@ impl Default for Settings {
             database_pool_min_idle: None,
             #[cfg(test)]
             database_use_test_transactions: false,
+            actix_keep_alive: None,
             limits: ServerLimits::default(),
             master_secret: Secrets::default(),
             statsd_host: None,

--- a/src/web/middleware/sentry.rs
+++ b/src/web/middleware/sentry.rs
@@ -100,7 +100,6 @@ where
 
     fn call(&mut self, sreq: ServiceRequest) -> Self::Future {
         let mut tags = Tags::from_request_head(sreq.head());
-        let uri = sreq.head().uri.to_string();
         sreq.extensions_mut().insert(tags.clone());
 
         Box::pin(self.service.call(sreq).and_then(move |mut sresp| {
@@ -119,8 +118,6 @@ where
                     tags.tags.insert(k, v);
                 }
             };
-            // add the uri.path (which can cause influx to puke)
-            tags.extra.insert("uri.path".to_owned(), uri);
             match sresp.response().error() {
                 None => {
                     // Middleware errors are eaten by current versions of Actix. Errors are now added


### PR DESCRIPTION
- add a keepalive setting
- fix: don't urldecode bso_ids from JSON
- pass the user-agent to sentry as an extra

Closes #786
Closes #785
Closes #764
Closes #787

## Description

Describe these changes.

## Testing

How should reviewers test?

## Issue(s)

Closes [link](link).
