### PR TITLE
bug: fix purge_ttl advanced features

### DIFF
--- a/tools/spanner/purge_ttl.py
+++ b/tools/spanner/purge_ttl.py
@@ -103,7 +103,11 @@ def spanner_purge(args):
         if args.mode in ["batches", "both"]:
             # Delete Batches. Also deletes child batch_bsos rows (INTERLEAVE
             # IN PARENT batches ON DELETE CASCADE)
-            batch_query = 'DELETE FROM batches WHERE {}'.format(expiry_condition)
+            batch_query = add_conditions(
+                args,
+                'DELETE FROM batches WHERE {}'.format(expiry_condition),
+                prefix,
+            )
             deleter(
                 database,
                 name="batches",

--- a/tools/spanner/purge_ttl.py
+++ b/tools/spanner/purge_ttl.py
@@ -64,11 +64,11 @@ def add_conditions(args, query: str, prefix: Optional[str]):
     :return: The updated SQL query
     """
     if args.collection_ids:
-        ids = list(map(str, filter(len, args.collection_ids)))
-        if len(ids):
+        ids = list(filter(len, args.collection_ids))
+        if ids:
             query += " AND collection_id"
             if len(ids) == 1:
-                query += " = {:d}".format(ids[0])
+                query += " = {}".format(ids[0])
             else:
                 query += " in ({})".format(
                     ', '.join(ids))


### PR DESCRIPTION
## Description

* fix `fxa_uaid` typo
* fix `collection_ids` handler to deal with default empty ids.
* added `--dryrun` option which will NOT delete records from spanner.

## Testing

the `--dryrun` flag will not send the PDML to spanner, so it can be useful for testing.

1) using a command like 
`GOOGLE_APPLICATION_CREDENTIALS=... venv/bin/python purge_ttl.py --dryrun` 

ensure that the output displays an output similar to:

```
...
{"datetime": "2020-08-24 15:19:24,202", "message": "Running: DELETE FROM batches WHERE expiry < TIMESTAMP_TRUNC(CURRENT_TIMESTAMP(), DAY, "UTC")"}
{"datetime": "2020-08-24 15:19:24,202", "message": "batches: removed 0 rows, batches_duration: 0:00:00.000001, prefix: "}
...
```

(note that there is no `REGEXP_CONTAINS` clause and no `collection_id` clause, and no command is run against spanner. This is confirmed by the `removed 0 rows, batches_duration: 0:00:00.000001`)

2) `GOOGLE_APPLICATION_CREDENTIALS=... venv/bin/python purge_ttl.py --dryrun --uid_prefixes="0[0,1,2,3]" --collection_ids=[1,2,3]` 

ensure that the output displays an output similar to:

```
...
{"datetime": "2020-08-24 15:24:02,426", "message": "Running: DELETE FROM batches WHERE expiry < TIMESTAMP_TRUNC(CURRENT_TIMESTAMP(), DAY, "UTC") AND collection_id in (1, 2, 3) AND REGEXP_CONTAINS(fxa_uid, r"0[0,1,2]")"}
{"datetime": "2020-08-24 15:24:02,426", "message": "batches: removed 0 rows, batches_duration: 0:00:00.000001, prefix: 0[0,1,2]"}
{"datetime": "2020-08-24 15:24:02,426", "message": "Running: DELETE FROM bsos WHERE expiry < TIMESTAMP_TRUNC(CURRENT_TIMESTAMP(), DAY, "UTC") AND collection_id in (1, 2, 3) AND REGEXP_CONTAINS(fxa_uid, r"0[0,1,2]")"}
{"datetime": "2020-08-24 15:24:02,426", "message": "bso: removed 0 rows, bso_duration: 0:00:00.000001, prefix: 0[0,1,2]"}
...
```

Note that on the second `DELETE FROM`, the collection_id is present and contains the items noted, and that the `REGEXP_CONTAINS` both contains the correct `fxa_uid` flag as well as the matching regular expression term `0[0,1,2]`

## Issue(s)

Closes #799