### PR TITLE
feat: cleanup the spanner pool managers

### DIFF
--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -57,9 +57,6 @@ pub const FIRST_CUSTOM_COLLECTION_ID: i32 = 101;
 /// Rough guesstimate of the maximum reasonable life span of a batch
 pub const BATCH_LIFETIME: i64 = 2 * 60 * 60 * 1000; // 2 hours, in milliseconds
 
-/// DbPools' worker ThreadPool size
-pub const DB_THREAD_POOL_SIZE: usize = 50;
-
 type DbFuture<'a, T> = LocalBoxFuture<'a, Result<T, ApiError>>;
 
 #[async_trait(?Send)]

--- a/src/db/results.rs
+++ b/src/db/results.rs
@@ -76,33 +76,6 @@ pub struct PoolState {
     pub idle_connections: u32,
 }
 
-impl From<diesel::r2d2::State> for PoolState {
-    fn from(state: diesel::r2d2::State) -> PoolState {
-        PoolState {
-            connections: state.connections,
-            idle_connections: state.idle_connections,
-        }
-    }
-}
-
-impl From<bb8::State> for PoolState {
-    fn from(state: bb8::State) -> PoolState {
-        PoolState {
-            connections: state.connections,
-            idle_connections: state.idle_connections,
-        }
-    }
-}
-
-impl From<deadpool::Status> for PoolState {
-    fn from(status: deadpool::Status) -> PoolState {
-        PoolState {
-            connections: status.size as u32,
-            idle_connections: status.available as u32,
-        }
-    }
-}
-
 #[cfg(test)]
 pub type GetCollectionId = i32;
 

--- a/src/db/spanner/manager/bb8.rs
+++ b/src/db/spanner/manager/bb8.rs
@@ -1,26 +1,25 @@
 use std::marker::PhantomData;
 use std::{fmt, sync::Arc};
 
-use actix_web::web::block;
 use async_trait::async_trait;
-use bb8::ManageConnection;
-use googleapis_raw::spanner::v1::{
-    spanner::{CreateSessionRequest, GetSessionRequest, Session},
-    spanner_grpc::SpannerClient,
-};
-use grpcio::{
-    CallOption, ChannelBuilder, ChannelCredentials, EnvBuilder, Environment, MetadataBuilder,
-};
+use bb8::{ManageConnection, PooledConnection};
+use grpcio::{EnvBuilder, Environment};
 
 use crate::{
-    db::error::{DbError, DbErrorKind},
+    db::{
+        error::{DbError, DbErrorKind},
+        results::PoolState,
+    },
     server::metrics::Metrics,
     settings::Settings,
 };
 
-pub const SPANNER_ADDRESS: &str = "spanner.googleapis.com:443";
+use super::session::{create_spanner_session, recycle_spanner_session, SpannerSession};
 
-pub struct SpannerConnectionManager<T> {
+#[allow(dead_code)]
+pub type Conn<'a> = PooledConnection<'a, SpannerSessionManager<SpannerSession>>;
+
+pub struct SpannerSessionManager<T> {
     database_name: String,
     /// The gRPC environment
     env: Arc<Environment>,
@@ -29,22 +28,22 @@ pub struct SpannerConnectionManager<T> {
     phantom: PhantomData<T>,
 }
 
-impl<_T> fmt::Debug for SpannerConnectionManager<_T> {
+impl<_T> fmt::Debug for SpannerSessionManager<_T> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct("SpannerConnectionManager")
+        fmt.debug_struct("bb8::SpannerSessionManager")
             .field("database_name", &self.database_name)
             .field("test_transactions", &self.test_transactions)
             .finish()
     }
 }
 
-impl<T> SpannerConnectionManager<T> {
+impl<T> SpannerSessionManager<T> {
+    #[allow(dead_code)]
     pub fn new(settings: &Settings, metrics: &Metrics) -> Result<Self, DbError> {
-        let url = &settings.database_url;
-        if !url.starts_with("spanner://") {
-            Err(DbErrorKind::InvalidUrl(url.to_owned()))?;
-        }
-        let database_name = url["spanner://".len()..].to_owned();
+        let database_name = settings
+            .spanner_database_name()
+            .ok_or_else(|| DbErrorKind::InvalidUrl(settings.database_url.to_owned()))?
+            .to_owned();
         let env = Arc::new(EnvBuilder::new().build());
 
         #[cfg(not(test))]
@@ -52,7 +51,7 @@ impl<T> SpannerConnectionManager<T> {
         #[cfg(test)]
         let test_transactions = settings.database_use_test_transactions;
 
-        Ok(SpannerConnectionManager::<T> {
+        Ok(SpannerSessionManager::<T> {
             database_name,
             env,
             metrics: metrics.clone(),
@@ -62,67 +61,23 @@ impl<T> SpannerConnectionManager<T> {
     }
 }
 
-pub struct SpannerSession {
-    pub client: SpannerClient,
-    pub session: Session,
-
-    pub(in crate::db::spanner) use_test_transactions: bool,
-}
-
 #[async_trait]
-impl<T: std::marker::Send + std::marker::Sync + 'static> ManageConnection
-    for SpannerConnectionManager<T>
-{
+impl<T: Send + Sync + 'static> ManageConnection for SpannerSessionManager<T> {
     type Connection = SpannerSession;
     type Error = DbError;
 
     async fn connect(&self) -> Result<Self::Connection, Self::Error> {
-        let env = self.env.clone();
-        let mut metrics = self.metrics.clone();
-        // XXX: issue732: Could google_default_credentials (or
-        // ChannelBuilder::secure_connect) block?!
-        let chan = block(move || -> Result<grpcio::Channel, grpcio::Error> {
-            metrics.start_timer("storage.pool.grpc_auth", None);
-            // Requires
-            // GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
-            let creds = ChannelCredentials::google_default_credentials()?;
-            Ok(ChannelBuilder::new(env)
-                .max_send_message_len(100 << 20)
-                .max_receive_message_len(100 << 20)
-                .secure_connect(SPANNER_ADDRESS, creds))
-        })
+        create_spanner_session(
+            Arc::clone(&self.env),
+            self.metrics.clone(),
+            &self.database_name,
+            self.test_transactions,
+        )
         .await
-        .map_err(|e| match e {
-            actix_web::error::BlockingError::Error(e) => e.into(),
-            actix_web::error::BlockingError::Canceled => {
-                DbError::internal("web::block Manager operation canceled")
-            }
-        })?;
-        let client = SpannerClient::new(chan);
-
-        // Connect to the instance and create a Spanner session.
-        let session = create_session(&client, &self.database_name).await?;
-
-        Ok(SpannerSession {
-            client,
-            session,
-            use_test_transactions: self.test_transactions,
-        })
     }
 
     async fn is_valid(&self, mut conn: Self::Connection) -> Result<Self::Connection, Self::Error> {
-        let mut req = GetSessionRequest::new();
-        req.set_name(conn.session.get_name().to_owned());
-        if let Err(e) = conn.client.get_session_async(&req)?.await {
-            match e {
-                grpcio::Error::RpcFailure(ref status)
-                    if status.status == grpcio::RpcStatusCode::NOT_FOUND =>
-                {
-                    conn.session = create_session(&conn.client, &self.database_name).await?;
-                }
-                _ => return Err(e.into()),
-            }
-        }
+        recycle_spanner_session(&mut conn, &self.database_name).await?;
         Ok(conn)
     }
 
@@ -131,15 +86,11 @@ impl<T: std::marker::Send + std::marker::Sync + 'static> ManageConnection
     }
 }
 
-pub async fn create_session(
-    client: &SpannerClient,
-    database_name: &str,
-) -> Result<Session, grpcio::Error> {
-    let mut req = CreateSessionRequest::new();
-    req.database = database_name.to_owned();
-    let mut meta = MetadataBuilder::new();
-    meta.add_str("google-cloud-resource-prefix", database_name)?;
-    meta.add_str("x-goog-api-client", "gcp-grpc-rs")?;
-    let opt = CallOption::default().headers(meta.build());
-    client.create_session_async_opt(&req, opt)?.await
+impl From<bb8::State> for PoolState {
+    fn from(state: bb8::State) -> PoolState {
+        PoolState {
+            connections: state.connections,
+            idle_connections: state.idle_connections,
+        }
+    }
 }

--- a/src/db/spanner/manager/mod.rs
+++ b/src/db/spanner/manager/mod.rs
@@ -1,2 +1,6 @@
-pub mod bb8;
-pub mod deadpool;
+mod bb8;
+mod deadpool;
+mod session;
+
+pub use self::deadpool::{Conn, SpannerSessionManager};
+pub use self::session::SpannerSession;

--- a/src/db/spanner/manager/session.rs
+++ b/src/db/spanner/manager/session.rs
@@ -1,0 +1,93 @@
+use actix_web::web::block;
+use googleapis_raw::spanner::v1::{
+    spanner::{CreateSessionRequest, GetSessionRequest, Session},
+    spanner_grpc::SpannerClient,
+};
+use grpcio::{CallOption, ChannelBuilder, ChannelCredentials, Environment, MetadataBuilder};
+use std::sync::Arc;
+
+use crate::{db::error::DbError, server::metrics::Metrics};
+
+const SPANNER_ADDRESS: &str = "spanner.googleapis.com:443";
+
+/// Represents a communication channel w/ Spanner
+///
+/// Session creation is expensive in Spanner so sessions should be long-lived
+/// and cached for reuse.
+pub struct SpannerSession {
+    pub session: Session,
+    /// The underlying client (Connection/Channel) for interacting with spanner
+    pub client: SpannerClient,
+    pub(in crate::db::spanner) use_test_transactions: bool,
+}
+
+/// Create a Session (and the underlying gRPC Channel)
+pub async fn create_spanner_session(
+    env: Arc<Environment>,
+    mut metrics: Metrics,
+    database_name: &str,
+    use_test_transactions: bool,
+) -> Result<SpannerSession, DbError> {
+    // XXX: issue732: Could google_default_credentials (or
+    // ChannelBuilder::secure_connect) block?!
+    let chan = block(move || -> Result<grpcio::Channel, grpcio::Error> {
+        metrics.start_timer("storage.pool.grpc_auth", None);
+        // Requires
+        // GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
+        let creds = ChannelCredentials::google_default_credentials()?;
+        Ok(ChannelBuilder::new(env)
+            .max_send_message_len(100 << 20)
+            .max_receive_message_len(100 << 20)
+            .secure_connect(SPANNER_ADDRESS, creds))
+    })
+    .await
+    .map_err(|e| match e {
+        actix_web::error::BlockingError::Error(e) => e.into(),
+        actix_web::error::BlockingError::Canceled => {
+            DbError::internal("web::block Manager operation canceled")
+        }
+    })?;
+    let client = SpannerClient::new(chan);
+
+    // Connect to the instance and create a Spanner session.
+    let session = create_session(&client, database_name).await?;
+
+    Ok(SpannerSession {
+        session,
+        client,
+        use_test_transactions,
+    })
+}
+
+/// Recycle a cached Session for reuse
+pub async fn recycle_spanner_session(
+    conn: &mut SpannerSession,
+    database_name: &str,
+) -> Result<(), DbError> {
+    let mut req = GetSessionRequest::new();
+    req.set_name(conn.session.get_name().to_owned());
+    if let Err(e) = conn.client.get_session_async(&req)?.await {
+        match e {
+            grpcio::Error::RpcFailure(ref status)
+                if status.status == grpcio::RpcStatusCode::NOT_FOUND =>
+            {
+                conn.session = create_session(&conn.client, database_name).await?;
+            }
+            _ => return Err(e.into()),
+        }
+    }
+    Ok(())
+}
+
+async fn create_session(
+    client: &SpannerClient,
+    database_name: &str,
+) -> Result<Session, grpcio::Error> {
+    let mut req = CreateSessionRequest::new();
+    req.database = database_name.to_owned();
+    let mut meta = MetadataBuilder::new();
+    meta.add_str("google-cloud-resource-prefix", database_name)?;
+    meta.add_str("x-goog-api-client", "gcp-grpc-rs")?;
+    let opt = CallOption::default().headers(meta.build());
+    client.create_session_async_opt(&req, opt)?.await
+}

--- a/src/db/spanner/models.rs
+++ b/src/db/spanner/models.rs
@@ -35,10 +35,9 @@ use super::{
     batch,
     pool::{CollectionCache, Conn},
     support::{
-        as_list_value, as_type, as_value, bso_from_row, ExecuteSqlRequestBuilder,
-        StreamedResultSetAsync,
+        as_list_value, as_type, as_value, bso_from_row, bso_to_insert_row, bso_to_update_row,
+        ExecuteSqlRequestBuilder, StreamedResultSetAsync,
     },
-    support::{bso_to_insert_row, bso_to_update_row},
 };
 
 #[derive(Debug, Eq, PartialEq)]

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -28,6 +28,7 @@ pub struct Settings {
     pub host: String,
     pub database_url: String,
     pub database_pool_max_size: Option<u32>,
+    // NOTE: Not supported by deadpool!
     pub database_pool_min_idle: Option<u32>,
     #[cfg(test)]
     pub database_use_test_transactions: bool,
@@ -163,7 +164,15 @@ impl Settings {
     }
 
     pub fn uses_spanner(&self) -> bool {
-        self.database_url.as_str().starts_with("spanner")
+        self.database_url.as_str().starts_with("spanner://")
+    }
+
+    pub fn spanner_database_name(&self) -> Option<&str> {
+        if !self.uses_spanner() {
+            None
+        } else {
+            Some(&self.database_url["spanner://".len()..])
+        }
     }
 
     /// A simple banner for display of certain settings at startup

--- a/src/web/extractors.rs
+++ b/src/web/extractors.rs
@@ -38,9 +38,6 @@ use crate::web::{
     X_WEAVE_RECORDS,
 };
 
-#[cfg(test)]
-use crate::db::Db;
-
 const BATCH_MAX_IDS: usize = 100;
 
 // BSO const restrictions
@@ -1798,7 +1795,10 @@ mod tests {
     use serde_json::{self, json};
     use sha2::Sha256;
 
-    use crate::db::mock::{MockDb, MockDbPool};
+    use crate::db::{
+        mock::{MockDb, MockDbPool},
+        Db,
+    };
     use crate::server::{metrics, ServerState};
     use crate::settings::{Secrets, ServerLimits, Settings};
 


### PR DESCRIPTION
## Description

- ignore deadpool's Status::available negative values for PoolState
- kill no longer used DB_THREAD_POOL_SIZE

## Testing

Stage load testing

## Issue(s)

Closes #794


You can review the deadpool change in its entirety (this commit and the previous) here: https://github.com/mozilla-services/syncstorage-rs/compare/7e526cb83...feat/794