### PR TITLE
feat: Convert some of the validation storage errors into metrics

### DIFF
--- a/src/web/auth.rs
+++ b/src/web/auth.rs
@@ -175,6 +175,7 @@ impl HawkPayload {
                     RequestErrorLocation::Header,
                     None,
                     tags,
+                    None,
                 )
             })?
         } else if ci.scheme() == "https" {

--- a/src/web/middleware/db.rs
+++ b/src/web/middleware/db.rs
@@ -176,6 +176,9 @@ where
                 if apie.is_reportable() {
                     report(&tags, sentry::integrations::failure::event_from_fail(&apie));
                 } else {
+                    if let Some(label) = apie.metric_label {
+                        state.metrics.incr_with_tags(apie.metric_label, tags);
+                    }
                     debug!("Not reporting error: {:?}", apie);
                 }
                 return Err(apie.into());


### PR DESCRIPTION
Closes #808

## Description

Added new field to Errors to indicate the metric name. If present (and in a non-reportable error) will not report a given error to Sentry, but will instead increment a metric associated with that metric name.

## Testing

When testing against stage or dev, notice the reduced number of reported error into sentry and the increased number of metric reports. See [spreadsheet](https://docs.google.com/spreadsheets/d/18RL-Brz-Q-jR-iClNPCwDMVPYS0P2CvkHSJ2WZK-ceA/edit#gid=419074517) under "Silence Errors" for new metric names and categories.

## Issue(s)

Closes #808.
