### PR TITLE
Fix #811 Document use_test_transactions and expose it using an environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,23 @@ We use [env_logger](https://crates.io/crates/env_logger): set the `RUST_LOG` env
 
 `make test` - open the Makefile to adjust your `SYNC_DATABASE_URL` as needed.
 
+#### Debugging unit test state
+
+In some cases, it is useful to inspect the mysql state of a failed test. By
+default, we use the diesel test_transaction functionality to ensure test data
+is not committed to the database. Therefore, there is an environment variable
+which can be used to turn off test_transaction.
+
+        SYNC_DATABASE_USE_TEST_TRANSACTIONS=false cargo test [testname]
+
+Note that you will almost certainly want to pass a single test name. When running
+the entire test suite, data from previous tests will cause future tests to fail.
+
+To reset the database state between test runs, drop and recreate the database
+in the mysql client:
+
+        drop database syncstorage_rs; create database syncstorage_rs; use syncstorage_rs;
+
 ### End-to-End tests
 
 Functional tests live in [server-syncstorage](https://github.com/mozilla-services/server-syncstorage/) and can be run against a local server, e.g.:

--- a/src/db/tests/support.rs
+++ b/src/db/tests/support.rs
@@ -19,7 +19,7 @@ pub async fn db_pool() -> Result<Box<dyn DbPool>> {
     // the env var because we can't rely on the default value or the env
     // var passed through to settings.
     let use_test_transactions = std::env::var("SYNC_DATABASE_USE_TEST_TRANSACTIONS")
-        .unwrap_or("true".to_string())
+        .unwrap_or_else(|_| "true".to_string())
         .eq("true");
 
     // inherit SYNC_DATABASE_URL from the env

--- a/src/db/tests/support.rs
+++ b/src/db/tests/support.rs
@@ -18,9 +18,9 @@ pub async fn db_pool() -> Result<Box<dyn DbPool>> {
     // but we want the mysql default to be true, so let's check explicitly
     // the env var because we can't rely on the default value or the env
     // var passed through to settings.
-    let use_test_transactions = std::env::var(
-        "SYNC_DATABASE_USE_TEST_TRANSACTIONS"
-    ).unwrap_or("true".to_string()).eq("true");
+    let use_test_transactions = std::env::var("SYNC_DATABASE_USE_TEST_TRANSACTIONS")
+        .unwrap_or("true".to_string())
+        .eq("true");
 
     // inherit SYNC_DATABASE_URL from the env
     let settings = Settings::with_env_and_config_file(&None).unwrap();

--- a/src/db/tests/support.rs
+++ b/src/db/tests/support.rs
@@ -14,6 +14,14 @@ pub type Result<T> = std::result::Result<T, ApiError>;
 
 pub async fn db_pool() -> Result<Box<dyn DbPool>> {
     let _ = env_logger::try_init();
+    // The default for SYNC_DATABASE_USE_TEST_TRANSACTIONS is false,
+    // but we want the mysql default to be true, so let's check explicitly
+    // the env var because we can't rely on the default value or the env
+    // var passed through to settings.
+    let use_test_transactions = std::env::var(
+        "SYNC_DATABASE_USE_TEST_TRANSACTIONS"
+    ).unwrap_or("true".to_string()).eq("true");
+
     // inherit SYNC_DATABASE_URL from the env
     let settings = Settings::with_env_and_config_file(&None).unwrap();
     let settings = Settings {
@@ -22,7 +30,7 @@ pub async fn db_pool() -> Result<Box<dyn DbPool>> {
         host: settings.host,
         database_url: settings.database_url,
         database_pool_max_size: Some(1),
-        database_use_test_transactions: true,
+        database_use_test_transactions: use_test_transactions,
         limits: ServerLimits::default(),
         master_secret: Secrets::default(),
         ..Default::default()


### PR DESCRIPTION
## Description

Normally, when running cargo test, the test transaction data is discarded. This makes debugging test state difficult. There is a use_test_transactions setting that can be overridden, but the tests then re-override your decision to force them on.

This branch exposes the variable using the SYNC_DATABASE_USE_TEST_TRANSACTIONS environment variable.

Also, it documents how to use this feature.

## Testing

All tests should pass.

Running `SYNC_DATABASE_USE_TEST_TRANSACTIONS=false cargo test commit` should leave data in the mysql database.

Running `cargo test commit` should not leave anything in the database, as usual.

## Issue(s)

Closes https://github.com/mozilla-services/syncstorage-rs/issues/811
