### PR TITLE
bugfix: the python spanner utils image needs a version.json

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -216,6 +216,7 @@ jobs:
     steps:
       - setup_remote_docker
       - checkout
+      - write-version
       - run:
           name: Build and deploy to Dockerhub
           command: |


### PR DESCRIPTION
## Description

Dockerflow automation expects a version.json file

## Testing

Deploy new image via automation

