### PR TITLE
chore: tag 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+<a name="0.6.0"></a>
+## 0.6.0 (2020-09-23)
+
+#### Features
+*   Add quota monitoring (#806) ([9e6759e](https://github.com/mozilla-services/syncstorage-rs/commit/9e6759efef8f163355ee1b23dc28b716335df66d), closes [#791](https://github.com/mozilla-services/syncstorage-rs/issues/791), [#793](https://github.com/mozilla-services/syncstorage-rs/issues/793), [#797](https://github.com/mozilla-services/syncstorage-rs/issues/797), [#789](https://github.com/mozilla-services/syncstorage-rs/issues/789), [#801](https://github.com/mozilla-services/syncstorage-rs/issues/801))
+*   Convert some of the validation storage errors into metrics (#810) ([66221d8b](https://github.com/mozilla-services/syncstorage-rs/commit/66221d8bec17f6134dee1b9d9005f5cdbe8121d3), closes [#795](https://github.com/mozilla-services/syncstorage-rs/issues/795))
+*   switch from `regex_contains` to `starts_with` (#805) ([a79f8407](https://github.com/mozilla-services/syncstorage-rs/commit/a79f8407de7b5f01413b09771dcfa8bb8e33ab9e))
+
+
+
 <a name="0.5.8"></a>
 ## 0.5.8 (2020-08-25)
 
@@ -575,6 +585,3 @@
 #### Features
 
 *   Initial release
-
-
-

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,9 +516,9 @@ dependencies = [
 
 [[package]]
 name = "cadence"
-version = "0.20.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c57523ff87f22fc96f07f5f379af387fdd86009242a17d805a3278540cde94a"
+checksum = "e45b9cdf75cdddb0877f8af74c345d06b0c8a924c5115d2467d94d7e4bdf9180"
 dependencies = [
  "crossbeam-channel",
 ]
@@ -2753,7 +2753,7 @@ dependencies = [
 
 [[package]]
 name = "syncstorage"
-version = "0.5.8"
+version = "0.6.0"
 dependencies = [
  "actix-cors",
  "actix-http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syncstorage"
-version = "0.5.8"
+version = "0.6.0"
 license = "MPL-2.0"
 authors = [
   "Ben Bangert <ben@groovie.org>",
@@ -23,7 +23,7 @@ async-trait = "0.1.40"
 base64 = "0.12"
 bb8 = "0.4.1"
 bytes = "0.5"
-cadence = "0.20.0"
+cadence = "0.21.1"
 chrono = "0.4"
 config = "0.10"
 deadpool = "0.5.2"


### PR DESCRIPTION
## Description

#### Features
*   Add quota monitoring (#806) ([9e6759e](https://github.com/mozilla-services/syncstorage-rs/commit/9e6759efef8f163355ee1b23dc28b716335df66d), closes [#791](https://github.com/mozilla-services/syncstorage-rs/issues/791), [#793](https://github.com/mozilla-services/syncstorage-rs/issues/793), [#797](https://github.com/mozilla-services/syncstorage-rs/issues/797), [#789](https://github.com/mozilla-services/syncstorage-rs/issues/789), [#801](https://github.com/mozilla-services/syncstorage-rs/issues/801))
*   Convert some of the validation storage errors into metrics (#810) ([66221d8b](https://github.com/mozilla-services/syncstorage-rs/commit/66221d8bec17f6134dee1b9d9005f5cdbe8121d3), closes [#795](https://github.com/mozilla-services/syncstorage-rs/issues/795))
*   switch from `regex_contains` to `starts_with` (#805) ([a79f8407](https://github.com/mozilla-services/syncstorage-rs/commit/a79f8407de7b5f01413b09771dcfa8bb8e33ab9e))

***DEPLOYMENT NOTE!***
This release ships with quota monitoring disabled. 
Enabling quota will require a modification to the `user_collections` table:
```sql
alter table user_collections add column (total_bytes bigint, count int);
```
This is included in `migrations/2020-08-24-091401_add_quota`. 

You will also need to specify `SYNC_ENABLE_QUOTA=1` in the run time environment.
## Testing

This release is for load testing in the STAGE environment.