### PR TITLE
bug: Disable quota check for mysql/stand-alone servers

### DIFF
--- a/src/db/spanner/batch.rs
+++ b/src/db/spanner/batch.rs
@@ -302,9 +302,11 @@ pub async fn do_append_async(
         })
         .collect();
 
-    if let Some(size) = batch.size {
-        if size + running_size >= (db.quota as usize) {
-            return Err(db.quota_error(collection));
+    if db.quota_enabled {
+        if let Some(size) = batch.size {
+            if size + running_size >= (db.quota as usize) {
+                return Err(db.quota_error(collection));
+            }
         }
     }
     let mut list_values = ListValue::new();

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -149,6 +149,9 @@ impl Settings {
                             env::set_var("ACTIX_THREADPOOL", database_pool_max_size.to_string());
                         }
                     }
+                    // No quotas for stand alone servers
+                    s.limits.max_quota_limit = 0;
+                    s.enable_quota = false;
                 }
                 if s.limits.max_quota_limit == 0 {
                     s.enable_quota = false


### PR DESCRIPTION
Closes #829

## Description

Do not enforce quota on MySQL DB users, since quotas aren't really required there. 

Also safeguard the quota size check in the spanner `do_append_sync()`.

## Testing

Tests included.

## Issue(s)

Closes #829.
