### PR TITLE
bug: return correct error code and value for OverQuota users

### DIFF
--- a/src/db/error.rs
+++ b/src/db/error.rs
@@ -79,6 +79,7 @@ impl From<Context<DbErrorKind>> for DbError {
             //  * desktop bug: https://bugzilla.mozilla.org/show_bug.cgi?id=959034
             //  * android bug: https://bugzilla.mozilla.org/show_bug.cgi?id=959032
             DbErrorKind::Conflict => StatusCode::SERVICE_UNAVAILABLE,
+            DbErrorKind::Quota => StatusCode::FORBIDDEN,
             _ => StatusCode::INTERNAL_SERVER_ERROR,
         };
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -142,7 +142,6 @@ impl ApiError {
     }
 
     fn weave_error_code(&self) -> WeaveError {
-        dbg!("### self.kind", self.kind());
         match self.kind() {
             ApiErrorKind::Validation(ver) => match ver.kind() {
                 ValidationErrorKind::FromDetails(

--- a/src/error.rs
+++ b/src/error.rs
@@ -142,6 +142,7 @@ impl ApiError {
     }
 
     fn weave_error_code(&self) -> WeaveError {
+        dbg!("### self.kind", self.kind());
         match self.kind() {
             ApiErrorKind::Validation(ver) => match ver.kind() {
                 ValidationErrorKind::FromDetails(
@@ -176,6 +177,10 @@ impl ApiError {
                         WeaveError::UnknownError
                     }
                 }
+            },
+            ApiErrorKind::Db(dber) => match dber.kind() {
+                DbErrorKind::Quota => WeaveError::OverQuota,
+                _ => WeaveError::UnknownError,
             },
             _ => WeaveError::UnknownError,
         }


### PR DESCRIPTION
Closes #836

## Description
Return status 403 (weave error "14") for users that trigger the Quota limits.

## Testing

Start a server with 

```
SYNC_LIMITS__MAX_QUOTA_LIMIT=10 SYNC_ENABLE_QUOTA=1  ...
```
you can then use a script similar to the one in `tools/examples/put.bash` (mind that the value of `SYNC_MASTER_SECRET` matches whatever you're using for the sync server). Since that script attempts to put more than 10 bytes* it should fail with the correct statuscode and body.

* this script may need to be run a second time if the database is empty.

## Issue(s)

Closes #836 .
