### PR TITLE
Add libmysqlclient dependency solution for Debian

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Mozilla Sync Storage built with [Rust](https://rust-lang.org).
 - pkg-config
 - [Rust stable](https://rustup.rs)
 - MySQL 5.7 (or compatible)
-  * libmysqlclient (`brew install mysql` on macOS, `apt install libmysqlclient-dev` on Ubuntu)
+  * libmysqlclient (`brew install mysql` on macOS, `apt install libmysqlclient-dev` on Ubuntu, `apt install libmariadb-dev-compat` on Debian)
 
 Depending on your OS, you may also need to install `libgrpcdev`,
 and `protobuf-compiler-grpc`. *Note*: if the code complies cleanly,


### PR DESCRIPTION
## Description

On Debian, there is not `libmysqlclient` available since Stretch. Debian has fully migrated to MariaDB as replacement. There is a `libmariadb-dev` package, which ships `libmariadbclient.so`, but this is currently not accepted by the `migrations_macros` compilation step. A simple solution is the available compat package: https://packages.debian.org/libmariadb-dev-compat

## Testing

`cd syncstorage-rs && cargo run` on any distro using the Debian APT repository from Stretch up.