### PR TITLE
fix: downgrade sentry to 0.19

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1431,9 +1431,9 @@ checksum = "c3360c7b59e5ffa2653671fb74b4741a5d343c03f331c0a4aeda42b5c2b0ec7d"
 
 [[package]]
 name = "im"
-version = "15.0.0"
+version = "14.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "111c1983f3c5bb72732df25cddacee9b546d08325fb584b5ebd38148be7b0246"
+checksum = "696059c87b83c5a258817ecd67c3af915e3ed141891fc35a1e79908801cf0ce7"
 dependencies = [
  "bitmaps",
  "rand_core",
@@ -2349,9 +2349,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "sentry"
-version = "0.20.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "988392b52bbddd922f13f687fd1584de9c8287d5b6cd9971fcec388b3f487a41"
+checksum = "ebd0927ec4a785fc4328abe9089afbe074b3874983b3373fc328a73a9f8310cb"
 dependencies = [
  "curl",
  "httpdate",
@@ -2366,9 +2366,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-backtrace"
-version = "0.20.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1d7da134c78b9719fbc73cebf747acf70fbc3a188eb76bd244fbd380d7ab3a8"
+checksum = "4585422b92435a04569441aef8dc3417eb9d7547fd591b67fdf6fdfe204232c9"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -2378,9 +2378,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-contexts"
-version = "0.20.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61f3e76fc9c05a90770510dc33daca8baf18aceda51a89cf07cb3d017a33e541"
+checksum = "d607b3be0593e026f1c089f0086c244429fe3026eca8e075e8f9e834703ee4c0"
 dependencies = [
  "hostname",
  "lazy_static",
@@ -2393,23 +2393,21 @@ dependencies = [
 
 [[package]]
 name = "sentry-core"
-version = "0.20.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2a839291a13e464a77a93cf3f54033b22774335f674203368ae3c76da7d3cbf"
+checksum = "c9c118347dc0958e66f8b0f3866f0d85bbf8a63bffe64603baebe3f989e929e6"
 dependencies = [
  "im",
  "lazy_static",
  "rand",
  "sentry-types",
- "serde 1.0.115",
- "serde_json",
 ]
 
 [[package]]
 name = "sentry-failure"
-version = "0.20.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2535d9fb479618f181d292b7c3b89776f3db94508d4ff7ae275367f6466b196a"
+checksum = "8599d375040329e106653a133a1d876af53df8b504cff1de7b6f4471fd41eec3"
 dependencies = [
  "failure",
  "sentry-backtrace",
@@ -2418,9 +2416,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-panic"
-version = "0.20.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78f59e4c9fde8d9fcccda14ed224297c3348fd26be3981d4b68781f18267441e"
+checksum = "e3943c3fc7fff39244158b625bb2235a27e7e4d0b862b5e52cb57db51e6a6e6e"
 dependencies = [
  "sentry-backtrace",
  "sentry-core",
@@ -2428,9 +2426,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-types"
-version = "0.20.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd8dc70f9b36527e6a4c945d72ec30b0ea5d885d05b6633e027a74dc82abd404"
+checksum = "87b41bac48a3586249431fa9efb88cd1414c3455117eb57c02f5bda9634e158d"
 dependencies = [
  "chrono",
  "debugid",
@@ -2562,9 +2560,9 @@ dependencies = [
 
 [[package]]
 name = "sized-chunks"
-version = "0.6.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec31ceca5644fa6d444cc77548b88b67f46db6f7c71683b0f9336e671830d2f"
+checksum = "d59044ea371ad781ff976f7b06480b9f0180e834eda94114f2afb4afc12b7718"
 dependencies = [
  "bitmaps",
  "typenum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ num_cpus = "1"
 protobuf = "2.17.0"
 rand = "0.7"
 regex = "1.3"
-sentry = { version = "0.20", features = ["with_curl_transport"] }
+sentry = { version = "0.19", features = ["with_curl_transport"] }
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = { version = "1.0", features = ["arbitrary_precision"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,8 +2,7 @@
 #[macro_use]
 extern crate slog_scope;
 
-use std::error::Error;
-use std::sync::Arc;
+use std::{error::Error, sync::Arc};
 
 use docopt::Docopt;
 use serde_derive::Deserialize;
@@ -36,11 +35,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // Avoid its default reqwest transport for now due to issues w/
     // likely grpcio's boringssl
     let curl_transport_factory = |options: &sentry::ClientOptions| {
-        // Note: set options.debug = true when diagnosing sentry issues.
         Arc::new(sentry::transports::CurlHttpTransport::new(&options))
             as Arc<dyn sentry::internals::Transport>
     };
     let _sentry = sentry::init(sentry::ClientOptions {
+        // Note: set "debug: true," to diagnose sentry issues
         transport: Some(Arc::new(curl_transport_factory)),
         release: sentry::release_name!(),
         ..sentry::ClientOptions::default()


### PR DESCRIPTION
## Description

0.20.x fails to emit any events (maybe a CurlHttpTransport issue?)

## Testing

Ensure hitting the `/__error__` endpoint emits an event

## Issue(s)

Issue #846
