### PR TITLE
fix: clippy error related to matches!

### DIFF
--- a/src/db/tests/batch.rs
+++ b/src/db/tests/batch.rs
@@ -87,10 +87,7 @@ async fn expiry() -> Result<()> {
     let bsos = vec![postbso("b0", Some("payload 0"), Some(10), None)];
     let result = db.append_to_batch(ab(uid, coll, new_batch, bsos)).await;
     let is_batch_not_found = match result.unwrap_err().kind() {
-        ApiErrorKind::Db(dbe) => match dbe.kind() {
-            DbErrorKind::BatchNotFound => true,
-            _ => false,
-        },
+        ApiErrorKind::Db(dbe) => matches!(dbe.kind(), DbErrorKind::BatchNotFound),
         _ => false,
     };
     assert!(is_batch_not_found, "Expected BatchNotFound");

--- a/src/db/transaction.rs
+++ b/src/db/transaction.rs
@@ -221,10 +221,7 @@ impl FromRequest for DbTransactionPool {
             let bso = BsoParam::extrude(req.head(), &mut req.extensions_mut()).ok();
             let bso_opt = bso.map(|b| b.bso);
 
-            let is_read = match method {
-                Method::GET | Method::HEAD => true,
-                _ => false,
-            };
+            let is_read = matches!(method, Method::GET | Method::HEAD);
             let precondition = PreConditionHeaderOpt::extrude(&req.headers(), Some(tags.clone()))?;
             let pool = Self {
                 pool: state.db_pool.clone(),


### PR DESCRIPTION
## Description

I just merged a PR and noticed failing builds due to a clippy error (guessing due to timing around today's stable rust release). Fixed.

## Testing

Doublecheck I didn't do anything silly as I'm not really much of a Rustacean :)

You could also run `cargo clippy --all --all-targets --all-features -- -D warnings` (which is what's run in CI) in this branch to see no more errors. Vs in master; see errors.

## Issue(s)

Closes [#850](https://github.com/mozilla-services/syncstorage-rs/issues/850).
