### PR TITLE
chore: tag 0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+<a name="0.7.1"></a>
+## 0.7.1 (2020-10-19)
+
+
+#### Bug Fixes
+
+*   correct quota env var in config test to SYNC_ENABLE_QUOTA (#859) ([f0aa4642](https://github.com/mozilla-services/syncstorage-rs/commit/f0aa4642b13a9e4d687707940959cc181e6f750d), closes [#829](https://github.com/mozilla-services/syncstorage-rs/issues/829))
+* rework error logging/metric reporting; fix BSO batch updates for spanner (#174, #619, #618) ([cef8fb521](https://github.com/mozilla-services/syncstorage-rs/commit/cef8fb521ad3239f5ecf356468715ca8341e7f73), closes [#174](https://github.com/mozilla-services/syncstorage-rs/issues/174), [#619](https://github.com/mozilla-services/syncstorage-rs/issues/619), [#618](https://github.com/mozilla-services/syncstorage-rs/issues/618))
+
+
+
 <a name="0.7.0"></a>
 ## 0.7.0 (2020-10-12)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2789,7 +2789,7 @@ dependencies = [
 
 [[package]]
 name = "syncstorage"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "actix-cors",
  "actix-http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syncstorage"
-version = "0.7.0"
+version = "0.7.1"
 license = "MPL-2.0"
 authors = [
   "Ben Bangert <ben@groovie.org>",


### PR DESCRIPTION
## Description

Tagging 0.7.1 for release tomorrow.

## Testing

I ran into some wonkiness when running `clog`. Specifically ran `clog -C CHANGELOG.md -p` - it looks like it picked up everything that's not been made an official GH release since 0.6.0...so I went and manually added what's changed post [0.7.0](https://github.com/mozilla-services/syncstorage-rs/releases/tag/0.7.0). Double check, make sure I didn't miss anything?

## Issue(s)

N/A
