### PR TITLE
fix: avoid extra quota related work in batch commit 

### DIFF
--- a/spanner_config.ini
+++ b/spanner_config.ini
@@ -1,2 +1,2 @@
-# Temp limit on the number of incoming records (See issue #298/#333)
-limits.max_total_records=1666
+# Limit the number of incoming records (See issue #298/#333/#869)
+limits.max_total_records=1664

--- a/src/db/params.rs
+++ b/src/db/params.rs
@@ -67,6 +67,7 @@ collection_data! {
     },
     PostBsos {
         bsos: Vec<PostCollectionBso>,
+        for_batch: bool,
         failed: HashMap<String, String>,
     },
 

--- a/src/db/spanner/BATCH_COMMIT.txt
+++ b/src/db/spanner/BATCH_COMMIT.txt
@@ -30,7 +30,7 @@ The batch commit mutations are as follows:
 - Possibly direct inserts via post_bsos (but these only reduce total mutations
   by avoiding writing to the batch table, so not included here)
 
-- Write 1666 (MAX_TOTAL_RECORDS) to `bsos`: max 19992 (1666 * 12) mutations
+- Write 1664 (MAX_TOTAL_RECORDS) to `bsos`: max 19968 (1664 * 12) mutations
   - INSERT takes 10 mutations:
     - 4 key columns
     - 4 non key columns
@@ -52,7 +52,7 @@ The batch commit mutations are as follows:
 
 Totals:
 - quota: False
-  4 + 19992 + 1 = 19997
+  4 + 19968 + 1 = 19973
 
 - quota: True
-  6 + 19992 + 1 + 6 = 20005!
+  6 + 19968 + 1 + 6 = 19981

--- a/src/db/spanner/BATCH_COMMIT.txt
+++ b/src/db/spanner/BATCH_COMMIT.txt
@@ -1,0 +1,58 @@
+Batches serve as a temporary storage for POST'd bsos. Committing a batch
+entails moving the bsos from the batch table to their final destination in the
+`bsos` table.
+
+The move operation is like an UPSERT: the bsos in the batch will either be
+INSERT'd into the `bsos` table or UPDATE'd if they already exist. Only columns
+with NON NULL values in the batch table will be UPDATE'd in the `bsos` table:
+those with NULL values won't be touched. When INSERTing bsos, columns with NULL
+values recieve defaults.
+
+The entire move (batch commit) happens in one single transaction. Spanner
+limits the number of writes (or "mutations") within a transaction to 20000
+total mutations. A mutation is a write to an individual column. Any writes
+requiring modifications to secondary indices also incur additional mutations.
+DELETEs are generally cheaper (incurring one mutation per DELETE, not including
+secondary indices).
+
+The batch commit mutations are as follows:
+
+- Ensure a parent record exists in `user_collections` (due to bsos INTERLEAVE
+  IN PARENT `user_collections`): 4 mutations (quota: False) or 6 mutations
+  (quota: True)
+  - INSERT or UPDATE:
+    - 3 key columns
+    - quota: False
+      - 1 non key column
+    - quota: True
+      - 3 non key columns
+
+- Possibly direct inserts via post_bsos (but these only reduce total mutations
+  by avoiding writing to the batch table, so not included here)
+
+- Write 1666 (MAX_TOTAL_RECORDS) to `bsos`: max 19992 (1666 * 12) mutations
+  - INSERT takes 10 mutations:
+    - 4 key columns
+    - 4 non key columns
+    - INSERT into 2 secondary indices: 2 mutations
+  - UPDATE takes 12 mutations:
+    - 4 key columns
+    - 4 non key columns
+    - UPDATE of 2 secondary indices: Each requires deleting + inserting a row:
+      2 mutations each. 4 total
+
+- Delete the batch
+  - DELETE incurs 1 mutation
+
+- Update `user_collections` quota counts (only when quota: True): 6 mutations
+  - UPDATE:
+    - 3 key columns
+    - quota: True
+      - 3 non key columns
+
+Totals:
+- quota: False
+  4 + 19992 + 1 = 19997
+
+- quota: True
+  6 + 19992 + 1 + 6 = 20005!

--- a/src/db/spanner/models.rs
+++ b/src/db/spanner/models.rs
@@ -1497,6 +1497,7 @@ impl SpannerDb {
                 user_id: params.user_id,
                 collection: params.collection,
                 bsos,
+                for_batch: false,
                 failed: HashMap::new(),
             })
             .await?;
@@ -1510,8 +1511,10 @@ impl SpannerDb {
             .get_or_create_collection_id_async(&params.collection)
             .await?;
 
-        self.check_quota(&user_id, &params.collection, collection_id)
-            .await?;
+        if !params.for_batch {
+            self.check_quota(&user_id, &params.collection, collection_id)
+                .await?;
+        }
 
         // Ensure a parent record exists in user_collections before writing to
         // bsos (INTERLEAVE IN PARENT user_collections)
@@ -1592,9 +1595,11 @@ impl SpannerDb {
         for (columns, values) in updates {
             self.update("bsos", &columns, values);
         }
-        // update the quotas
-        self.update_user_collection_quotas(&user_id, collection_id)
-            .await?;
+        if !params.for_batch {
+            // update the quotas
+            self.update_user_collection_quotas(&user_id, collection_id)
+                .await?;
+        }
 
         let result = results::PostBsos {
             modified: timestamp,

--- a/src/db/tests/db.rs
+++ b/src/db/tests/db.rs
@@ -781,6 +781,7 @@ async fn post_bsos() -> Result<()> {
                 postbso("b1", Some("payload 1"), Some(1_000_000_000), None),
                 postbso("b2", Some("payload 2"), Some(100), None),
             ],
+            for_batch: false,
             failed: Default::default(),
         })
         .await?;
@@ -808,6 +809,7 @@ async fn post_bsos() -> Result<()> {
                 postbso("b0", Some("updated 0"), Some(11), Some(100_000)),
                 postbso("b2", Some("updated 2"), Some(22), Some(10000)),
             ],
+            for_batch: false,
             failed: Default::default(),
         })
         .await?;

--- a/src/web/handlers.rs
+++ b/src/web/handlers.rs
@@ -245,6 +245,7 @@ pub async fn post_collection(
                     user_id: coll.user_id,
                     collection: coll.collection,
                     bsos: coll.bsos.valid.into_iter().map(From::from).collect(),
+                    for_batch: false,
                     failed: coll.bsos.invalid,
                 })
                 .await?;
@@ -347,6 +348,7 @@ pub async fn post_collection_batch(
                     ttl: batch_bso.ttl,
                 })
                 .collect(),
+            for_batch: true,
             failed: Default::default(),
         })
         .await


### PR DESCRIPTION
## Description

and document batch commit's mutations

also reduce MAX_TOTAL_RECORDS for quota write allowance

## Testing

TODO: https://github.com/mozilla-services/server-syncstorage/issues/155

## Issue(s)

Closes #869
