### PR TITLE
feat: optimize POST w/ ?batch=true&commit=true

### DIFF
--- a/src/web/handlers.rs
+++ b/src/web/handlers.rs
@@ -236,8 +236,14 @@ pub async fn post_collection(
 
             // batches are a conceptual, singular update, so we should handle
             // them separately.
-            if coll.batch.is_some() {
-                return post_collection_batch(coll, db).await;
+            if let Some(ref batch) = coll.batch {
+                // Optimization: specifying ?batch=true&commit=true
+                // (batch.id.is_none() && batch.commit) is equivalent to a
+                // simpler post_bsos call. Fallthrough in that case, instead of
+                // incurring post_collection_batch's overhead
+                if !(batch.id.is_none() && batch.commit) {
+                    return post_collection_batch(coll, db).await;
+                }
             }
 
             let result = db


### PR DESCRIPTION
## Description

this is equivalent to a simpler post_bsos call: so do that instead of
incurring post_collection_batch's overhead

### **NOTE:** let's give this change some good consideration. it seems too easy..

## Testing

e2e tests executes this path a couple of times (and there's a specific test_batch_with_immediate_commit test for it)

## Issue(s)

Closes #876
