### PR TITLE
feat: Enable cargo build `--release` flag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ commands:
 
   run-tests:
     steps:
-        - run:
+      - run:
           name: cargo test
           command: cargo test --all --verbose
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ commands:
     steps:
       - run:
           name: cargo build
-          command: cargo build
+          command: cargo build --release
   setup-gcp-grpc:
     steps:
       - run:
@@ -63,7 +63,7 @@ commands:
 
   run-tests:
     steps:
-      - run:
+        - run:
           name: cargo test
           command: cargo test --all --verbose
       - run:

--- a/src/db/mysql/batch.rs
+++ b/src/db/mysql/batch.rs
@@ -20,7 +20,11 @@ use crate::{
     web::extractors::HawkIdentifier,
 };
 
-const MAXTTL: i32 = 2_100_000_000;
+// TTL is the number of seconds from now that a given entry should live.
+// 2,100,000,000 seconds is ~ 66 years.
+// Note that we use SyncTimestamp, which is millisecond based, so be sure
+// to adjust all seconds by * 1000
+pub const MAXTTL: i32 = 2_100_000_000;
 
 pub fn create(db: &MysqlDb, params: params::CreateBatch) -> Result<results::CreateBatch> {
     let user_id = params.user_id.legacy_id as i64;
@@ -144,7 +148,7 @@ pub fn commit(db: &MysqlDb, params: params::CommitBatch) -> Result<results::Comm
         .bind::<Integer, _>(&collection_id)
         .bind::<BigInt, _>(&db.timestamp().as_i64())
         .bind::<BigInt, _>(&db.timestamp().as_i64())
-        .bind::<BigInt, _>((MAXTTL as i64) * 1000) // XXX:
+        .bind::<BigInt, _>(MAXTTL as i64 * 1000)
         .bind::<BigInt, _>(&batch_id)
         .bind::<BigInt, _>(user_id as i64)
         .bind::<BigInt, _>(&db.timestamp().as_i64())

--- a/src/db/mysql/test.rs
+++ b/src/db/mysql/test.rs
@@ -28,7 +28,6 @@ impl CustomizeConnection<MysqlConnection, PoolError> for TestTransactionCustomiz
 pub fn db(settings: &Settings) -> Result<MysqlDb> {
     let _ = env_logger::try_init();
     // inherit SYNC_DATABASE_URL from the env
-
     let pool = MysqlDbPool::new(&settings, &metrics::Metrics::noop())?;
     pool.get_sync()
 }

--- a/src/db/spanner/models.rs
+++ b/src/db/spanner/models.rs
@@ -55,6 +55,8 @@ pub enum CollectionLock {
 pub type Result<T> = std::result::Result<T, DbError>;
 
 /// The ttl to use for rows that are never supposed to expire (in seconds)
+/// Remember: we store time as SyncTimestamp, which is in milliseconds, so
+/// be sure to multiply this by 1000
 pub const DEFAULT_BSO_TTL: u32 = 2_100_000_000;
 
 pub const TOMBSTONE: i32 = 0;

--- a/src/db/tests/batch.rs
+++ b/src/db/tests/batch.rs
@@ -247,8 +247,8 @@ async fn test_append_async_w_null() -> Result<()> {
     let settings = crate::settings::test_settings();
     let pool = db_pool(Some(settings)).await?;
     let db = test_db(pool.as_ref()).await?;
-    let ttl_0 = crate::db::util::ms_since_epoch() as u32 + 10_000;
-    let ttl_1 = ttl_0 + (86_400 * 2);
+    let ttl_0 = 86_400; // Remember. TTL == how many seconds should this live, not the actual expiration time.
+    let ttl_1 = 86_400;
     let bid_0 = "b0";
     let bid_1 = "b1";
 


### PR DESCRIPTION
Closes #896

## Description

We are currently building a default "dev" environment. `cargo build --release` enables a number of optimizations which may improve performance.

## Testing

We should preform a comparative load test between a current and `--release` version to see if there are any notable benefits of using this flag.

## Issue(s)

Closes #896.
