### PR TITLE
test: add a basic overquota test

### DIFF
--- a/src/db/mysql/test.rs
+++ b/src/db/mysql/test.rs
@@ -70,6 +70,7 @@ fn static_collection_id() -> Result<()> {
         .select((collections::id, collections::name))
         .filter(collections::name.ne(""))
         //.filter(collections::name.not_like("xxx%")) // from most integration tests
+        .filter(collections::name.ne("xxx_col2")) // from server::test
         .filter(collections::name.ne("col2")) // from older intergration tests
         .load(&db.inner.conn)?
         .into_iter()

--- a/src/db/spanner/models.rs
+++ b/src/db/spanner/models.rs
@@ -1676,9 +1676,6 @@ impl SpannerDb {
             .await?;
         let timestamp = self.timestamp()?;
 
-        self.check_quota(&bso.user_id, &bso.collection, collection_id)
-            .await?;
-
         let result = self
             .sql(
                 "SELECT 1 AS count


### PR DESCRIPTION
## Description

- make server test uids random to avoid potential conflicts
- remove an extra check_quota call from test's spanner put_bso

This was actually a pain to do for another reason: these server tests don't persist the db across each request (they use `database_use_test_transactions`). That's easily fixed on a per test basis but then test failures can cause stale data to hang around, conflicting with other tests. Hence randomizing the uids.

## Testing

new test passes

## Issue(s)

Closes #120
