### PR TITLE
Tokenserver jr

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -187,6 +187,7 @@ impl ApiError {
 
     pub fn render_404<B>(res: ServiceResponse<B>) -> Result<ErrorHandlerResponse<B>> {
         // Replace the outbound error message with our own.
+        dbg!("Returning 404...");
         let resp =
             HttpResponseBuilder::new(StatusCode::NOT_FOUND).json(WeaveError::UnknownError as u32);
         Ok(ErrorHandlerResponse::Response(ServiceResponse::new(

--- a/src/server/metrics.rs
+++ b/src/server/metrics.rs
@@ -127,6 +127,7 @@ impl Metrics {
 
     pub fn incr_with_tags(&self, label: &str, tags: Option<Tags>) {
         if let Some(client) = self.client.as_ref() {
+            dbg!(&label, &tags);
             let mut tagged = client.incr_with_tags(label);
             let mut mtags = self.tags.clone().unwrap_or_default();
             if let Some(tags) = tags {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -130,6 +130,10 @@ macro_rules! build_app {
             .service(
                 web::resource("/1.0/sync/1.5".to_string()).route(web::get().to(tokenserver::get)),
             )
+            .service(
+                web::resource("/1.0/sync/1.5/{user_id:[0-9]{1,10}}".to_string())
+                    .route(web::get().to(tokenserver::get))
+            )
             // Dockerflow
             // Remember to update .::web::middleware::DOCKER_FLOW_ENDPOINTS
             // when applying changes to endpoint names.

--- a/src/web/extractors.rs
+++ b/src/web/extractors.rs
@@ -157,6 +157,7 @@ impl FromRequest for BsoBodies {
     ///
     /// No collection id is used, so payload checks are not done here.
     fn from_request(req: &HttpRequest, payload: &mut Payload) -> Self::Future {
+        dbg!("bso bodies");
         // Only try and parse the body if its a valid content-type
         let metrics = metrics::Metrics::from(req);
         let ctype = match ContentType::parse(req) {
@@ -356,6 +357,8 @@ impl FromRequest for BsoBody {
     type Future = LocalBoxFuture<'static, Result<BsoBody, Self::Error>>;
 
     fn from_request(req: &HttpRequest, payload: &mut Payload) -> Self::Future {
+        dbg!("bso body");
+
         // Only try and parse the body if its a valid content-type
         let ctype = match ContentType::parse(req) {
             Ok(v) => v,
@@ -593,6 +596,7 @@ impl FromRequest for CollectionParam {
     type Future = LocalBoxFuture<'static, Result<Self, Self::Error>>;
 
     fn from_request(req: &HttpRequest, _payload: &mut Payload) -> Self::Future {
+        dbg!("collectionparam request");
         let req = req.clone();
         Box::pin(async move {
             if let Some(collection) = Self::extrude(&req.uri(), &mut req.extensions_mut())? {
@@ -624,6 +628,8 @@ impl FromRequest for MetaRequest {
     type Future = LocalBoxFuture<'static, Result<Self, Self::Error>>;
 
     fn from_request(req: &HttpRequest, _payload: &mut Payload) -> Self::Future {
+        dbg!("meta request");
+
         let req = req.clone();
         let mut payload = Payload::None;
         async move {
@@ -663,6 +669,7 @@ impl FromRequest for CollectionRequest {
     type Future = LocalBoxFuture<'static, Result<Self, Self::Error>>;
 
     fn from_request(req: &HttpRequest, _payload: &mut Payload) -> Self::Future {
+        dbg!("collection request 1");
         let req = req.clone();
         let mut payload = Payload::None;
         async move {
@@ -726,6 +733,7 @@ impl FromRequest for CollectionPostRequest {
     ///   - If the collection is 'crypto', known bad payloads are checked for
     ///   - Any valid BSO's beyond `BATCH_MAX_RECORDS` are moved to invalid
     fn from_request(req: &HttpRequest, payload: &mut Payload) -> Self::Future {
+        dbg!("collection request");
         let req = req.clone();
         let mut payload = payload.take();
         Box::pin(async move {
@@ -811,6 +819,7 @@ impl FromRequest for BsoRequest {
     type Future = LocalBoxFuture<'static, Result<Self, Self::Error>>;
 
     fn from_request(req: &HttpRequest, payload: &mut Payload) -> Self::Future {
+        dbg!("bso request");
         let req = req.clone();
         let mut payload = payload.take();
         Box::pin(async move {
@@ -850,6 +859,8 @@ impl FromRequest for BsoPutRequest {
     type Future = LocalBoxFuture<'static, Result<Self, Self::Error>>;
 
     fn from_request(req: &HttpRequest, payload: &mut Payload) -> Self::Future {
+        dbg!("bso put request");
+
         let metrics = metrics::Metrics::from(req);
         let req = req.clone();
         let mut payload = payload.take();

--- a/src/web/handlers.rs
+++ b/src/web/handlers.rs
@@ -96,6 +96,7 @@ pub async fn delete_all(
     meta: MetaRequest,
     db_pool: DbTransactionPool,
 ) -> Result<HttpResponse, Error> {
+    dbg!("Delete all...");
     db_pool
         .transaction_http(|db| async move {
             meta.metrics.incr("request.delete_all");

--- a/src/web/middleware/mod.rs
+++ b/src/web/middleware/mod.rs
@@ -24,6 +24,7 @@ pub trait SyncServerRequest {
 
 impl SyncServerRequest for ServiceRequest {
     fn get_hawk_id(&self) -> Result<HawkIdentifier, Error> {
+        dbg!("ServiceRequest: Checking hawk");
         if DOCKER_FLOW_ENDPOINTS.contains(&self.uri().path().to_lowercase().as_str()) {
             return Ok(HawkIdentifier::cmd_dummy());
         }
@@ -40,6 +41,7 @@ impl SyncServerRequest for ServiceRequest {
 
 impl SyncServerRequest for HttpRequest {
     fn get_hawk_id(&self) -> Result<HawkIdentifier, Error> {
+        dbg!("HttpRequest: Checking hawk");
         if DOCKER_FLOW_ENDPOINTS.contains(&self.uri().path().to_lowercase().as_str()) {
             return Ok(HawkIdentifier::cmd_dummy());
         }

--- a/src/web/tokenserver.rs
+++ b/src/web/tokenserver.rs
@@ -70,6 +70,7 @@ pub struct Claims {
 pub fn get(
     auth: BearerAuth,
 ) -> impl Future<Output = Result<HttpResponse, BlockingError<ApiError>>> {
+    dbg!("Getting...");
     block(move || get_sync(&auth).map_err(Into::into)).map_ok(move |result| {
         HttpResponse::Ok()
             .content_type("application/json")


### PR DESCRIPTION
* adds dbg!()
* adds route for `/1.0/sync/1.5/{uid}` (not sure if that's needed.

