### PR TITLE
Release/0.8.1 - and include details/helper script for creating sentry releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,7 @@ target
 *.rs.bk
 .#*
 service-account.json
-
+.sentryclirc
 
 config/local.toml
 venv

--- a/.sentryclirc.example
+++ b/.sentryclirc.example
@@ -1,0 +1,7 @@
+[defaults]
+project=syncstorage-prod
+org=your-org-name-here
+url=https://self.hosted.sentry-url
+
+[auth]
+token=super_secret_token

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,31 @@
+<a name="0.8.1"></a>
+### 0.8.1 (2020-11-16)
+
+
+#### Chore
+
+*   Update depenedencies (#904) ([4e95c571](https://github.com/mozilla-services/syncstorage-rs/commit/4e95c571c73953e1f92bee46a58c49a97d9aa463), closes [#899](https://github.com/mozilla-services/syncstorage-rs/issues/899))
+*   update dependencies (#900) ([0afb9691](https://github.com/mozilla-services/syncstorage-rs/commit/0afb9691f7538dd9eaa68dc7eac11a2e06a12a70))
+*   tag 0.8.0 (#881) ([b6ff73d2](https://github.com/mozilla-services/syncstorage-rs/commit/b6ff73d2916e5c4afacede8bb2db905a576dba26))
+
+
+#### Test
+
+*   add a basic overquota test (#912) ([5afda742](https://github.com/mozilla-services/syncstorage-rs/commit/5afda7427b487110cc256cda4f517e8ea2f796fb), closes [#120](https://github.com/mozilla-services/syncstorage-rs/issues/120))
+
+
+#### Features
+
+*   Add `SYNC_ENFORCE_QUOTA` flag (#875) ([0e30801d](https://github.com/mozilla-services/syncstorage-rs/commit/0e30801dbbfe3693c8d2c21c0e6fc09262d7afb3), closes [#870](https://github.com/mozilla-services/syncstorage-rs/issues/870))
+*   switch coll cache's RwLock to async (#906) ([14fc49a5](https://github.com/mozilla-services/syncstorage-rs/commit/14fc49a559e69c695bc17c220b72817b2d971e1d), closes [#905](https://github.com/mozilla-services/syncstorage-rs/issues/905))
+*   Implement rudimentary tokenserver route in syncstorage-rs (#871) ([b74943e4](https://github.com/mozilla-services/syncstorage-rs/commit/b74943e4580e0db36f3a1a55c2eb8f9083f2759b))
+
+#### Bug Fixes
+
+*   downgrade to sentry 0.19 ([243eb17a](https://github.com/mozilla-services/syncstorage-rs/commit/243eb17a35ce3dc1c07090dcf0439e4eadeb855a), closes [#907](https://github.com/mozilla-services/syncstorage-rs/issues/907))
+
+
+
 <a name="0.8.0"></a>
 ## 0.8.0 (2020-10-29)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 *   Update depenedencies (#904) ([4e95c571](https://github.com/mozilla-services/syncstorage-rs/commit/4e95c571c73953e1f92bee46a58c49a97d9aa463), closes [#899](https://github.com/mozilla-services/syncstorage-rs/issues/899))
 *   update dependencies (#900) ([0afb9691](https://github.com/mozilla-services/syncstorage-rs/commit/0afb9691f7538dd9eaa68dc7eac11a2e06a12a70))
 *   tag 0.8.0 (#881) ([b6ff73d2](https://github.com/mozilla-services/syncstorage-rs/commit/b6ff73d2916e5c4afacede8bb2db905a576dba26))
+*   tag 0.8.1 for release and include scripts for setting up sentry releases (#881) ([33f900dc8e](https://github.com/mozilla-services/syncstorage-rs/commit/33f900dc8edd4e583b04af9363ef2cc51a0c889d))
 
 
 #### Test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 #### Bug Fixes
 
 *   downgrade to sentry 0.19 ([243eb17a](https://github.com/mozilla-services/syncstorage-rs/commit/243eb17a35ce3dc1c07090dcf0439e4eadeb855a), closes [#907](https://github.com/mozilla-services/syncstorage-rs/issues/907))
+*   add a short delay to avoid 503s (#922) ([36698137](https://github.com/mozilla-services/syncstorage-rs/pull/922/commits/ecf073e300630c56e0659c9bbb00653c442937f4), closes [#920](https://github.com/mozilla-services/syncstorage-rs/issues/920))
 
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2939,7 +2939,7 @@ dependencies = [
 
 [[package]]
 name = "syncstorage"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "actix-cors",
  "actix-http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syncstorage"
-version = "0.8.0"
+version = "0.8.1"
 license = "MPL-2.0"
 authors = [
   "Ben Bangert <ben@groovie.org>",

--- a/README.md
+++ b/README.md
@@ -211,24 +211,25 @@ Functional tests live in [server-syncstorage](https://github.com/mozilla-service
 ## Creating Releases
 
 1. Switch to master branch of syncstorage-rs
-2. `git pull` to ensure that the local copy is up-to-date.
-3. `git pull origin master` to make sure that you've incorporated any changes to the master branch.
-4. `git diff origin/master` to ensure that there are no local staged or uncommited changes.
-5. Bump the version number in [Cargo.toml](https://github.com/mozilla-services/syncstorage-rs/blob/master/Cargo.toml) (this new version number will be designated as `<version>` in this checklist)
-6. create a git branch for the new version `git checkout -b release/<version>`
-7. `cargo build --release` - Build with the release profile [release mode](https://doc.rust-lang.org/book/ch14-01-release-profiles.html).
-8. `clog -C CHANGELOG.md` - Generate release notes. We're using [clog](https://github.com/clog-tool/clog-cli) for release notes. Add a `-p`, `-m` or `-M` flag to denote major/minor/patch version, ie `clog -C CHANGELOG.md -p`.
-9. Review the `CHANGELOG.md` file and ensure all relevant changes since the last tag are included.
-10. `git commit -am "chore: tag <version>"` to commit the new version and changes
-11. `git tag -s -m "chore: tag <version>" <version>` to create a signed tag of the current HEAD commit for release.
-12. `git push origin release/<version>` to push the commits to a new origin release branch
-13. `git push --tags origin release/<version>` to push the tags to the release branch.
-14. Submit a Pull Request (PR) on github to merge the release branch to master.
-15. Go to the [GitHub release](https://github.com/mozilla-services/syncstorage-rs/releases), you should see the new tag with no release information.
-16. Click the `Draft a new release` button.
-17. Enter the \<version> number for `Tag version`.
-18. Copy and paste the most recent change set from `CHANGELOG.md` into the release description, omitting the top 2 lines (the name and version)
-19. Once your PR merges, click [Publish Release] on the [GitHub release](https://github.com/mozilla-services/syncstorage-rs/releases) page.
+1. `git pull` to ensure that the local copy is up-to-date.
+1. `git pull origin master` to make sure that you've incorporated any changes to the master branch.
+1. `git diff origin/master` to ensure that there are no local staged or uncommited changes.
+1. Bump the version number in [Cargo.toml](https://github.com/mozilla-services/syncstorage-rs/blob/master/Cargo.toml) (this new version number will be designated as `<version>` in this checklist)
+1. create a git branch for the new version `git checkout -b release/<version>`
+1. `cargo build --release` - Build with the release profile [release mode](https://doc.rust-lang.org/book/ch14-01-release-profiles.html).
+1. `clog -C CHANGELOG.md` - Generate release notes. We're using [clog](https://github.com/clog-tool/clog-cli) for release notes. Add a `-p`, `-m` or `-M` flag to denote major/minor/patch version, ie `clog -C CHANGELOG.md -p`.
+1. Review the `CHANGELOG.md` file and ensure all relevant changes since the last tag are included.
+1. Create a new [release in Sentry](https://docs.sentry.io/product/releases/#create-release): `bash scripts/sentry-release.sh`. If you're doing this for the first time, checkout the [tips below](https://github.com/mozilla-services/syncstorage-rs#troubleshooting) for troubleshooting sentry cli access.
+1. `git commit -am "chore: tag <version>"` to commit the new version and changes
+1. `git tag -s -m "chore: tag <version>" <version>` to create a signed tag of the current HEAD commit for release.
+1. `git push origin release/<version>` to push the commits to a new origin release branch
+1. `git push --tags origin release/<version>` to push the tags to the release branch.
+1. Submit a Pull Request (PR) on github to merge the release branch to master.
+1. Go to the [GitHub release](https://github.com/mozilla-services/syncstorage-rs/releases), you should see the new tag with no release information.
+1. Click the `Draft a new release` button.
+1. Enter the \<version> number for `Tag version`.
+1. Copy and paste the most recent change set from `CHANGELOG.md` into the release description, omitting the top 2 lines (the name and version)
+1. Once your PR merges, click [Publish Release] on the [GitHub release](https://github.com/mozilla-services/syncstorage-rs/releases) page.
 
 Sync server is automatically deployed to STAGE, however QA may need to be notified if testing is required. Once QA signs off, then a bug should be filed to promote the server to PRODUCTION.
 
@@ -238,6 +239,10 @@ Sync server is automatically deployed to STAGE, however QA may need to be notifi
 
 - Some versions of OpenSSL 1.1.1 can conflict with grpcio's built in BoringSSL. These errors can cause syncstorage to fail to run or compile.
 If you see a problem related to `libssl` you may need to specify the `cargo` option `--features grpcio/openssl`  to force grpcio to use OpenSSL.
+
+### Sentry
+
+- If you're having trouble working with Sentry to create releases, try authenticating using their self hosted server option that's outlined [here](https://docs.sentry.io/product/cli/configuration/) Ie, `sentry-cli --url https://selfhosted.url.com/ login`. It's also recommended to create a `.sentryclirc` config file. See [this example](https://github.com/mozilla-services/syncstorage-rs/blob/master/.sentryclirc.example) for the config values you'll need.
 
 ## Related Documentation
 

--- a/scripts/sentry-release.sh
+++ b/scripts/sentry-release.sh
@@ -1,0 +1,4 @@
+sentry-cli releases set-commits --auto $VERSION
+sentry-cli releases new -p syncstorage-prod $VERSION
+sentry-cli releases set-commits --auto $VERSION
+sentry-cli releases finalize $VERSION


### PR DESCRIPTION
## Description

Tagged 0.8.1 for release. Since I was planning to integrate sentry releases into this process I did that at the same time. If folks prefer to split that out separately from release tag, let me know I'll open a separate PR.

## Testing

Note the newly added instructions to the README for creating sentry releases; make sense? Do they work for you?

## Issue(s)

Closes [#910](https://github.com/mozilla-services/syncstorage-rs/issues/910).
