### PR TITLE
fix: prefer a set vs vec for the bso_id dupe check

### DIFF
--- a/src/db/mysql/batch.rs
+++ b/src/db/mysql/batch.rs
@@ -161,11 +161,7 @@ pub fn commit(db: &MysqlDb, params: params::CommitBatch) -> Result<results::Comm
             id: params.batch.id,
         },
     )?;
-    Ok(results::PostBsos {
-        modified: timestamp,
-        success: Default::default(),
-        failed: Default::default(),
-    })
+    Ok(timestamp)
 }
 
 pub fn do_append(

--- a/src/db/results.rs
+++ b/src/db/results.rs
@@ -31,7 +31,7 @@ pub type ValidateBatch = bool;
 pub type AppendToBatch = ();
 pub type GetBatch = params::Batch;
 pub type DeleteBatch = ();
-pub type CommitBatch = PostBsos;
+pub type CommitBatch = SyncTimestamp;
 pub type ValidateBatchId = ();
 pub type Check = bool;
 

--- a/src/db/spanner/batch.rs
+++ b/src/db/spanner/batch.rs
@@ -236,11 +236,7 @@ pub async fn commit_async(
         db.update_user_collection_quotas(&params.user_id, collection_id)
             .await?;
     }
-    Ok(results::PostBsos {
-        modified: timestamp,
-        success: Default::default(),
-        failed: Default::default(),
-    })
+    Ok(timestamp)
 }
 
 // Append a collection to an existing, pending batch.

--- a/src/db/tests/batch.rs
+++ b/src/db/tests/batch.rs
@@ -136,7 +136,7 @@ async fn append_commit() -> Result<()> {
         .await?;
 
     let batch = db.get_batch(gb(uid, coll, new_batch.id)).await?.unwrap();
-    let result = db
+    let modified = db
         .commit_batch(params::CommitBatch {
             user_id: hid(uid),
             collection: coll.to_owned(),
@@ -153,7 +153,7 @@ async fn append_commit() -> Result<()> {
             collection: coll.to_owned(),
         })
         .await?;
-    assert_eq!(result.modified, ts);
+    assert_eq!(modified, ts);
 
     let bso = db.get_bso(gbso(uid, coll, "b1")).await?.unwrap();
     assert_eq!(bso.sortindex, Some(1_000_000_000));


### PR DESCRIPTION
## Description

- simplify results::CommitBatch
- kill the request.error.invalid_json metric (dupe of
  request.validate.invalid_body_json)

## Testing

mostly a refactor

## Issue(s)

Closes #933
Issue #835
