### PR TITLE
feat: Add quota info to __heartbeat__

### DIFF
--- a/src/web/extractors.rs
+++ b/src/web/extractors.rs
@@ -889,10 +889,17 @@ impl FromRequest for BsoPutRequest {
     }
 }
 
+#[derive(Clone, Copy, Debug, Serialize)]
+pub struct QuotaInfo {
+    pub enabled: bool,
+    pub size: u32,
+}
+
 #[derive(Clone, Debug)]
 pub struct HeartbeatRequest {
     pub headers: HeaderMap,
     pub db_pool: Box<dyn DbPool>,
+    pub quota: QuotaInfo,
 }
 
 impl FromRequest for HeartbeatRequest {
@@ -919,7 +926,12 @@ impl FromRequest for HeartbeatRequest {
                 }
             };
             let db_pool = state.db_pool.clone();
-            Ok(HeartbeatRequest { headers, db_pool })
+            let quota = QuotaInfo {
+                enabled: state.quota_enabled,
+                size: state.limits.max_quota_limit,
+            };
+
+            Ok(HeartbeatRequest { headers, db_pool, quota })
         }
         .boxed_local()
     }

--- a/src/web/extractors.rs
+++ b/src/web/extractors.rs
@@ -931,7 +931,11 @@ impl FromRequest for HeartbeatRequest {
                 size: state.limits.max_quota_limit,
             };
 
-            Ok(HeartbeatRequest { headers, db_pool, quota })
+            Ok(HeartbeatRequest {
+                headers,
+                db_pool,
+                quota,
+            })
         }
         .boxed_local()
     }

--- a/src/web/handlers.rs
+++ b/src/web/handlers.rs
@@ -518,6 +518,8 @@ pub async fn heartbeat(hb: HeartbeatRequest) -> Result<HttpResponse, Error> {
     );
     let db = hb.db_pool.get().await?;
 
+    checklist.insert("quota".to_owned(), serde_json::to_value(hb.quota)?);
+
     match db.check().await {
         Ok(result) => {
             if result {


### PR DESCRIPTION
Closes #947

## Description

Adds `quota` info to the `__heartbeat__` result.

## Testing

Set quota via env vars like:
```
    SYNC_ENABLE_QUOTA=true \
    SYNC_ENFORCE_QUOTA=true \
    SYNC_LIMITS__MAX_QUOTA_LIMIT=10000 \
    ... \
    cargo run 
```

Verify that 
```
> curl http://localhost:8000/__heartbeat__
{"quota":{"enabled":true,"size":10000},"status":"Ok","version":"0.8.3","database":"Ok"}
```
If quota is not enabled, `__heartbeat__` should return something like:
```
> curl http://localhost:8000/__heartbeat__
{"version":"0.8.2","database":"Ok","quota":{"enabled":false,"size":2097152000},"status":"Ok"}
```
(The only field that matters here is `enabled`.)

## Issue(s)

Closes #947.
