### PR TITLE
feat: Implement generation and keysChangedAt in the rust tokenserver.

### DIFF
--- a/src/web/tokenserver.rs
+++ b/src/web/tokenserver.rs
@@ -126,7 +126,7 @@ pub fn check_if_should_update_keys(
         Err(ApiError::from(ApiErrorKind::Internal(
             "invalid-generation".to_string(),
         )))
-    } else if client_keys_changed_at != 0 && server_keys_changed_at > client_keys_changed_at {
+    } else if server_keys_changed_at > client_keys_changed_at {
         // Error out if we previously saw a keys_changed_at for this user, but they
         // haven't provided one or it's earlier than previously seen. This means
         // that once the IdP starts sending keys_changed_at, we'll error out if it

--- a/src/web/tokenserver.rs
+++ b/src/web/tokenserver.rs
@@ -68,7 +68,7 @@ pub struct Claims {
     pub sub: String,
     pub iat: i64,
     pub exp: i64,
-    #[serde(rename = "fxa-generation")] 
+    #[serde(rename = "fxa-generation")]
     pub generation: i64,
 }
 
@@ -264,7 +264,9 @@ def hash_device_id(fxa_uid, device, secret):
                 // noop
             }
             Err(_e) => {
-                return Err(exceptions::PyValueError::new_err("stale generation or keysChangedAt"))
+                return Err(exceptions::PyValueError::new_err(
+                    "stale generation or keysChangedAt",
+                ))
             }
         }
         let client_state_b64 = match tokenlib.call1("encode_bytes", (new_client_state,)) {

--- a/src/web/tokenserver.rs
+++ b/src/web/tokenserver.rs
@@ -250,7 +250,7 @@ def hash_device_id(fxa_uid, device, secret):
                           SET users.generation = ?,
                               users.client_state = ?,
                               users.keys_changed_at = ?
-                             WHERE users.uid = ?"#,
+                        WHERE users.uid = ?"#,
                 )
                 .bind::<Bigint, _>(token_data.claims.generation)
                 .bind::<Text, _>(new_client_state)

--- a/src/web/tokenserver.rs
+++ b/src/web/tokenserver.rs
@@ -228,7 +228,7 @@ def hash_device_id(fxa_uid, device, secret):
             e.print_and_set_sys_last_vars(py);
             e
         })?;
-        let mut key_id_iter = x_key_id.split("-");
+        let mut key_id_iter = x_key_id.split('-');
         let keys_changed_at = key_id_iter
             .next()
             .expect("X-KeyId was the wrong format")


### PR DESCRIPTION
## Description

Implement the logic for generation and keysChangedAt in rust. If either generation or keysChangedAt is newer, update the tokenserver user record, recording the new generation, keysChangedAt, and clientState.

## Testing

First, you need python3 and to run pip3 install tokenlib.

Need a tokenserver mysql database:

    create table services (id int(11) auto_increment not null, service varchar(30), pattern varchar(128), primary key(id));
    create table nodes (
      id bigint(20) auto_increment not null, service int(11) not null,
      node varchar(64) not null, available int(11) not null, current_load int(11) not null,
      capacity int(11) not null, downed int(11) not null, backoff int(11) not null,
      primary key(id), foreign key(service) references services(id)
    );
    create table users (
      uid bigint(20) auto_increment not null, service int(11) not null,
      email varchar(255) not null, generation bigint(20) not null,
      client_state varchar(32) not null, created_at bigint(20) not null,
      replaced_at bigint(20), nodeid bigint(20) not null,
      keys_changed_at bigint(20), primary key(uid),
      foreign key(nodeid) references nodes(id)
    );

Run syncstorage-rs. You will need to give cargo run the following settings:

    SYNC_TOKENSERVER_DATABASE_URL=mysql://username:pw@localhost/tokenserver
    SYNC_TOKENSERVER_JWKS_RSA_MODULUS=2lDphW0lNZ4w1m9CfmIhC1AxYG9iwihxBdQZo7_6e0TBAi8_TNaoHHI90G9n5d8BQQnNcF4j2vOs006zlXcqGrP27b49KkN3FmbcOMovvfesMseghaqXqqFLALL9us3Wstt_fV_qV7ceRcJq5Hd_Mq85qUgYSfb9qp0vyePb26KEGy4cwO7c9nCna1a_i5rzUEJu6bAtcLS5obSvmsOOpTLHXojKKOnC4LRC3osdR6AU6v3UObKgJlkk_-8LmPhQZqOXiI_TdBpNiw6G_-eishg8V_poPlAnLNd8mfZBam-_7CdUS4-YoOvJZfYjIoboOuVmUrBjogFyDo72EPTReQ
    SYNC_TOKENSERVER_JWKS_RSA_EXPONENT=AQAB
    SYNC_FXA_METRICS_HASH_SECRET=insecure

In firefox, create a new profile. In about:config, set identity.sync.tokenserver.uri to http://localhost:8000/1.0/sync/1.5

Log in to sync with your normal prod fxa credentials. It should be able to put your stuff in your localhost syncstorage-rs.

## Issue(s)

Closes #866
