### PR TITLE
feat: default to timing out deadpool checkouts (30 seconds)

### DIFF
--- a/src/db/mysql/pool.rs
+++ b/src/db/mysql/pool.rs
@@ -6,6 +6,7 @@ use std::{
     collections::HashMap,
     fmt,
     sync::{Arc, RwLock},
+    time::Duration,
 };
 
 use diesel::{
@@ -70,6 +71,9 @@ impl MysqlDbPool {
         let manager = ConnectionManager::<MysqlConnection>::new(settings.database_url.clone());
         let builder = Pool::builder()
             .max_size(settings.database_pool_max_size.unwrap_or(10))
+            .connection_timeout(Duration::from_secs(
+                settings.database_pool_max_size.unwrap_or(30) as u64,
+            ))
             .min_idle(settings.database_pool_min_idle);
 
         #[cfg(test)]

--- a/src/db/mysql/pool.rs
+++ b/src/db/mysql/pool.rs
@@ -72,7 +72,7 @@ impl MysqlDbPool {
         let builder = Pool::builder()
             .max_size(settings.database_pool_max_size.unwrap_or(10))
             .connection_timeout(Duration::from_secs(
-                settings.database_pool_max_size.unwrap_or(30) as u64,
+                settings.database_pool_connection_timeout.unwrap_or(30) as u64,
             ))
             .min_idle(settings.database_pool_min_idle);
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -43,6 +43,8 @@ pub struct Settings {
     pub database_pool_max_size: Option<u32>,
     // NOTE: Not supported by deadpool!
     pub database_pool_min_idle: Option<u32>,
+    /// Pool timeout when waiting for a slot to become available, in seconds
+    pub database_pool_connection_timeout: Option<u32>,
     #[cfg(test)]
     pub database_use_test_transactions: bool,
 
@@ -79,6 +81,7 @@ impl Default for Settings {
             tokenserver_database_url: None,
             database_pool_max_size: None,
             database_pool_min_idle: None,
+            database_pool_connection_timeout: Some(30),
             #[cfg(test)]
             database_use_test_transactions: false,
             actix_keep_alive: None,


### PR DESCRIPTION
## Description

and add a database_pool_connection_timout setting for it

## Testing

On prod (#945)

## Issue(s)

Closes #973
