### PR TITLE
fix: downgrade deadpool so it stays on tokio 0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -715,12 +715,13 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f6cb3c7f5b8e51bc3ebb73a2327ad4abdbd119dc13223f14f961d2f38486756"
+checksum = "774ba60a54c213d409d5353bda12d49cd68d14e45036a285234c8d6f91f92570"
 dependencies = [
- "cfg-if 1.0.0",
- "crossbeam-utils 0.8.1",
+ "cfg-if 0.1.10",
+ "crossbeam-utils 0.7.2",
+ "maybe-uninit",
 ]
 
 [[package]]
@@ -797,16 +798,16 @@ dependencies = [
 
 [[package]]
 name = "deadpool"
-version = "0.7.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d126179d86aee4556e54f5f3c6bf6d9884e7cc52cef82f77ee6f90a7747616d"
+checksum = "4aaff9a7a1de9893f4004fa08527b31cb2ae4121c44e053cf53f29203c73bd23"
 dependencies = [
  "async-trait",
  "config",
  "crossbeam-queue",
  "num_cpus",
  "serde 1.0.119",
- "tokio 1.0.1",
+ "tokio 0.2.24",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,8 @@ bytes = "1.0"
 cadence = "0.23"
 chrono = "0.4"
 config = "0.10"
-deadpool = "0.7"
+# Pin to 0.5 for now, to keep it under tokio 0.2 (issue977)
+deadpool = "0.5"
 diesel = { version = "1.4", features = ["mysql", "r2d2"] }
 diesel_logger = "0.1.1"
 diesel_migrations = { version = "1.4.0", features = ["mysql"] }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -111,6 +111,7 @@ impl Settings {
         s.set_default("host", "127.0.0.1")?;
         s.set_default("human_logs", false)?;
         #[cfg(test)]
+        s.set_default("database_pool_connection_timeout", Some(30))?;
         s.set_default("database_use_test_transactions", false)?;
         s.set_default("master_secret", "")?;
         s.set_default::<Option<String>>("tokenserver_database_url", None)?;


### PR DESCRIPTION
## Description

needed for its timer usage (when enabling connection timeouts)

and set a default connection timeout

## Testing

Tests now pass when using a connection timeout (which is now always enabled)

## Issue(s)

Closes #977, #976
