### PR TITLE
 bug: write bsos contained within a commit after the batch has been commited.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+<a name="0.8.4"></a>
+### 0.8.4 (2021-01-19)
+
+
+#### Chore
+*   Update pyo3 to the latest version (#938) ([cc7d9d36]https://github.com/mozilla-services/syncstorage-rs/commit/cc7d9d367310aeb7551668c049f1a895a6eae853))
+*   update dependencies (#953) ([bca8770f](https://github.com/mozilla-services/syncstorage-rs/commit/bca8770f531b45b00e57e137082b1ed9d90acd7f))
+*   tag 0.8.3 (#937) ([02b76231](https://github.com/mozilla-services/syncstorage-rs/commit/02b76231cf4fa015093cea75286a82f306c833b0))
+
+
+#### Features
+
+*   default to timing out deadpool checkouts (30 seconds) (#974) ([2ecca202](https://github.com/mozilla-services/syncstorage-rs/commit/2ecca202aa01f123898115827af6e5967f8a1e9b), closes [#973](https://github.com/mozilla-services/syncstorage-rs/issues/973))
+*   avoid an unnecessarily cloning for from_raw_bso (#972) ([07352b6d](https://github.com/mozilla-services/syncstorage-rs/commit/07352b6d7a331d07e18ec386a650d3b720c5703f), closes [#971](https://github.com/mozilla-services/syncstorage-rs/issues/971))
+
 <a name="0.8.3"></a>
 ### 0.8.3 (2020-11-30)
 
@@ -5,7 +20,6 @@
 #### Chore
 
 *   Update to rust 1.48 (#927) ([ea1f222b](https://github.com/mozilla-services/syncstorage-rs/commit/ea1f222b219ddd78684945058c3b3430ed636982))
-*   Update pyo3 to the latest version (#938) ([cc7d9d36]https://github.com/mozilla-services/syncstorage-rs/commit/cc7d9d367310aeb7551668c049f1a895a6eae853))
 
 <a name="0.8.2"></a>
 ## 0.8.2 (2020-11-20)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2940,7 +2940,7 @@ dependencies = [
 
 [[package]]
 name = "syncstorage"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "actix-cors",
  "actix-http",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,7 +12,7 @@ dependencies = [
  "futures-sink",
  "log",
  "pin-project 0.4.27",
- "tokio 0.2.24",
+ "tokio",
  "tokio-util",
 ]
 
@@ -131,7 +131,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "smallvec",
- "tokio 0.2.24",
+ "tokio",
 ]
 
 [[package]]
@@ -428,7 +428,7 @@ checksum = "374bba43fc924d90393ee7768e6f75d223a98307a488fe5bc34b66c3e96932a6"
 dependencies = [
  "async-trait",
  "futures 0.3.9",
- "tokio 0.2.24",
+ "tokio",
 ]
 
 [[package]]
@@ -807,7 +807,7 @@ dependencies = [
  "crossbeam-queue",
  "num_cpus",
  "serde 1.0.119",
- "tokio 0.2.24",
+ "tokio",
 ]
 
 [[package]]
@@ -1272,7 +1272,7 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio 0.2.24",
+ "tokio",
  "tokio-util",
  "tracing",
  "tracing-futures",
@@ -1405,7 +1405,7 @@ dependencies = [
  "itoa",
  "pin-project 1.0.4",
  "socket2",
- "tokio 0.2.24",
+ "tokio",
  "tower-service",
  "tracing",
  "want",
@@ -1420,7 +1420,7 @@ dependencies = [
  "bytes 0.5.6",
  "hyper",
  "native-tls",
- "tokio 0.2.24",
+ "tokio",
  "tokio-tls",
 ]
 
@@ -2358,7 +2358,7 @@ dependencies = [
  "serde 1.0.119",
  "serde_json",
  "serde_urlencoded",
- "tokio 0.2.24",
+ "tokio",
  "tokio-tls",
  "url 2.2.0",
  "wasm-bindgen",
@@ -2992,7 +2992,7 @@ dependencies = [
  "slog-stdlog",
  "slog-term",
  "time 0.2.25",
- "tokio 1.0.1",
+ "tokio",
  "url 2.2.0",
  "urlencoding",
  "uuid",
@@ -3172,25 +3172,15 @@ dependencies = [
  "pin-project-lite 0.1.11",
  "signal-hook-registry",
  "slab",
+ "tokio-macros",
  "winapi 0.3.9",
 ]
 
 [[package]]
-name = "tokio"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d258221f566b6c803c7b4714abadc080172b272090cdc5e244a6d4dd13c3a6bd"
-dependencies = [
- "autocfg",
- "pin-project-lite 0.2.4",
- "tokio-macros",
-]
-
-[[package]]
 name = "tokio-macros"
-version = "1.0.0"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42517d2975ca3114b22a16192634e8241dc5cc1f130be194645970cc1c371494"
+checksum = "e44da00bfc73a25f814cd8d7e57a68a5c31b74b3152a0a1d1f590c97ed06265a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3204,7 +3194,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a70f4fcd7b3b24fb194f837560168208f669ca8cb70d0c4b862944452396343"
 dependencies = [
  "native-tls",
- "tokio 0.2.24",
+ "tokio",
 ]
 
 [[package]]
@@ -3218,7 +3208,7 @@ dependencies = [
  "futures-sink",
  "log",
  "pin-project-lite 0.1.11",
- "tokio 0.2.24",
+ "tokio",
 ]
 
 [[package]]
@@ -3283,7 +3273,7 @@ dependencies = [
  "rand 0.7.3",
  "smallvec",
  "thiserror",
- "tokio 0.2.24",
+ "tokio",
  "url 2.2.0",
 ]
 
@@ -3303,7 +3293,7 @@ dependencies = [
  "resolv-conf",
  "smallvec",
  "thiserror",
- "tokio 0.2.24",
+ "tokio",
  "trust-dns-proto",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1379,9 +1379,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.13.9"
+version = "0.13.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ad767baac13b44d4529fcf58ba2cd0995e36e7b435bc5b039de6f47e880dbf"
+checksum = "8a6f157065790a3ed2f88679250419b5cdd96e714a0d65f7797fd337186e96bb"
 dependencies = [
  "bytes 0.5.6",
  "futures-channel",
@@ -2968,6 +2968,7 @@ dependencies = [
  "hkdf",
  "hmac",
  "hostname",
+ "hyper",
  "jsonwebtoken",
  "lazy_static",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ googleapis-raw = { version = "0", path = "vendor/mozilla-rust-sdk/googleapis-raw
 # syncserver to either fail to either compile, or start. In those cases, try
 # `cargo build --features grpcio/openssl ...`
 grpcio = { version = "0.7" }
+hyper = "0.13.10"  # RUSTSEC-2021-0020 requires 0.13.10+ or 0.14.3+
 lazy_static = "1.4.0"
 pyo3 = "0.13"
 hawk = "3.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ hostname = "0.3.1"
 hkdf = "0.10"
 hmac = "0.10"
 jsonwebtoken = "7.2.0"
-log = { version = "0.4", features = ["max_level_info", "release_max_level_info"] }
+log = { version = "0.4", features = ["max_level_trace", "release_max_level_info"] }
 mime = "0.3"
 num_cpus = "1"
 # must match what's used by googleapis-raw

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,8 @@ slog-scope = "4.3"
 slog-stdlog = "4.1"
 slog-term = "2.6"
 time = "^0.2.25"
-tokio = { version = "1.0", features = ["macros", "sync", "rt"] }
+# pinning to 0.2.4 due to high number of dependencies (actix, bb8, deadpool, etc.)
+tokio = { version = "0.2.4", features = ["macros", "sync"] }
 url = "2.1"
 urlencoding = "1.1"
 uuid = { version = "0.8.2", features = ["serde", "v4"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syncstorage"
-version = "0.8.3"
+version = "0.8.4"
 license = "MPL-2.0"
 authors = [
   "Ben Bangert <ben@groovie.org>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ hostname = "0.3.1"
 hkdf = "0.10"
 hmac = "0.10"
 jsonwebtoken = "7.2.0"
-log = { version = "0.4", features = ["max_level_trace", "release_max_level_info"] }
+log = { version = "0.4", features = ["max_level_debug", "release_max_level_info"] }
 mime = "0.3"
 num_cpus = "1"
 # must match what's used by googleapis-raw

--- a/src/web/handlers.rs
+++ b/src/web/handlers.rs
@@ -436,11 +436,11 @@ pub async fn post_collection_batch(
             .map(|_| ());
 
         handle_result!(result);
-
-        resp["success"] = json!(success);
-        resp["failed"] = json!(failed);
     }
 
+    // Always return success, failed, & modified
+    resp["success"] = json!(success);
+    resp["failed"] = json!(failed);
     resp["modified"] = json!(modified);
     trace!("Batch: Returning result: {}", &resp);
     Ok(HttpResponse::build(StatusCode::OK)

--- a/src/web/handlers.rs
+++ b/src/web/handlers.rs
@@ -318,75 +318,69 @@ pub async fn post_collection_batch(
         .await?
     };
 
-    let commit = breq.commit;
     let user_id = coll.user_id.clone();
     let collection = coll.collection.clone();
 
     let mut success = vec![];
     let mut failed = coll.bsos.invalid;
+    // Option #2, mark each bso.id included in the "commit" as "failing" so that they're
+    // resubmitted.
     let bso_ids: Vec<_> = coll.bsos.valid.iter().map(|bso| bso.id.clone()).collect();
 
-    let result = if commit && !coll.bsos.valid.is_empty() {
-        // There's pending items to append to the batch but since we're
-        // committing, write them to bsos immediately. Otherwise under
-        // Spanner we would pay twice the mutations for those pending
-        // items (once writing them to to batch_bsos, then again
-        // writing them to bsos)
-        trace!("Batch: Committing {}", &new_batch.id);
-        db.post_bsos(params::PostBsos {
-            user_id: coll.user_id.clone(),
-            collection: coll.collection.clone(),
-            // XXX: why does BatchBsoBody exist (it's the same struct
-            // as PostCollectionBso)?
-            bsos: coll
-                .bsos
-                .valid
-                .into_iter()
-                .map(|batch_bso| params::PostCollectionBso {
-                    id: batch_bso.id,
-                    sortindex: batch_bso.sortindex,
-                    payload: batch_bso.payload,
-                    ttl: batch_bso.ttl,
-                })
-                .collect(),
-            for_batch: true,
-            failed: Default::default(),
-        })
-        .await
-        .map(|_| ())
-    } else {
-        // We're not yet to commit the accumulated batch, but there are some
-        // additional records we need to add.
-        trace!("Batch: Appending to {}", &new_batch.id);
-        db.append_to_batch(params::AppendToBatch {
-            user_id: coll.user_id.clone(),
-            collection: coll.collection.clone(),
-            batch: new_batch.clone(),
-            bsos: coll.bsos.valid.into_iter().map(From::from).collect(),
-        })
-        .await
-    };
+    let mut resp: Value = json!({});
 
-    // collect up the successful and failed bso_ids into a response.
-    match result {
-        Ok(_) => success.extend(bso_ids),
-        Err(e) if e.is_conflict() => return Err(e.into()),
-        Err(apperr) => {
-            if let ApiErrorKind::Db(dberr) = apperr.kind() {
-                // If we're over quota, return immediately with a 403 to let the client know.
-                // Otherwise the client will simply keep retrying records.
-                if let DbErrorKind::Quota = dberr.kind() {
-                    return Err(apperr.into());
-                }
-            };
-            failed.extend(bso_ids.into_iter().map(|id| (id, "db error".to_owned())))
-        }
-    };
+    /* Ideally, we would be clever here and pre-commit the bsos included
+       with this request after the batches are committed.
+       There are a few problems with doing that.
+        1) since there are two different methods being used (DML &
+            Mutations), the previous written data included can't always
+            be read by the same transaction.
+        2) newer elements should probably overwrite older batch elements.
+       This means that we pay a mutations tax by double writing
+       (or we might be able to have an "exclude" list when we do the
+       final merge, but that SQL is gnarly, so this is probably
+       safer.)
 
-    let mut resp = json!({
-        "success": success,
-        "failed": failed,
-    });
+       Posting the bsos once the commit is done can also run into conflicts
+       because of the same mutation read limitations.
+    */
+    if !coll.bsos.valid.is_empty() {
+        let result = {
+            dbg!("Batch: Appending to {}", &new_batch.id);
+            db.append_to_batch(params::AppendToBatch {
+                user_id: coll.user_id.clone(),
+                collection: coll.collection.clone(),
+                batch: new_batch.clone(),
+                bsos: coll.bsos.valid.into_iter().map(From::from).collect(),
+            })
+            .await
+        };
+
+        // collect up the successful and failed bso_ids into a response.
+        match result {
+            Ok(_) => success.extend(bso_ids.clone()),
+            Err(e) if e.is_conflict() => return Err(e.into()),
+            Err(apperr) => {
+                if let ApiErrorKind::Db(dberr) = apperr.kind() {
+                    // If we're over quota, return immediately with a 403 to let the client know.
+                    // Otherwise the client will simply keep retrying records.
+                    if let DbErrorKind::Quota = dberr.kind() {
+                        return Err(apperr.into());
+                    }
+                };
+                dbg!(apperr);
+                failed.extend(
+                    bso_ids
+                        .clone()
+                        .into_iter()
+                        .map(|id| (id, "db error".to_owned())),
+                )
+            }
+        };
+    }
+
+    resp["success"] = json!(success);
+    resp["failed"] = json!(failed);
 
     if !breq.commit {
         resp["batch"] = json!(&new_batch.id);

--- a/tools/integration_tests/test_storage.py
+++ b/tools/integration_tests/test_storage.py
@@ -1583,7 +1583,7 @@ class TestStorage(StorageFunctionalTestCase):
         self.assertEquals(committed, resp3.json['modified'])
 
 
-    def test_batch_commit_collision(self):
+    def test_aaa_batch_commit_collision(self):
         # It's possible that a batch contain a BSO inside a batch as well
         # as inside the final "commit" message. This is a bit of a problem
         # for spanner because of conflicting ways that the data is written


### PR DESCRIPTION
## Description

The client may sometimes include bsos in the batch
commit message. The problem is that due to the way
that data is written to spanner, mutations do not
retain the ability to see data previously written
in the same transaction. This causes collisions.

To solve this, treat the bsos included in the commit
as another batch update, then commit all the data.
This does run the risk of bumping up against the
mutation limit, but it ensures the best chance of
data consistency.

Writing the commit bsos prior to batch commit will
result in the "newer" records being overwritten by
"older" ones in the batch.

Writing the commit bsos after the batch commit runs
the same mutation index conflict problem.

## Testing

Unit test included

## Issue(s)

Closes #882
