### PR TITLE
feat: Add pool connection info to __lbheartbeat__ for ops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+<a name="0.8.5"></a>
+## 0.8.5 (2021-01-21)
+
+
+#### Bug Fixes
+
+*   downgrade deadpool so it stays on tokio 0.2 ([99975ef8](https://github.com/mozilla-services/syncstorage-rs/commit/99975ef8b64317511111d48c6ebfc75e7facc334), closes [#976](https://github.com/mozilla-services/syncstorage-rs/issues/976))
+
+
+
 <a name="0.8.4"></a>
 ### 0.8.4 (2021-01-19)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2941,7 +2941,7 @@ dependencies = [
 
 [[package]]
 name = "syncstorage"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "actix-cors",
  "actix-http",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,7 +12,7 @@ dependencies = [
  "futures-sink",
  "log",
  "pin-project 0.4.27",
- "tokio 0.2.24",
+ "tokio",
  "tokio-util",
 ]
 
@@ -93,7 +93,7 @@ dependencies = [
  "serde_urlencoded",
  "sha-1",
  "slab",
- "time 0.2.24",
+ "time 0.2.25",
 ]
 
 [[package]]
@@ -131,7 +131,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "smallvec",
- "tokio 0.2.24",
+ "tokio",
 ]
 
 [[package]]
@@ -259,7 +259,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "socket2",
- "time 0.2.24",
+ "time 0.2.25",
  "tinyvec",
  "url 2.2.0",
 ]
@@ -320,9 +320,9 @@ checksum = "afddf7f520a80dbf76e6f50a35bca42a2331ef227a28b3b6dc5c2e2338d114b1"
 
 [[package]]
 name = "arc-swap"
-version = "0.4.8"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dabe5a181f83789739c194cbe5a897dde195078fac08568d09221fd6137a7ba8"
+checksum = "d4d7d63395147b81a9e570bcc6243aaf71c017bd666d4909cfef0085bdda8d73"
 
 [[package]]
 name = "arrayref"
@@ -428,7 +428,7 @@ checksum = "374bba43fc924d90393ee7768e6f75d223a98307a488fe5bc34b66c3e96932a6"
 dependencies = [
  "async-trait",
  "futures 0.3.9",
- "tokio 0.2.24",
+ "tokio",
 ]
 
 [[package]]
@@ -553,7 +553,7 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5e081f585760b508909cb08ff76e558053f80b95b7344d1c3846f695b188d03"
 dependencies = [
- "crossbeam-channel 0.5.0",
+ "crossbeam-channel",
 ]
 
 [[package]]
@@ -652,7 +652,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784ad0fbab4f3e9cef09f20e0aea6000ae08d2cb98ac4c0abc53df18803d702f"
 dependencies = [
  "percent-encoding 2.1.0",
- "time 0.2.24",
+ "time 0.2.25",
  "version_check 0.9.2",
 ]
 
@@ -691,16 +691,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
 dependencies = [
  "cfg-if 1.0.0",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b153fe7cbef478c567df0f972e02e6d736db11affe43dfc9c56a9374d1adfb87"
-dependencies = [
- "crossbeam-utils 0.7.2",
- "maybe-uninit",
 ]
 
 [[package]]
@@ -807,7 +797,7 @@ dependencies = [
  "crossbeam-queue",
  "num_cpus",
  "serde 1.0.119",
- "tokio 0.2.24",
+ "tokio",
 ]
 
 [[package]]
@@ -1272,7 +1262,7 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio 0.2.24",
+ "tokio",
  "tokio-util",
  "tracing",
  "tracing-futures",
@@ -1405,7 +1395,7 @@ dependencies = [
  "itoa",
  "pin-project 1.0.4",
  "socket2",
- "tokio 0.2.24",
+ "tokio",
  "tower-service",
  "tracing",
  "want",
@@ -1420,7 +1410,7 @@ dependencies = [
  "bytes 0.5.6",
  "hyper",
  "native-tls",
- "tokio 0.2.24",
+ "tokio",
  "tokio-tls",
 ]
 
@@ -2358,7 +2348,7 @@ dependencies = [
  "serde 1.0.119",
  "serde_json",
  "serde_urlencoded",
- "tokio 0.2.24",
+ "tokio",
  "tokio-tls",
  "url 2.2.0",
  "wasm-bindgen",
@@ -2757,11 +2747,11 @@ dependencies = [
 
 [[package]]
 name = "slog-async"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b3336ce47ce2f96673499fc07eb85e3472727b9a7a2959964b002c2ce8fbbb"
+checksum = "c60813879f820c85dbc4eabf3269befe374591289019775898d56a81a804fbdc"
 dependencies = [
- "crossbeam-channel 0.4.4",
+ "crossbeam-channel",
  "slog",
  "take_mut",
  "thread_local",
@@ -2796,9 +2786,9 @@ dependencies = [
 
 [[package]]
 name = "slog-scope"
-version = "4.3.0"
+version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c44c89dd8b0ae4537d1ae318353eaf7840b4869c536e31c41e963d1ea523ee6"
+checksum = "2f95a4b4c3274cd2869549da82b57ccc930859bdbf5bcea0424bc5f140b3c786"
 dependencies = [
  "arc-swap",
  "lazy_static",
@@ -2991,8 +2981,8 @@ dependencies = [
  "slog-scope",
  "slog-stdlog",
  "slog-term",
- "time 0.2.24",
- "tokio 1.0.1",
+ "time 0.2.25",
+ "tokio",
  "url 2.2.0",
  "urlencoding",
  "uuid",
@@ -3102,9 +3092,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.2.24"
+version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "273d3ed44dca264b0d6b3665e8d48fb515042d42466fad93d2a45b90ec4058f7"
+checksum = "1195b046942c221454c2539395f85413b33383a067449d78aab2b7b052a142f7"
 dependencies = [
  "const_fn",
  "libc",
@@ -3172,25 +3162,15 @@ dependencies = [
  "pin-project-lite 0.1.11",
  "signal-hook-registry",
  "slab",
+ "tokio-macros",
  "winapi 0.3.9",
 ]
 
 [[package]]
-name = "tokio"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d258221f566b6c803c7b4714abadc080172b272090cdc5e244a6d4dd13c3a6bd"
-dependencies = [
- "autocfg",
- "pin-project-lite 0.2.4",
- "tokio-macros",
-]
-
-[[package]]
 name = "tokio-macros"
-version = "1.0.0"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42517d2975ca3114b22a16192634e8241dc5cc1f130be194645970cc1c371494"
+checksum = "e44da00bfc73a25f814cd8d7e57a68a5c31b74b3152a0a1d1f590c97ed06265a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3204,7 +3184,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a70f4fcd7b3b24fb194f837560168208f669ca8cb70d0c4b862944452396343"
 dependencies = [
  "native-tls",
- "tokio 0.2.24",
+ "tokio",
 ]
 
 [[package]]
@@ -3218,7 +3198,7 @@ dependencies = [
  "futures-sink",
  "log",
  "pin-project-lite 0.1.11",
- "tokio 0.2.24",
+ "tokio",
 ]
 
 [[package]]
@@ -3283,7 +3263,7 @@ dependencies = [
  "rand 0.7.3",
  "smallvec",
  "thiserror",
- "tokio 0.2.24",
+ "tokio",
  "url 2.2.0",
 ]
 
@@ -3303,7 +3283,7 @@ dependencies = [
  "resolv-conf",
  "smallvec",
  "thiserror",
- "tokio 0.2.24",
+ "tokio",
  "trust-dns-proto",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,8 @@ slog-scope = "4.3"
 slog-stdlog = "4.1"
 slog-term = "2.6"
 time = "^0.2.23"
-tokio = { version = "1.0", features = ["macros", "sync", "rt"] }
+# pinning to 0.2.4 due to high number of dependencies (actix, bb8, deadpool, etc.)
+tokio = { version = "0.2.4", features = ["macros", "sync"] }
 url = "2.1"
 urlencoding = "1.1"
 uuid = { version = "0.8.2", features = ["serde", "v4"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syncstorage"
-version = "0.8.4"
+version = "0.8.5"
 license = "MPL-2.0"
 authors = [
   "Ben Bangert <ben@groovie.org>",

--- a/src/server/test.rs
+++ b/src/server/test.rs
@@ -76,6 +76,7 @@ async fn get_test_state(settings: &Settings) -> ServerState {
         metrics: Box::new(metrics),
         port: settings.port,
         quota_enabled: settings.enable_quota,
+        deadman: Arc::new(RwLock::new(Deadman::default())),
     }
 }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -121,7 +121,7 @@ impl Settings {
         s.set_default("database_pool_connection_timeout", Some(30))?;
         s.set_default("database_use_test_transactions", false)?;
         s.set_default("master_secret", "")?;
-        s.set_default::<Option<String>>("database_pool_max_size", Some("10".to_owned()))?;
+        s.set_default("database_pool_max_size", Some(10))?;
         s.set_default::<Option<String>>("tokenserver_database_url", None)?;
         s.set_default::<Option<String>>("tokenserver_jwks_rsa_modulus", None)?;
         s.set_default::<Option<String>>("tokenserver_jwks_rsa_exponent", None)?;

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -123,7 +123,7 @@ impl Settings {
         s.set_default("master_secret", "")?;
         // Each backend does their own default process, so specifying a "universal" value
         // for database_pool_max_size doesn't quite work. Generally the max pool size is
-        // 10. 
+        // 10.
         s.set_default::<Option<String>>("tokenserver_database_url", None)?;
         s.set_default::<Option<String>>("tokenserver_jwks_rsa_modulus", None)?;
         s.set_default::<Option<String>>("tokenserver_jwks_rsa_exponent", None)?;

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -33,6 +33,13 @@ pub struct Quota {
     pub enforced: bool,
 }
 
+#[derive(Copy, Clone, Default, Debug)]
+pub struct Deadman {
+    pub max_size: Option<u32>,
+    pub previous_count: usize,
+    pub clock_start: Option<time::Instant>,
+}
+
 #[derive(Clone, Debug, Deserialize)]
 pub struct Settings {
     pub debug: bool,
@@ -114,6 +121,7 @@ impl Settings {
         s.set_default("database_pool_connection_timeout", Some(30))?;
         s.set_default("database_use_test_transactions", false)?;
         s.set_default("master_secret", "")?;
+        s.set_default::<Option<String>>("database_pool_max_size", Some("10".to_owned()))?;
         s.set_default::<Option<String>>("tokenserver_database_url", None)?;
         s.set_default::<Option<String>>("tokenserver_jwks_rsa_modulus", None)?;
         s.set_default::<Option<String>>("tokenserver_jwks_rsa_exponent", None)?;

--- a/src/web/extractors.rs
+++ b/src/web/extractors.rs
@@ -1673,13 +1673,14 @@ mod tests {
     use rand::{thread_rng, Rng};
     use serde_json::{self, json};
     use sha2::Sha256;
+    use tokio::sync::RwLock;
 
     use crate::db::{
         mock::{MockDb, MockDbPool},
         Db,
     };
     use crate::server::{metrics, ServerState};
-    use crate::settings::{Secrets, ServerLimits, Settings};
+    use crate::settings::{Deadman, Secrets, ServerLimits, Settings};
 
     use crate::web::auth::{hkdf_expand_32, HawkPayload};
 
@@ -1715,6 +1716,7 @@ mod tests {
             port: 8000,
             metrics: Box::new(metrics::metrics_from_opts(&settings).unwrap()),
             quota_enabled: settings.enable_quota,
+            deadman: Arc::new(RwLock::new(Deadman::default())),
         }
     }
 

--- a/src/web/handlers.rs
+++ b/src/web/handlers.rs
@@ -540,6 +540,53 @@ pub async fn heartbeat(hb: HeartbeatRequest) -> Result<HttpResponse, Error> {
     }
 }
 
+pub async fn lbheartbeat(req: HttpRequest) -> Result<HttpResponse, Error> {
+    let mut resp: HashMap<String, Value> = HashMap::new();
+
+    let state = match req.app_data::<Data<ServerState>>() {
+        Some(s) => s,
+        None => {
+            error!("⚠️ Could not load the app state");
+            return Ok(HttpResponse::InternalServerError().body(""));
+        }
+    };
+
+    let deadarc = state.deadman.clone();
+    let mut deadman = *deadarc.read().await;
+    let db_state = state.db_pool.clone().state();
+
+    if let Some(max_size) = deadman.max_size {
+        if db_state.connections >= max_size && db_state.idle_connections == 0 {
+            if deadman.previous_count > 0 {
+                deadman.clock_start = Some(time::Instant::now());
+            }
+        } else if deadman.clock_start.is_some() {
+                deadman.clock_start = None
+            }
+        deadman.previous_count = db_state.idle_connections as usize;
+        {
+            *deadarc.write().await = deadman;
+        }
+        resp.insert(
+            "active_connections".to_string(),
+            Value::from(db_state.connections),
+        );
+        resp.insert(
+            "idle_connections".to_string(),
+            Value::from(db_state.idle_connections),
+        );
+        if let Some(clock) = deadman.clock_start {
+            let duration: time::Duration = time::Instant::now() - clock;
+            resp.insert(
+                "duration_ms".to_string(),
+                Value::from(duration.whole_milliseconds()),
+            );
+        };
+    }
+
+    Ok(HttpResponse::Ok().json(json!(resp)))
+}
+
 // try returning an API error
 pub async fn test_error(
     _req: HttpRequest,

--- a/src/web/handlers.rs
+++ b/src/web/handlers.rs
@@ -569,10 +569,7 @@ pub async fn lbheartbeat(req: HttpRequest) -> Result<HttpResponse, Error> {
         {
             *deadarc.write().await = deadman;
         }
-        resp.insert(
-            "active_connections".to_string(),
-            Value::from(active),
-        );
+        resp.insert("active_connections".to_string(), Value::from(active));
         resp.insert(
             "idle_connections".to_string(),
             Value::from(db_state.idle_connections),

--- a/src/web/handlers.rs
+++ b/src/web/handlers.rs
@@ -561,8 +561,8 @@ pub async fn lbheartbeat(req: HttpRequest) -> Result<HttpResponse, Error> {
                 deadman.clock_start = Some(time::Instant::now());
             }
         } else if deadman.clock_start.is_some() {
-                deadman.clock_start = None
-            }
+            deadman.clock_start = None
+        }
         deadman.previous_count = db_state.idle_connections as usize;
         {
             *deadarc.write().await = deadman;


### PR DESCRIPTION
## Description

This will add several fields to `__lbheartbeat__` if
`database_pool_max_size` is specified. These include:

```json
{
  "active_connections": ... /* Number of active connections */,
  "idle_connections": ... /* number of idle connections */,
  "duration": ... /* how long no idle connections have been availble */,
}
```

Note that "duration" will only be present if `idle_connections` has been
zero since the last time a check was performed.

* this also adds `database_pool_max_size` as a config option.

## Testing

`curl http://{server}/__lbheartbeat` should return 
200  with a body of
`{"active_connections":0,"idle_connections":0}`

(values may differ depending on the server being queried.

A saturated server should return something like:
`{"active_connections":0,"idle_connections":0, "duration_ms": 1000}`

indicating that the server has been saturated for 1 second. 
*Note* the saturation is only checked on each call to `__lbheartbeat__`, however that should be sufficient for most of the instances we've seen. 

## Issue(s)

Issue: #945

