### PR TITLE
chore: RUSTSEC-2021-0020 fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1379,9 +1379,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.13.9"
+version = "0.13.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ad767baac13b44d4529fcf58ba2cd0995e36e7b435bc5b039de6f47e880dbf"
+checksum = "8a6f157065790a3ed2f88679250419b5cdd96e714a0d65f7797fd337186e96bb"
 dependencies = [
  "bytes 0.5.6",
  "futures-channel",
@@ -2968,6 +2968,7 @@ dependencies = [
  "hkdf",
  "hmac",
  "hostname",
+ "hyper",
  "jsonwebtoken",
  "lazy_static",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ googleapis-raw = { version = "0", path = "vendor/mozilla-rust-sdk/googleapis-raw
 # syncserver to either fail to either compile, or start. In those cases, try
 # `cargo build --features grpcio/openssl ...`
 grpcio = { version = "0.7" }
+hyper = "0.13.10"  # RUSTSEC-2021-0020 requires 0.13.10+ or 0.14.3+
 lazy_static = "1.4.0"
 pyo3 = "0.13"
 hawk = "3.2"


### PR DESCRIPTION
Closes #999

## Description

Include updated hyper 

## Testing

N/A (internal build requirement)

## Issue(s)

Closes #999.
