### PR TITLE
bug: ensure "extra" data added to Hawk header in e2e tests

### DIFF
--- a/tools/integration_tests/test_storage.py
+++ b/tools/integration_tests/test_storage.py
@@ -885,7 +885,7 @@ class TestStorage(StorageFunctionalTestCase):
         # trying weird args and make sure the server returns 400s
         # Note: "Offset" is a string since the bsoid could be anything.
         # skipping that for now.
-        args = ('newer', 'older', 'limit', 'offset')
+        args = ('newer', 'older', 'limit')
         for arg in args:
             value = randtext()
             self.app.get(self.root + '/storage/xxx_col2?%s=%s' % (arg, value),

--- a/tools/integration_tests/test_support.py
+++ b/tools/integration_tests/test_support.py
@@ -386,14 +386,18 @@ class StorageFunctionalTestCase(FunctionalTestCase, StorageTestCase):
         if global_secret is not None:
             policy.secrets._secrets = [global_secret]
         self.user_id = random.randint(1, 100000)
+        self.fxa_uid = "DECAFBAD" + str(uuid.uuid4().hex)[8:]
+        self.hashed_fxa_uid = str(uuid.uuid4().hex)
+        self.fxa_kid = "0000000000000-DECAFBAD" + str(
+            uuid.uuid4().hex)[8:]
         auth_policy = self.config.registry.getUtility(IAuthenticationPolicy)
         req = Request.blank(self.host_url)
         creds = auth_policy.encode_hawk_id(
             req, self.user_id, extra={
                 # Include a hashed_fxa_uid to trigger uid/kid extraction
-                "hashed_fxa_uid": str(uuid.uuid4()),
-                "fxa_uid": str(uuid.uuid4()),
-                "fxa_kid": str(uuid.uuid4()),
+                "hashed_fxa_uid": self.hashed_fxa_uid,
+                "fxa_uid": self.fxa_uid,
+                "fxa_kid": self.fxa_kid,
             }
         )
         self.auth_token, self.auth_secret = creds
@@ -569,6 +573,8 @@ class TokenServerAuthenticationPolicy(HawkAuthenticationPolicy):
         # the last one aka the "most recent" secret.
         secret = self._get_token_secrets(node_name)[-1]
         data = {"uid": userid, "node": node_name}
+        if extra is not None:
+            data.update(extra)
         tokenid = tokenlib.make_token(data, secret=secret)
         key = tokenlib.get_derived_secret(tokenid, secret=secret)
         return tokenid, key


### PR DESCRIPTION
## Description

Make sure that the "extra" data passed to `

## Testing

Code added to testing routines. 

## Issue(s)

Closes #1002.
