### PR TITLE
doc: Add reminders to notify iOS team on changing limits

### DIFF
--- a/spanner_config.ini
+++ b/spanner_config.ini
@@ -1,2 +1,8 @@
 # Limit the number of incoming records (See issue #298/#333/#869)
+# NOTE: Make sure to alert the iOS team after altering any of these values
+# in production <https://github.com/mozilla-mobile/firefox-ios/issues>
+# * limits.MAX_REQUEST_BYTES
+# * limits.MAX_POST_REQCORDS
+# * limits.MAX_TOTAL_RECORDS
+# * limits.MAX_TOTAL_BYTES
 limits.max_total_records=1664

--- a/src/db/spanner/BATCH_COMMIT.txt
+++ b/src/db/spanner/BATCH_COMMIT.txt
@@ -56,3 +56,12 @@ Totals:
 
 - quota: True
   6 + 19968 + 1 + 6 = 19981
+
+
+**NOTE** iOS hardcodes syncstorage values. ANY ALTERATION OF THE FOLLOWING VALUES
+MUST REQUIRE FILING AN ISSUE WITH THE iOS TEAM!
+<https://github.com/mozilla-mobile/firefox-ios/issues>
+* MAX_REQUEST_BYTES
+* MAX_POST_REQCORDS
+* MAX_TOTAL_RECORDS
+* MAX_TOTAL_BYTES


### PR DESCRIPTION
## Description

Adds documentation and comment requiring notification of the iOS team to change their hard coded values whenever we alter a limit.

## Testing

documentation

## Issue(s)

Closes #1026.
