### PR TITLE
bug: report query parameters with Invalid Value error

### DIFF
--- a/src/db/mysql/batch.rs
+++ b/src/db/mysql/batch.rs
@@ -179,7 +179,7 @@ pub fn do_append(
             user_id = user_id,
             bso_id = bso_id,
         )
-    };
+    }
 
     // It's possible for the list of items to contain a duplicate key entry.
     // This means that we can't really call `ON DUPLICATE` here, because that's
@@ -192,7 +192,7 @@ pub fn do_append(
         user_id: i64,
         batch_id: i64,
         id: String,
-    };
+    }
 
     #[derive(AsChangeset)]
     #[table_name = "batch_upload_items"]

--- a/src/db/mysql/models.rs
+++ b/src/db/mysql/models.rs
@@ -729,7 +729,7 @@ impl MysqlDb {
             .filter(user_collections::user_id.eq(user_id))
             .first::<Option<i64>>(&self.conn)?
             .unwrap_or_default();
-        Ok(SyncTimestamp::from_i64(modified)?)
+        SyncTimestamp::from_i64(modified)
     }
 
     pub fn get_collection_timestamp_sync(
@@ -766,7 +766,7 @@ impl MysqlDb {
             .first::<i64>(&self.conn)
             .optional()?
             .unwrap_or_default();
-        Ok(SyncTimestamp::from_i64(modified)?)
+        SyncTimestamp::from_i64(modified)
     }
 
     pub fn get_collection_timestamps_sync(

--- a/src/db/spanner/batch.rs
+++ b/src/db/spanner/batch.rs
@@ -277,7 +277,7 @@ pub async fn do_append_async(
         sortindex: Option<i32>,
         payload: Option<String>,
         ttl: Option<u32>,
-    };
+    }
 
     //prefetch the existing batch_bsos for this user's batch.
     let mut existing = HashSet::new();

--- a/src/db/transaction.rs
+++ b/src/db/transaction.rs
@@ -39,7 +39,7 @@ fn set_extra(exts: &mut RefMut<'_, Extensions>, connection_info: ConnectionInfo)
         &connection_info.spanner_age.to_string(),
     );
     tags.add_extra(
-        "spanner_sconnection_idle",
+        "spanner_connection_idle",
         &connection_info.spanner_idle.to_string(),
     );
     tags.commit(exts);

--- a/src/server/test.rs
+++ b/src/server/test.rs
@@ -329,7 +329,8 @@ async fn delete_collection() {
         &move |result: DeleteBso| {
             assert!(
                 result == SyncTimestamp::from_seconds(0.00),
-                format!("Bad Bookmarks {:?} != 0", result)
+                "Bad Bookmarks {:?} != 0",
+                result
             );
         },
     )
@@ -340,7 +341,9 @@ async fn delete_collection() {
         &move |result: DeleteBso| {
             assert!(
                 result > start,
-                format!("Bad Bookmarks ids {:?} < {:?}", result, start)
+                "Bad Bookmarks ids {:?} < {:?}",
+                result,
+                start
             );
         },
     )
@@ -351,7 +354,9 @@ async fn delete_collection() {
         &move |result: DeleteBso| {
             assert!(
                 result > start,
-                format!("Bad Bookmarks ids, m {:?} < {:?}", result, start)
+                "Bad Bookmarks ids, m {:?} < {:?}",
+                result,
+                start
             );
         },
     )

--- a/src/web/extractors.rs
+++ b/src/web/extractors.rs
@@ -34,7 +34,6 @@ use crate::settings::Secrets;
 use crate::web::{
     auth::HawkPayload,
     error::{HawkErrorKind, ValidationErrorKind},
-    tags::Tags,
     X_WEAVE_RECORDS,
 };
 const BATCH_MAX_IDS: usize = 100;
@@ -2302,15 +2301,15 @@ mod tests {
 
     #[actix_rt::test]
     async fn test_offset() {
-        let sample_offset = Offset{
+        let sample_offset = Offset {
             timestamp: Some(SyncTimestamp::default()),
-            offset: 1234
+            offset: 1234,
         };
 
         //Issue559: only use offset, don't use timestamp, even if set.
-        let test_offset = Offset{
+        let test_offset = Offset {
             timestamp: None,
-            offset: sample_offset.offset
+            offset: sample_offset.offset,
         };
 
         let offset_str = sample_offset.to_string();

--- a/src/web/extractors.rs
+++ b/src/web/extractors.rs
@@ -34,6 +34,7 @@ use crate::settings::Secrets;
 use crate::web::{
     auth::HawkPayload,
     error::{HawkErrorKind, ValidationErrorKind},
+    tags::Tags,
     X_WEAVE_RECORDS,
 };
 const BATCH_MAX_IDS: usize = 100;
@@ -1216,6 +1217,10 @@ impl FromRequest for BsoQueryParams {
         Box::pin(async move {
             let params = Query::<BsoQueryParams>::from_request(&req, &mut payload)
                 .map_err(|e| {
+                    let mut exts = req.extensions_mut();
+                    let mut tags = Tags::default();
+                    tags.add_extra("query_params", req.query_string());
+                    tags.commit(&mut exts);
                     ValidationErrorKind::FromDetails(
                         e.to_string(),
                         RequestErrorLocation::QueryString,

--- a/src/web/middleware/rejectua.rs
+++ b/src/web/middleware/rejectua.rs
@@ -32,6 +32,7 @@ $
     .unwrap();
 }
 
+#[allow(clippy::clippy::upper_case_acronyms)]
 #[derive(Debug, Default)]
 pub struct RejectUA;
 
@@ -52,6 +53,7 @@ where
         future::ok(RejectUAMiddleware { service })
     }
 }
+#[allow(clippy::clippy::upper_case_acronyms)]
 
 pub struct RejectUAMiddleware<S> {
     service: S,

--- a/src/web/middleware/sentry.rs
+++ b/src/web/middleware/sentry.rs
@@ -68,8 +68,7 @@ pub fn queue_report(mut ext: RefMut<'_, Extensions>, err: &Error) {
         if let Some(events) = ext.get_mut::<Vec<Event<'static>>>() {
             events.push(event);
         } else {
-            let mut events: Vec<Event<'static>> = Vec::new();
-            events.push(event);
+            let events: Vec<Event<'static>> = vec![event];
             ext.insert(events);
         }
     }

--- a/src/web/tags.rs
+++ b/src/web/tags.rs
@@ -165,11 +165,11 @@ impl FromRequest for Tags {
     }
 }
 
-impl Into<BTreeMap<String, String>> for Tags {
-    fn into(self) -> BTreeMap<String, String> {
+impl From<Tags> for BTreeMap<String, String> {
+    fn from(tags: Tags) -> BTreeMap<String, String> {
         let mut result = BTreeMap::new();
 
-        for (k, v) in self.tags {
+        for (k, v) in tags.tags {
             result.insert(k.clone(), v.clone());
         }
 


### PR DESCRIPTION
## Description

This is not a resolution. Instead, this will report the query parameters
that lead to a serde parse failure so we can better isolate potential
problems.

(also fixes a typo in a logging message extra parameter)

## Testing

Invalid values in query params that trigger serde parse errors should result in sentry messages containing the query parameters

## Issue(s)

Issue #1029
