### PR TITLE
feat: Add "auto-split" arg to auto-gen UID prefixes

### DIFF
--- a/tools/spanner/purge_ttl.py
+++ b/tools/spanner/purge_ttl.py
@@ -112,6 +112,10 @@ def spanner_purge(args):
     instance = client.instance(args.instance_id)
     database = instance.database(args.database_id)
     expiry_condition = get_expiry_condition(args)
+    if args.auto_split:
+        args.uid_prefixes = [
+                hex(i).lstrip("0x").zfill(args.auto_split) for i in range(
+                    0, 16 ** args.auto_split)]
     prefixes = args.uid_prefixes if args.uid_prefixes else [None]
 
     for prefix in prefixes:
@@ -189,6 +193,14 @@ def get_args():
         default=os.environ.get("PURGE_UID_PREFIXES", "[]"),
         help="Array of strings used to limit purges based on UID. "
              "Each entry is a separate purge run."
+    )
+    parser.add_argument(
+        "--auto_split",
+        type=int,
+        default=os.environ.get("PURGE_AUTO_SPLIT"),
+        help="""Automatically generate `uid_prefixes` for this many digits, """
+          """(e.g. `3` would produce """
+          """`uid_prefixes=["000","001","002",...,"fff"])"""
     )
     parser.add_argument(
         "--mode",


### PR DESCRIPTION
Closes: #1034

## Description
adds `--auto_split` / `PURGE_AUTO_SPLIT` arg to auto-gen `uid_prefix` fields for _N_ digits, (e.g. `--auto_split=3` will generate prefixes of `["000","001","002",...,"fff"]`

## Testing

You can use `--dry_run` and verify that queries for each prefix are generated

## Issue(s)

Closes #1034.
