### PR TITLE
chore: tag 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+<a name="0.10.0"></a>
+## 0.10.0 (2021-04-05)
+
+
+#### Bug Fixes
+
+*   Restore hawk error metrics (#1033) ([f795eb08](https://github.com/mozilla-services/syncstorage-rs/commit/f795eb0813b4ee37463add5391c829c906fdb35d), closes [#812](https://github.com/mozilla-services/syncstorage-rs/issues/812))
+*   report query parameters with Invalid Value error (#1030) ([354cf794](https://github.com/mozilla-services/syncstorage-rs/commit/354cf794c59266dccfd3c6d12b880b466efa5650))
+
+#### Features
+
+*   Add "auto-split" arg to auto-gen UID prefixes (#1035) ([487ac11e](https://github.com/mozilla-services/syncstorage-rs/commit/487ac11ed0abf4ddc77cea1be852169846796a57))
+
+
+
 <a name="0.9.1"></a>
 ## 0.9.1 (2021-03-12)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2924,7 +2924,7 @@ dependencies = [
 
 [[package]]
 name = "syncstorage"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "actix-cors",
  "actix-http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syncstorage"
-version = "0.9.1"
+version = "0.10.0"
 license = "MPL-2.0"
 authors = [
   "Ben Bangert <ben@groovie.org>",


### PR DESCRIPTION
## 0.10.0 (2021-04-05)


#### Bug Fixes

*   Restore hawk error metrics (#1033) ([f795eb08](https://github.com/mozilla-services/syncstorage-rs/commit/f795eb0813b4ee37463add5391c829c906fdb35d), closes [#812](https://github.com/mozilla-services/syncstorage-rs/issues/812))
*   report query parameters with Invalid Value error (#1030) ([354cf794](https://github.com/mozilla-services/syncstorage-rs/commit/354cf794c59266dccfd3c6d12b880b466efa5650))

#### Features

*   Add "auto-split" arg to auto-gen UID prefixes (#1035) ([487ac11e](https://github.com/mozilla-services/syncstorage-rs/commit/487ac11ed0abf4ddc77cea1be852169846796a57))
