### PR TITLE
fix: use ValidationErrorKind metric_label in ApiError 

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -81,6 +81,7 @@ impl ApiErrorKind {
         match self {
             ApiErrorKind::Db(err) => err.metric_label(),
             ApiErrorKind::Hawk(err) => err.metric_label(),
+            ApiErrorKind::Validation(err) => err.metric_label(),
             _ => None,
         }
     }

--- a/src/web/error.rs
+++ b/src/web/error.rs
@@ -105,6 +105,21 @@ impl ValidationError {
     pub fn kind(&self) -> &ValidationErrorKind {
         self.inner.get_context()
     }
+
+    pub fn metric_label(&self) -> Option<String> {
+        match self.kind() {
+            ValidationErrorKind::FromDetails(
+                _description,
+                ref _location,
+                Some(ref _name),
+                metric_label,
+            ) => metric_label.clone(),
+            ValidationErrorKind::FromValidationErrors(_errors, _location, metric_label) => {
+                metric_label.clone()
+            }
+            _ => None,
+        }
+    }
 }
 
 /// Causes of extractor errors.

--- a/src/web/extractors.rs
+++ b/src/web/extractors.rs
@@ -158,7 +158,6 @@ impl FromRequest for BsoBodies {
     /// No collection id is used, so payload checks are not done here.
     fn from_request(req: &HttpRequest, payload: &mut Payload) -> Self::Future {
         // Only try and parse the body if its a valid content-type
-        let metrics = metrics::Metrics::from(req);
         let ctype = match ContentType::parse(req) {
             Ok(v) => v,
             Err(e) => {
@@ -167,7 +166,7 @@ impl FromRequest for BsoBodies {
                         format!("Unreadable Content-Type: {:?}", e),
                         RequestErrorLocation::Header,
                         Some("Content-Type".to_owned()),
-                        label!("request.validate.bad_content_type"),
+                        label!("request.validate.invalid_content_type"),
                     )
                     .into(),
                 ))
@@ -177,13 +176,12 @@ impl FromRequest for BsoBodies {
         trace!("BSO Body content_type: {:?}", &content_type);
 
         if !ACCEPTED_CONTENT_TYPES.contains(&content_type.as_ref()) {
-            metrics.incr("request.error.invalid_content_type");
             return Box::pin(future::err(
                 ValidationErrorKind::FromDetails(
                     format!("Invalid Content-Type {:?}", content_type),
                     RequestErrorLocation::Header,
                     Some("Content-Type".to_owned()),
-                    label!("request.validate.bad_content_type"),
+                    label!("request.validate.invalid_content_type"),
                 )
                 .into(),
             ));
@@ -364,7 +362,7 @@ impl FromRequest for BsoBody {
                         format!("Unreadable Content-Type: {:?}", e),
                         RequestErrorLocation::Header,
                         Some("Content-Type".to_owned()),
-                        label!("request.validate.bad_content_type"),
+                        label!("request.validate.invalid_content_type"),
                     )
                     .into(),
                 ))
@@ -377,7 +375,7 @@ impl FromRequest for BsoBody {
                     "Invalid Content-Type".to_owned(),
                     RequestErrorLocation::Header,
                     Some("Content-Type".to_owned()),
-                    label!("request.validate.bad_content_type"),
+                    label!("request.validate.invalid_content_type"),
                 )
                 .into(),
             ));

--- a/src/web/extractors.rs
+++ b/src/web/extractors.rs
@@ -166,7 +166,7 @@ impl FromRequest for BsoBodies {
                         format!("Unreadable Content-Type: {:?}", e),
                         RequestErrorLocation::Header,
                         Some("Content-Type".to_owned()),
-                        label!("request.validate.invalid_content_type"),
+                        label!("request.error.invalid_content_type"),
                     )
                     .into(),
                 ))
@@ -181,7 +181,7 @@ impl FromRequest for BsoBodies {
                     format!("Invalid Content-Type {:?}", content_type),
                     RequestErrorLocation::Header,
                     Some("Content-Type".to_owned()),
-                    label!("request.validate.invalid_content_type"),
+                    label!("request.error.invalid_content_type"),
                 )
                 .into(),
             ));
@@ -362,7 +362,7 @@ impl FromRequest for BsoBody {
                         format!("Unreadable Content-Type: {:?}", e),
                         RequestErrorLocation::Header,
                         Some("Content-Type".to_owned()),
-                        label!("request.validate.invalid_content_type"),
+                        label!("request.error.invalid_content_type"),
                     )
                     .into(),
                 ))
@@ -375,7 +375,7 @@ impl FromRequest for BsoBody {
                     "Invalid Content-Type".to_owned(),
                     RequestErrorLocation::Header,
                     Some("Content-Type".to_owned()),
-                    label!("request.validate.invalid_content_type"),
+                    label!("request.error.invalid_content_type"),
                 )
                 .into(),
             ));


### PR DESCRIPTION
## Description

* removes extra metric call
* fixes up label to match existing metrics

## Testing

Various validation errors (Like an invalid content type for a BSO) should not be sent to Sentry, but should instead increment an appropriate metric (e.g. `syncstorage.request.validate.invalid_content_type`)

## Issue(s)

Closes #1037.
