### PR TITLE
chore: tag 0.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+<a name="0.10.1"></a>
+## 0.10.1 (2021-04-14)
+
+
+#### Refactor
+
+*   Remove middleware::sentry::queue_report (#1040) ([0dccb00f](https://github.com/mozilla-services/syncstorage-rs/commit/0dccb00fb95d0aebabe79d5e6ecb1fb537445444))
+
+
+
 <a name="0.10.0"></a>
 ## 0.10.0 (2021-04-05)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2924,7 +2924,7 @@ dependencies = [
 
 [[package]]
 name = "syncstorage"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "actix-cors",
  "actix-http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syncstorage"
-version = "0.10.0"
+version = "0.10.1"
 license = "MPL-2.0"
 authors = [
   "Ben Bangert <ben@groovie.org>",


### PR DESCRIPTION
## 0.10.1 (2021-04-14)

* This minor tag caches changes to `purge_ttl.py` that were missed by 0.10.0

#### Refactor

*   Remove middleware::sentry::queue_report (#1040) ([0dccb00f](https://github.com/mozilla-services/syncstorage-rs/commit/0dccb00fb95d0aebabe79d5e6ecb1fb537445444))

