### PR TITLE
refactor: Use generic tuple extractor in web extractors

### DIFF
--- a/src/web/extractors.rs
+++ b/src/web/extractors.rs
@@ -665,11 +665,13 @@ impl FromRequest for CollectionRequest {
         let req = req.clone();
         let mut payload = Payload::None;
         async move {
-            let user_id = HawkIdentifier::from_request(&req, &mut payload).await?;
-            let query = BsoQueryParams::from_request(&req, &mut payload).await?;
-            let collection = CollectionParam::from_request(&req, &mut payload)
-                .await?
-                .collection;
+            let (user_id, query, collection) =
+                <(HawkIdentifier, BsoQueryParams, CollectionParam)>::from_request(
+                    &req,
+                    &mut payload,
+                )
+                .await?;
+            let collection = collection.collection;
 
             let accept = get_accepted(&req, &ACCEPTED_CONTENT_TYPES, "application/json");
             let reply = match accept.as_str() {
@@ -744,10 +746,12 @@ impl FromRequest for CollectionPostRequest {
 
             let max_post_records = i64::from(state.limits.max_post_records);
 
-            let user_id = HawkIdentifier::from_request(&req, &mut payload).await?;
-            let collection = CollectionParam::from_request(&req, &mut payload).await?;
-            let query = BsoQueryParams::from_request(&req, &mut payload).await?;
-            let mut bsos = BsoBodies::from_request(&req, &mut payload).await?;
+            let (user_id, query, collection, mut bsos) =
+                <(HawkIdentifier, BsoQueryParams, CollectionParam, BsoBodies)>::from_request(
+                    &req,
+                    &mut payload,
+                )
+                .await?;
 
             let collection = collection.collection;
             if collection == "crypto" {
@@ -813,12 +817,13 @@ impl FromRequest for BsoRequest {
         let req = req.clone();
         let mut payload = payload.take();
         Box::pin(async move {
-            let user_id = HawkIdentifier::from_request(&req, &mut payload).await?;
-            let query = BsoQueryParams::from_request(&req, &mut payload).await?;
-            let collection = CollectionParam::from_request(&req, &mut payload)
-                .await?
-                .collection;
-            let bso = BsoParam::from_request(&req, &mut payload).await?;
+            let (user_id, query, collection, bso) =
+                <(HawkIdentifier, BsoQueryParams, CollectionParam, BsoParam)>::from_request(
+                    &req,
+                    &mut payload,
+                )
+                .await?;
+            let collection = collection.collection;
 
             Ok(BsoRequest {
                 collection,
@@ -854,11 +859,15 @@ impl FromRequest for BsoPutRequest {
         let mut payload = payload.take();
 
         async move {
-            let user_id = HawkIdentifier::from_request(&req, &mut payload).await?;
-            let collection = CollectionParam::from_request(&req, &mut payload).await?;
-            let query = BsoQueryParams::from_request(&req, &mut payload).await?;
-            let bso = BsoParam::from_request(&req, &mut payload).await?;
-            let body = BsoBody::from_request(&req, &mut payload).await?;
+            let (user_id, query, collection, bso, body) =
+                <(
+                    HawkIdentifier,
+                    BsoQueryParams,
+                    CollectionParam,
+                    BsoParam,
+                    BsoBody,
+                )>::from_request(&req, &mut payload)
+                .await?;
 
             let collection = collection.collection;
             if collection == "crypto" {

--- a/src/web/extractors.rs
+++ b/src/web/extractors.rs
@@ -859,11 +859,11 @@ impl FromRequest for BsoPutRequest {
         let mut payload = payload.take();
 
         async move {
-            let (user_id, query, collection, bso, body) =
+            let (user_id, collection, query, bso, body) =
                 <(
                     HawkIdentifier,
-                    BsoQueryParams,
                     CollectionParam,
+                    BsoQueryParams,
                     BsoParam,
                     BsoBody,
                 )>::from_request(&req, &mut payload)

--- a/src/web/extractors.rs
+++ b/src/web/extractors.rs
@@ -746,8 +746,8 @@ impl FromRequest for CollectionPostRequest {
 
             let max_post_records = i64::from(state.limits.max_post_records);
 
-            let (user_id, query, collection, mut bsos) =
-                <(HawkIdentifier, BsoQueryParams, CollectionParam, BsoBodies)>::from_request(
+            let (user_id, collection, query, mut bsos) =
+                <(HawkIdentifier, CollectionParam, BsoQueryParams, BsoBodies)>::from_request(
                     &req,
                     &mut payload,
                 )


### PR DESCRIPTION
## Description

Refactors parts of the web extractors to use a generic tuple extractor pattern in Rust. There was some discussion in #698 as to which of the two variants is more performant:

Generic tuple extraction:
```rust
let (user_id, query, collection, bso, body) =
    <(
        HawkIdentifier,
        BsoQueryParams,
        CollectionParam,
        BsoParam,
        BsoBody,
    )>::from_request(&req, &mut payload)
    .await?;
```

Extracting the values separately:
```rust
let user_id = HawkIdentifier::from_request(&req, &mut payload).await?;
let collection = CollectionParam::from_request(&req, &mut payload).await?;
let query = BsoQueryParams::from_request(&req, &mut payload).await?;
let bso = BsoParam::from_request(&req, &mut payload).await?;
let body = BsoBody::from_request(&req, &mut payload).await?;
```

The idea is that in the second example above, once the request future resolves, all of the `*::from_request` function calls will happen serially and immediately, resulting in a lot of pushes/pops to/from the call stack. Since these extractors are used in the context of a web request that grabs things from the database, I'd expect any performance difference between the two patterns to be negligible. That said, I may be off-base, and I'd love to learn why if that's the case!

## Testing

This is just a refactor, and there should be no difference in functionality introduced by this change. To ensure that nothing has changed, you could either:
1. Use the sync feature in Firefox such that each of the four extractors is used without an issue
2. Test endpoints that use these extractors using curl/Postman 

## Issue(s)

Closes #698 