### PR TITLE
Refactor/952 add metric for spanner pool get

### DIFF
--- a/src/db/spanner/pool.rs
+++ b/src/db/spanner/pool.rs
@@ -91,6 +91,9 @@ impl SpannerDbPool {
 #[async_trait(?Send)]
 impl DbPool for SpannerDbPool {
     async fn get<'a>(&'a self) -> ApiResult<Box<dyn Db<'a>>> {
+        let mut metrics = self.metrics.clone();
+        metrics.start_timer("storage.spanner.get_pool", None);
+
         self.get_async()
             .await
             .map(|db| Box::new(db) as Box<dyn Db<'a>>)

--- a/src/server/metrics.rs
+++ b/src/server/metrics.rs
@@ -3,16 +3,13 @@ use std::time::Instant;
 
 use actix_web::{error::ErrorInternalServerError, web::Data, Error, HttpRequest};
 use cadence::{
-    BufferedUdpMetricSink, Counted, Metric, NopMetricSink, QueuingMetricSink, SpyMetricSink, StatsdClient, Timed,
+    BufferedUdpMetricSink, Counted, Metric, NopMetricSink, QueuingMetricSink, StatsdClient, Timed,
 };
 
 use crate::error::ApiError;
 use crate::server::ServerState;
 use crate::settings::Settings;
 use crate::web::tags::Tags;
-
-use std::fs::File;
-use std::sync::{Arc, Mutex};
 
 #[derive(Debug, Clone)]
 pub struct MetricTimer {
@@ -178,10 +175,8 @@ pub fn metrics_from_opts(opts: &Settings) -> Result<StatsdClient, ApiError> {
 
         let host = (statsd_host.as_str(), opts.statsd_port);
         let udp_sink = BufferedUdpMetricSink::from(host, socket)?;
-        // let sink = QueuingMetricSink::from(udp_sink);
-        let file = File::create("foo.txt")?;
-        let spy = SpyMetricSink::from(Arc::new(Mutex::new(file)));
-        StatsdClient::builder(opts.statsd_label.as_ref(), spy)
+        let sink = QueuingMetricSink::from(udp_sink);
+        StatsdClient::builder(opts.statsd_label.as_ref(), sink)
     } else {
         StatsdClient::builder(opts.statsd_label.as_ref(), NopMetricSink)
     };


### PR DESCRIPTION
## Description

Adds a timer that tracks the time it takes to get a new Spanner pool. It seemed like this was the right approach based on other areas in the code we're logging elapsed time. I think we'll need to add the new timer to [this chart](https://earthangel-b40313e5.influxcloud.net/d/5kIPrfbWj/sync-rs-prod?orgId=1&refresh=1m&from=1618217737611&to=1618239337611&viewPanel=8) or make a new chart entirely on the same dashboard.

## Testing
I was able to test this by swapping out the `QueuingMetricSync` [here](https://github.com/mozilla-services/syncstorage-rs/blob/master/src/server/metrics.rs#L178) with a [`SpyMetricSync`](https://docs.rs/cadence/0.25.0/cadence/struct.SpyMetricSink.html#impl-From%3CT%3E) that prints to a file like so:
```rust
let file = File::create("foo.txt")?;
let spy = SpyMetricSink::from(Arc::new(Mutex::new(file)));
StatsdClient::builder(opts.statsd_label.as_ref(), spy)
```

The metrics that would have been sent to sentry were logged to a file named "foo.txt", and I was able to confirm that the metric I added worked as expected. I included a commit (b658de0) on this branch with these changes so the reviewer can try it out themselves.

I didn't see unit tests for the metrics logging, so I didn't add one for this change, but it's totally possible I just couldn't find them!

## Issue(s)

Closes #952 
