### PR TITLE
refactor: Add ToSpannerValue trait

### DIFF
--- a/src/db/spanner/batch.rs
+++ b/src/db/spanner/batch.rs
@@ -355,7 +355,8 @@ pub async fn do_append_async(
         } else {
             let sortindex = bso
                 .sortindex
-                .map(|sortindex| sortindex.to_spanner_value())
+                .as_ref()
+                .map(ToSpannerValue::to_spanner_value)
                 .unwrap_or_else(null_value);
             let payload = bso
                 .payload

--- a/src/db/spanner/batch.rs
+++ b/src/db/spanner/batch.rs
@@ -359,10 +359,12 @@ pub async fn do_append_async(
                 .unwrap_or_else(null_value);
             let payload = bso
                 .payload
+                .as_ref()
                 .map(ToSpannerValue::to_spanner_value)
                 .unwrap_or_else(null_value);
             let ttl = bso
                 .ttl
+                .as_ref()
                 .map(ToSpannerValue::to_spanner_value)
                 .unwrap_or_else(null_value);
 
@@ -483,10 +485,7 @@ pub async fn do_append_async(
             };
             if let Some(sortindex) = val.sortindex {
                 fields.push("sortindex");
-                params.insert(
-                    "sortindex".to_owned(),
-                    ToSpannerValue::to_spanner_value(sortindex.to_string()),
-                );
+                params.insert("sortindex".to_owned(), sortindex.to_spanner_value());
             }
             if let Some(payload) = val.payload {
                 fields.push("payload");

--- a/src/db/spanner/batch.rs
+++ b/src/db/spanner/batch.rs
@@ -10,11 +10,8 @@ use protobuf::{
 };
 use uuid::Uuid;
 
-use super::support::{null_value, struct_type_field};
-use super::{
-    models::{Result, SpannerDb, DEFAULT_BSO_TTL, PRETOUCH_TS},
-    support::{as_list_value, as_value},
-};
+use super::models::{Result, SpannerDb, DEFAULT_BSO_TTL, PRETOUCH_TS};
+use super::support::{null_value, struct_type_field, ToSpannerValue};
 use crate::{
     db::{params, results, util::to_rfc3339, DbError, DbErrorKind, BATCH_LIFETIME},
     web::{extractors::HawkIdentifier, tags::Tags},
@@ -298,7 +295,10 @@ pub async fn do_append_async(
         "collection_id" => collection_id.to_string(),
         "batch_id" => batch.id.clone(),
     };
-    params.insert("ids".to_owned(), as_list_value(bso_ids));
+    params.insert(
+        "ids".to_owned(),
+        bso_ids.collect::<Vec<String>>().to_spanner_value(),
+    );
     let mut existing_stream = db
         .sql(
             "SELECT batch_bso_id
@@ -355,23 +355,26 @@ pub async fn do_append_async(
         } else {
             let sortindex = bso
                 .sortindex
-                .map(|sortindex| as_value(sortindex.to_string()))
+                .map(|sortindex| sortindex.to_spanner_value())
                 .unwrap_or_else(null_value);
-            let payload = bso.payload.map(as_value).unwrap_or_else(null_value);
+            let payload = bso
+                .payload
+                .map(ToSpannerValue::to_spanner_value)
+                .unwrap_or_else(null_value);
             let ttl = bso
                 .ttl
-                .map(|ttl| as_value(ttl.to_string()))
+                .map(ToSpannerValue::to_spanner_value)
                 .unwrap_or_else(null_value);
 
             // convert to a protobuf structure for direct insertion to
             // avoid some mutation limits.
             let mut row = ListValue::new();
             row.set_values(RepeatedField::from_vec(vec![
-                as_value(user_id.fxa_uid.clone()),
-                as_value(user_id.fxa_kid.clone()),
-                as_value(collection_id.to_string()),
-                as_value(batch.id.clone()),
-                as_value(bso.id),
+                user_id.fxa_uid.clone().to_spanner_value(),
+                user_id.fxa_kid.clone().to_spanner_value(),
+                collection_id.to_spanner_value(),
+                batch.id.clone().to_spanner_value(),
+                bso.id.to_spanner_value(),
                 sortindex,
                 payload,
                 ttl,
@@ -480,15 +483,18 @@ pub async fn do_append_async(
             };
             if let Some(sortindex) = val.sortindex {
                 fields.push("sortindex");
-                params.insert("sortindex".to_owned(), as_value(sortindex.to_string()));
+                params.insert(
+                    "sortindex".to_owned(),
+                    ToSpannerValue::to_spanner_value(sortindex.to_string()),
+                );
             }
             if let Some(payload) = val.payload {
                 fields.push("payload");
-                params.insert("payload".to_owned(), as_value(payload));
+                params.insert("payload".to_owned(), payload.to_spanner_value());
             };
             if let Some(ttl) = val.ttl {
                 fields.push("ttl");
-                params.insert("ttl".to_owned(), as_value(ttl.to_string()));
+                params.insert("ttl".to_owned(), ttl.to_spanner_value());
             }
             if fields.is_empty() {
                 continue;
@@ -545,7 +551,10 @@ async fn pretouch_collection_async(
         .one_or_none()
         .await?;
     if result.is_none() {
-        sqlparams.insert("modified".to_owned(), as_value(PRETOUCH_TS.to_owned()));
+        sqlparams.insert(
+            "modified".to_owned(),
+            PRETOUCH_TS.to_owned().to_spanner_value(),
+        );
         let sql = if db.quota.enabled {
             "INSERT INTO user_collections (fxa_uid, fxa_kid, collection_id, modified, count, total_bytes)
             VALUES (@fxa_uid, @fxa_kid, @collection_id, @modified, 0, 0)"

--- a/src/db/spanner/macros.rs
+++ b/src/db/spanner/macros.rs
@@ -8,7 +8,7 @@ macro_rules! params {
             let _cap = params!(@count $($key),*);
             let mut _map = ::std::collections::HashMap::with_capacity(_cap);
             $(
-                _map.insert($key.to_owned(), ToSpannerValue::to_spanner_value($value));
+                _map.insert($key.to_owned(), ToSpannerValue::to_spanner_value(&$value));
             )*
             _map
         }

--- a/src/db/spanner/macros.rs
+++ b/src/db/spanner/macros.rs
@@ -8,7 +8,7 @@ macro_rules! params {
             let _cap = params!(@count $($key),*);
             let mut _map = ::std::collections::HashMap::with_capacity(_cap);
             $(
-                _map.insert($key.to_owned(), as_value($value));
+                _map.insert($key.to_owned(), ToSpannerValue::to_spanner_value($value));
             )*
             _map
         }

--- a/src/db/spanner/support.rs
+++ b/src/db/spanner/support.rs
@@ -27,29 +27,29 @@ use crate::{
 use super::{models::Result, pool::Conn};
 
 pub trait ToSpannerValue {
-    fn to_spanner_value(self) -> Value;
+    fn to_spanner_value(&self) -> Value;
 }
 
 impl ToSpannerValue for String {
-    fn to_spanner_value(self) -> Value {
+    fn to_spanner_value(&self) -> Value {
         let mut value = Value::new();
-        value.set_string_value(self);
+        value.set_string_value(self.clone());
         value
     }
 }
 
 impl ToSpannerValue for i32 {
-    fn to_spanner_value(self) -> Value {
+    fn to_spanner_value(&self) -> Value {
         let mut value = Value::new();
-        value.set_number_value(self as f64);
+        value.set_number_value(*self as f64);
         value
     }
 }
 
 impl ToSpannerValue for u32 {
-    fn to_spanner_value(self) -> Value {
+    fn to_spanner_value(&self) -> Value {
         let mut value = Value::new();
-        value.set_number_value(self as f64);
+        value.set_number_value(*self as f64);
         value
     }
 }
@@ -62,7 +62,7 @@ impl<T> ToSpannerValue for Vec<T>
 where
     T: ToSpannerValue + Clone,
 {
-    fn to_spanner_value(self) -> Value {
+    fn to_spanner_value(&self) -> Value {
         let mut list = ListValue::new();
         list.set_values(RepeatedField::from_vec(
             self.iter().map(|v| v.clone().to_spanner_value()).collect(),

--- a/src/db/spanner/support.rs
+++ b/src/db/spanner/support.rs
@@ -353,7 +353,7 @@ pub fn bso_to_insert_row(
 ) -> Result<ListValue> {
     let sortindex = bso
         .sortindex
-        .map(|sortindex| sortindex.to_string().to_spanner_value())
+        .map(|sortindex| sortindex.to_spanner_value())
         .unwrap_or_else(null_value);
     let ttl = bso.ttl.unwrap_or(DEFAULT_BSO_TTL);
     let expiry = to_rfc3339(now.as_i64() + (i64::from(ttl) * 1000))?;
@@ -362,7 +362,7 @@ pub fn bso_to_insert_row(
     row.set_values(RepeatedField::from_vec(vec![
         user_id.fxa_uid.clone().to_spanner_value(),
         user_id.fxa_kid.clone().to_spanner_value(),
-        collection_id.to_string().to_spanner_value(),
+        collection_id.to_spanner_value(),
         bso.id.to_spanner_value(),
         sortindex,
         bso.payload.unwrap_or_default().to_spanner_value(),
@@ -382,7 +382,7 @@ pub fn bso_to_update_row(
     let mut values = vec![
         user_id.fxa_uid.clone().to_spanner_value(),
         user_id.fxa_kid.clone().to_spanner_value(),
-        collection_id.to_string().to_spanner_value(),
+        collection_id.to_spanner_value(),
         bso.id.to_spanner_value(),
     ];
 

--- a/src/db/spanner/support.rs
+++ b/src/db/spanner/support.rs
@@ -54,10 +54,6 @@ impl ToSpannerValue for u32 {
     }
 }
 
-// impl<T, V> ToSpannerValue for T
-// where
-//     T: Iterator<Item = V>,
-//     V: ToSpannerValue,
 impl<T> ToSpannerValue for Vec<T>
 where
     T: ToSpannerValue + Clone,


### PR DESCRIPTION
## Description

Improves our conversion of `String`s, `i32`s, and `u32`s to protobuf `Value`s by using a `ToSpannerValue` trait. This makes adding support for the conversion of a new type to a `Value` as easy as adding a `ToSpannerValue` implementation for that type.

## Testing

I tested this using the integration tests in `tools/integration_tests/`. To do this, I:
- Changed [this line](https://github.com/mozilla-services/syncstorage-rs/blob/master/tools/integration_tests/run.py#L25) to read:
```python
    the_server_subprocess = subprocess.Popen('SYNC_MASTER_SECRET=secret0 ' + target_binary + ' --config ./config/local.toml', shell=True)
```
- Ran `python3 tools/integration_tests/run.py 'http://localhost:8000#secret0'`

There was one integration test failure:
```
======================================================================
FAIL: test_batch_size_limits (test_storage.TestStorage)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/edonowitz/syncstorage-rs/tools/integration_tests/test_storage.py", line 1697, in test_batch_size_limits
    self.assertFalse(res.json['failed'])
AssertionError: {'big': 'db error', 'little': 'db error'} is not false
```

I confirmed that this test was also failing on the main branch, so I don't think the changes here introduced the failure.

## Issue(s)

Closes #260
