### PR TITLE
docs: Update spanner configuration documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@
 SYNC_DATABASE_URL = 'mysql://sample_user:sample_password@localhost/syncstorage_rs'
 
 # This key can live anywhere on your machine. Adjust path as needed.
+PATH_TO_SYNC_SPANNER_KEYS = `pwd`/service-account.json
+
 # TODO: replace with rust grpc alternative when ready
 # Assumes you've cloned the server-syncstorage repo locally into a peer dir.
 # https://github.com/mozilla-services/server-syncstorage
@@ -36,7 +38,7 @@ run:
 	RUST_LOG=debug RUST_BACKTRACE=full cargo run -- --config config/local.toml
 
 run_spanner:
-	GRPC_DEFAULT_SSL_ROOTS_FILE_PATH=$(PATH_TO_GRPC_CERT) make run
+	GOOGLE_APPLICATION_CREDENTIALS=$(PATH_TO_SYNC_SPANNER_KEYS) GRPC_DEFAULT_SSL_ROOTS_FILE_PATH=$(PATH_TO_GRPC_CERT) make run
 
 test:
 	SYNC_DATABASE_URL=$(SYNC_DATABASE_URL) RUST_TEST_THREADS=1 cargo test

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,6 @@
 SYNC_DATABASE_URL = 'mysql://sample_user:sample_password@localhost/syncstorage_rs'
 
 # This key can live anywhere on your machine. Adjust path as needed.
-PATH_TO_SYNC_SPANNER_KEYS = `pwd`/service-account.json
-
 # TODO: replace with rust grpc alternative when ready
 # Assumes you've cloned the server-syncstorage repo locally into a peer dir.
 # https://github.com/mozilla-services/server-syncstorage
@@ -38,7 +36,7 @@ run:
 	RUST_LOG=debug RUST_BACKTRACE=full cargo run -- --config config/local.toml
 
 run_spanner:
-	GOOGLE_APPLICATION_CREDENTIALS=$(PATH_TO_SYNC_SPANNER_KEYS) GRPC_DEFAULT_SSL_ROOTS_FILE_PATH=$(PATH_TO_GRPC_CERT) make run
+	GRPC_DEFAULT_SSL_ROOTS_FILE_PATH=$(PATH_TO_GRPC_CERT) make run
 
 test:
 	SYNC_DATABASE_URL=$(SYNC_DATABASE_URL) RUST_TEST_THREADS=1 cargo test

--- a/README.md
+++ b/README.md
@@ -74,15 +74,7 @@ First, install the Google Cloud command-line interface by following the instruct
 ```sh
 gcloud auth application-default login
 ```
-The above command will prompt you to visit a webpage in your browser to complete the login process. Once completed, ensure that a file called `application_default_credentials.json` has been created in the appropriate directory (on Linux, this directory is `$HOME/.config/gcloud/`). Now, create a symbolic link from this file to a file called `service-account.json` in the root of the repository:
-```sh
-ln -s /path/to/application_default_credentials.json /path/to/syncstorage-rs/service-account.json
-```
-**Make sure that the filename matches `service-account.json` exactly!** The `.gitignore` file is set to ignore that filename specifically, and a misspelling or typo could result in committing a private OAuth key to the public repository. To avoid such errors, consider installing a tool like [git secrets](https://github.com/awslabs/git-secrets), which will add a git commit hook that checks for sensitive information whenever you add a new commit.
-
-Using a symbolic link (as opposed to copying the file) has a couple of benefits:
-1. If the OAuth token is updated, the update will be reflected in `service-account.json` without additional steps.
-2. Key revocation is simpler. `gcloud auth application-default revoke` requires that the key to be revoked is stored in the correct place. *Copying* the key to another location could lead to situations in which multiple active application default credentials are present on your computer; using a symbolic link helps to ensure that the only active credentials are stored in `application_default_credentials.json`. 
+The above command will prompt you to visit a webpage in your browser to complete the login process. Once completed, ensure that a file called `application_default_credentials.json` has been created in the appropriate directory (on Linux, this directory is `$HOME/.config/gcloud/`). The Google Cloud SDK knows to check this location for your credentials, so no further configuration is needed.
 
 Note, that unlike MySQL, there is no automatic migrations facility. Currently Spanner schema must be hand edited and modified.
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ gcloud auth application-default revoke
 This will revoke the access of the credentials currently stored in the `application_default_credentials.json` file. **If the file in that location does not contain the leaked credentials, you will need to copy the file containing the leaked credentials to that location and re-run the above command.** You can ensure that the leaked credentials are no longer active by attempting to connect to Spanner using the credentials. If access has been revoked, your application server should print an error saying that the token has expired or has been revoked.
 
 #### Authenticating via Service Account
-An alternative to authentication via application default credentials is authentication via a service account. *Note that this method of authentication is not recommended. Service accounts are intended to be used by other applications or virtual machines and not people. See [this article](https://cloud.google.com/iam/docs/service-accounts#what_are_service_accounts) for more information.*
+An alternative to authentication via application default credentials is authentication via a service account. **Note that this method of authentication is not recommended. Service accounts are intended to be used by other applications or virtual machines and not people. See [this article](https://cloud.google.com/iam/docs/service-accounts#what_are_service_accounts) for more information.**
 
 Your system administrator will be able to tell you which service account keys have access to the Spanner instance to which you are trying to connect. Once you are given the email identifier of an active key, log into the [Google Cloud Console Service Accounts](https://console.cloud.google.com/iam-admin/serviceaccounts) page. Be sure to select the correct project.
 
@@ -113,7 +113,7 @@ The proper key file is in JSON format. An example file is provided below, with p
 }
 ```
 
-*Note that the name `service-account.json` must be exactly correct to be ignored by `.gitignore`.*
+**Note that the name `service-account.json` must be exactly correct to be ignored by `.gitignore`.**
 
 #### Connecting to Spanner
 To point to a GCP-hosted Spanner instance from your local machine, follow these steps:

--- a/README.md
+++ b/README.md
@@ -69,13 +69,20 @@ GRANT ALL PRIVILEGES on syncstorage_rs.* to sample_user@localhost;
 ### Spanner
 
 #### Authenticating via OAuth
-The correct way to authenticate with Spanner is by generating an OAuth token and pointing your local application server to the token. In order for this to work, your Google Cloud must have the correct permissions; contact the Ops team to ensure the correct permissions are added to your account.
+The correct way to authenticate with Spanner is by generating an OAuth token and pointing your local application server to the token. In order for this to work, your Google Cloud account must have the correct permissions; contact the Ops team to ensure the correct permissions are added to your account.
 
 First, install the Google Cloud command-line interface by following the instructions for your operating system [here](https://cloud.google.com/sdk/docs/install). Next, run the following to log in with your Google account (this should be the Google account associated with your Mozilla LDAP credentials):
 ```sh
 gcloud auth application-default login
 ```
 The above command will prompt you to visit a webpage in your browser to complete the login process. Once completed, ensure that a file called `application_default_credentials.json` has been created in the appropriate directory (on Linux, this directory is `$HOME/.config/gcloud/`). The Google Cloud SDK knows to check this location for your credentials, so no further configuration is needed.
+
+##### Key Revocation
+Accidents happen, and you may need to revoke the access of a set of credentials if they have been publicly leaked. To do this, run:
+```sh
+gcloud auth application-default revoke
+```
+This will revoke the access of the credentials currently stored in the `application_default_credentials.json` file. **If the file in that location does not contain the leaked credentials, you will need to copy the file containing the leaked credentials to that location and re-run the above command.** You can ensure that the leaked credentials are no longer active by attempting to connect to Spanner using the credentials. If access has been revoked, your application server should print an error saying that the token has expired or has been revoked.
 
 #### Authenticating via Service Account
 An alternative to authentication via application default credentials is authentication via a service account. *Note that this method of authentication is not recommended. Service accounts are intended to be used by other applications or virtual machines and not people. See [this article](https://cloud.google.com/iam/docs/service-accounts#what_are_service_accounts) for more information.*
@@ -117,15 +124,7 @@ To point to a GCP-hosted Spanner instance from your local machine, follow these 
 4. `make run_spanner`.
 5. Visit `http://localhost:8000/__heartbeat__` to make sure the server is running.
 
-Note, that unlike MySQL, there is no automatic migrations facility. Currently Spanner schema must be hand edited and modified.
-
-#### Key Revocation
-
-Accidents happen, and you may need to revoke the access of a set of credentials if they have been publicly leaked. To do this, run:
-```sh
-gcloud auth application-default revoke
-```
-This will revoke the access of the credentials currently stored in the `application_default_credentials.json` file. **If the file in that location does not contain the leaked credentials, you will need to copy the file containing the leaked credentials to that location and re-run the above command.** You can ensure that the leaked credentials are no longer active by attempting to connect to Spanner using the credentials. If access has been revoked, your application server should print an error saying that the token has expired or has been revoked.
+Note, that unlike MySQL, there is no automatic migrations facility. Currently, the Spanner schema must be hand edited and modified.
 
 #### Emulator
 Google supports an in-memory Spanner emulator, which can run on your local machine for development purposes. You can install the emulator via the gcloud CLI or Docker by following the instructions [here](https://cloud.google.com/spanner/docs/emulator#installing_and_running_the_emulator). Once the emulator is running, you'll need to create a new instance and a new database. To create an instance using the REST API (exposed via port 9020 on the emulator), we can use `curl`:

--- a/README.md
+++ b/README.md
@@ -77,16 +77,6 @@ gcloud auth application-default login
 ```
 The above command will prompt you to visit a webpage in your browser to complete the login process. Once completed, ensure that a file called `application_default_credentials.json` has been created in the appropriate directory (on Linux, this directory is `$HOME/.config/gcloud/`). The Google Cloud SDK knows to check this location for your credentials, so no further configuration is needed.
 
-Note, that unlike MySQL, there is no automatic migrations facility. Currently Spanner schema must be hand edited and modified.
-
-To point to a GCP hosted Spanner instance from your local machine, follow these steps:
-
-1. Create an OAuth token file as shown above.
-2. Open `local.toml` and replace `database_url` with a link to your spanner instance.
-3. Open the Makefile and ensure you've correctly set you `PATH_TO_GRPC_CERT`.
-4. `make run_spanner`.
-5. Visit `http://localhost:8000/__heartbeat__` to make sure the server is running.
-
 #### Authenticating via Service Account
 An alternative to authentication via application default credentials is authentication via a service account. *Note that this method of authentication is not recommended. Service accounts are intended to be used by other applications or virtual machines and not people. See [this article](https://cloud.google.com/iam/docs/service-accounts#what_are_service_accounts) for more information.*
 
@@ -116,15 +106,18 @@ The proper key file is in JSON format. An example file is provided below, with p
 }
 ```
 
-Note, that unlike MySQL, there is no automatic migrations facility. Currently Spanner schema must be hand edited and modified.
+*Note that the name `service-account.json` must be exactly correct to be ignored by `.gitignore`.*
 
-To point to a GCP hosted Spanner instance from your local machine, follow these steps:
+#### Connecting to Spanner
+To point to a GCP-hosted Spanner instance from your local machine, follow these steps:
 
-1. Download the key file as shown above and place it in the root directory of the project. *Note that the name `service-account.json` must be exactly correct to be ignored by `.gitignore`*
+1. Authenticate via either of the two methods outlined above.
 2. Open `local.toml` and replace `database_url` with a link to your spanner instance.
-3. Ensure you've correctly set `PATH_TO_GRPC_CERT` in the Makefile
+3. Open the Makefile and ensure you've correctly set you `PATH_TO_GRPC_CERT`.
 4. `make run_spanner`.
 5. Visit `http://localhost:8000/__heartbeat__` to make sure the server is running.
+
+Note, that unlike MySQL, there is no automatic migrations facility. Currently Spanner schema must be hand edited and modified.
 
 #### Key Revocation
 

--- a/README.md
+++ b/README.md
@@ -96,11 +96,11 @@ To point to a GCP hosted Spanner instance from your local machine, follow these 
 
 #### Key Revocation
 
-Accidents happen, and you may need to revoke a credential's access if it has been publicly leaked. To do this, run:
+Accidents happen, and you may need to revoke the access of a set of credentials if they have been publicly leaked. To do this, run:
 ```sh
 gcloud auth application-default revoke
 ```
-This will revoke the access of the credentials currently stored in the `application_default_credentials.json` file. **If the file in that location does not contain the leaked credentials, you will need to copy the file containing the leaked credentials to that location and re-run the above command.** You can ensure that the leaked credentials are no longer active by attempting to connect to Spanner using the credentials. If access has been revoked, your application server should print error saying that the token has expired or has been revoked.
+This will revoke the access of the credentials currently stored in the `application_default_credentials.json` file. **If the file in that location does not contain the leaked credentials, you will need to copy the file containing the leaked credentials to that location and re-run the above command.** You can ensure that the leaked credentials are no longer active by attempting to connect to Spanner using the credentials. If access has been revoked, your application server should print an error saying that the token has expired or has been revoked.
 
 #### Emulator
 Google supports an in-memory Spanner emulator, which can run on your local machine for development purposes. You can install the emulator via the gcloud CLI or Docker by following the instructions [here](https://cloud.google.com/spanner/docs/emulator#installing_and_running_the_emulator). Once the emulator is running, you'll need to create a new instance and a new database. To create an instance using the REST API (exposed via port 9020 on the emulator), we can use `curl`:

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ GRANT ALL PRIVILEGES on syncstorage_rs.* to sample_user@localhost;
 
 ### Spanner
 
+#### Authenticating via OAuth
 The correct way to authenticate with Spanner is by generating an OAuth token and pointing your local application server to the token. In order for this to work, your Google Cloud must have the correct permissions; contact the Ops team to ensure the correct permissions are added to your account.
 
 First, install the Google Cloud command-line interface by following the instructions for your operating system [here](https://cloud.google.com/sdk/docs/install). Next, run the following to log in with your Google account (this should be the Google account associated with your Mozilla LDAP credentials):
@@ -83,6 +84,45 @@ To point to a GCP hosted Spanner instance from your local machine, follow these 
 1. Create an OAuth token file as shown above.
 2. Open `local.toml` and replace `database_url` with a link to your spanner instance.
 3. Open the Makefile and ensure you've correctly set you `PATH_TO_GRPC_CERT`.
+4. `make run_spanner`.
+5. Visit `http://localhost:8000/__heartbeat__` to make sure the server is running.
+
+#### Authenticating via Service Account
+An alternative to authentication via application default credentials is authentication via a service account. *Note that this method of authentication is not recommended. Service accounts are intended to be used by other applications or virtual machines and not people. See [this article](https://cloud.google.com/iam/docs/service-accounts#what_are_service_accounts) for more information.*
+
+Your system administrator will be able to tell you which service account keys have access to the Spanner instance to which you are trying to connect. Once you are given the email identifier of an active key, log into the [Google Cloud Console Service Accounts](https://console.cloud.google.com/iam-admin/serviceaccounts) page. Be sure to select the correct project.
+
+- Locate the email identifier of the access key and pick the vertical dot menu at the far right of the row.
+- Select "_Create Key_" from the pop-up menu.
+- Select "JSON" from the Dialog Box.
+
+A proper key file will be downloaded to your local directory. It's important to safeguard that key file. For this example, we're going to name the file
+`service-account.json`.
+
+The proper key file is in JSON format. An example file is provided below, with private information replaced by "`...`"
+
+```json
+{
+  "type": "service_account",
+  "project_id": "...",
+  "private_key_id": "...",
+  "private_key": "...",
+  "client_email": "...",
+  "client_id": "...",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://oauth2.googleapis.com/token",
+  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  "client_x509_cert_url": "..."
+}
+```
+
+Note, that unlike MySQL, there is no automatic migrations facility. Currently Spanner schema must be hand edited and modified.
+
+To point to a GCP hosted Spanner instance from your local machine, follow these steps:
+
+1. Download the key file as shown above and place it in the root directory of the project. *Note that the name `service-account.json` must be exactly correct to be ignored by `.gitignore`*
+2. Open `local.toml` and replace `database_url` with a link to your spanner instance.
+3. Ensure you've correctly set `PATH_TO_GRPC_CERT` in the Makefile
 4. `make run_spanner`.
 5. Visit `http://localhost:8000/__heartbeat__` to make sure the server is running.
 


### PR DESCRIPTION
## Description

Updates the documentation to include the following information:
- How to install the `gcloud` CLI tool
- How to authenticate using `gcloud auth application-default login` to generate a JSON file with an OAuth token in the proper location
- How to symlink this file to be picked up by `.gitignore`
- How to revoke these credentials in case of a leak

A question for the reviewer: is it worth including the URL that points to the Spanner instance that should be used for development?

## Testing

I tested this by revoking my previous OAuth keys, running through the new workflow outlined in the docs, and ensuring that I was able to access the Spanner dev instance with the newly-generated credentials.

## Issue(s)

Closes #1045 
