### PR TITLE
fix: Convert integral values to String before converting to Value

### DIFF
--- a/src/db/spanner/batch.rs
+++ b/src/db/spanner/batch.rs
@@ -291,7 +291,10 @@ pub async fn do_append_async(
             .unwrap_or_else(|| "UNKNOWN".to_string()),
     );
 
-    let bso_ids = bsos.iter().map(|pbso| pbso.id.clone()).collect::<Vec<String>>();
+    let bso_ids = bsos
+        .iter()
+        .map(|pbso| pbso.id.clone())
+        .collect::<Vec<String>>();
     let (sqlparams, sqlparam_types) = params! {
         "fxa_uid" => user_id.fxa_uid.clone(),
         "fxa_kid" => user_id.fxa_kid.clone(),

--- a/src/db/spanner/macros.rs
+++ b/src/db/spanner/macros.rs
@@ -16,3 +16,134 @@ macro_rules! params {
         }
     };
 }
+
+#[test]
+fn test_params_macro() {
+    use crate::db::spanner::support::ToSpannerValue;
+    use googleapis_raw::spanner::v1::type_pb::{Type, TypeCode};
+    use protobuf::{
+        well_known_types::{ListValue, Value},
+        RepeatedField,
+    };
+    use std::collections::HashMap;
+
+    let (sqlparams, sqlparam_types) = params! {
+        "String param" => "I am a String".to_owned(),
+        "i32 param" => 100i32,
+        "u32 param" => 100u32,
+        "Vec<String> param" => vec!["I am a String".to_owned()],
+        "Vec<i32> param" => vec![100i32],
+        "Vec<u32> param" => vec![100u32],
+    };
+
+    let mut expected_sqlparams = HashMap::new();
+    let string_value = {
+        let mut t = Value::new();
+        t.set_string_value("I am a String".to_owned());
+        t
+    };
+    expected_sqlparams.insert("String param".to_owned(), string_value.clone());
+
+    let i32_value = {
+        let mut t = Value::new();
+        t.set_string_value(100i32.to_string());
+        t
+    };
+    expected_sqlparams.insert("i32 param".to_owned(), i32_value.clone());
+
+    let u32_value = {
+        let mut t = Value::new();
+        t.set_string_value(100u32.to_string());
+        t
+    };
+    expected_sqlparams.insert("u32 param".to_owned(), u32_value.clone());
+
+    let string_vec_value = {
+        let mut list = ListValue::new();
+        list.set_values(RepeatedField::from_vec(vec![string_value]));
+        let mut value = Value::new();
+        value.set_list_value(list);
+        value
+    };
+    expected_sqlparams.insert("Vec<String> param".to_owned(), string_vec_value);
+
+    let i32_vec_value = {
+        let mut list = ListValue::new();
+        list.set_values(RepeatedField::from_vec(vec![i32_value]));
+        let mut value = Value::new();
+        value.set_list_value(list);
+        value
+    };
+    expected_sqlparams.insert("Vec<i32> param".to_owned(), i32_vec_value);
+
+    let u32_vec_value = {
+        let mut list = ListValue::new();
+        list.set_values(RepeatedField::from_vec(vec![u32_value]));
+        let mut value = Value::new();
+        value.set_list_value(list);
+        value
+    };
+    expected_sqlparams.insert("Vec<u32> param".to_owned(), u32_vec_value);
+
+    let mut expected_sqlparam_types = HashMap::new();
+
+    let string_type = {
+        let mut t = Type::new();
+        t.set_code(TypeCode::STRING);
+        t
+    };
+    expected_sqlparam_types.insert("String param".to_owned(), string_type);
+
+    let i32_type = {
+        let mut t = Type::new();
+        t.set_code(TypeCode::INT64);
+        t
+    };
+    expected_sqlparam_types.insert("i32 param".to_owned(), i32_type);
+
+    let u32_type = {
+        let mut t = Type::new();
+        t.set_code(TypeCode::INT64);
+        t
+    };
+    expected_sqlparam_types.insert("u32 param".to_owned(), u32_type);
+
+    let string_vec_type = {
+        let mut element_type = Type::new();
+        element_type.set_code(TypeCode::STRING);
+
+        let mut vec_type = Type::new();
+        vec_type.set_code(TypeCode::ARRAY);
+        vec_type.set_array_element_type(element_type);
+
+        vec_type
+    };
+    expected_sqlparam_types.insert("Vec<String> param".to_owned(), string_vec_type);
+
+    let i32_vec_type = {
+        let mut element_type = Type::new();
+        element_type.set_code(TypeCode::INT64);
+
+        let mut vec_type = Type::new();
+        vec_type.set_code(TypeCode::ARRAY);
+        vec_type.set_array_element_type(element_type);
+
+        vec_type
+    };
+    expected_sqlparam_types.insert("Vec<i32> param".to_owned(), i32_vec_type);
+
+    let u32_vec_type = {
+        let mut element_type = Type::new();
+        element_type.set_code(TypeCode::INT64);
+
+        let mut vec_type = Type::new();
+        vec_type.set_code(TypeCode::ARRAY);
+        vec_type.set_array_element_type(element_type);
+
+        vec_type
+    };
+    expected_sqlparam_types.insert("Vec<u32> param".to_owned(), u32_vec_type);
+
+    assert_eq!(expected_sqlparams, sqlparams);
+    assert_eq!(expected_sqlparam_types, sqlparam_types);
+}

--- a/src/db/spanner/macros.rs
+++ b/src/db/spanner/macros.rs
@@ -6,28 +6,13 @@ macro_rules! params {
     ($($key:expr => $value:expr),*) => {
         {
             let _cap = params!(@count $($key),*);
-            let mut _map = ::std::collections::HashMap::with_capacity(_cap);
+            let mut _value_map = ::std::collections::HashMap::with_capacity(_cap);
+            let mut _type_map = ::std::collections::HashMap::with_capacity(_cap);
             $(
-                _map.insert($key.to_owned(), ToSpannerValue::to_spanner_value(&$value));
+                _value_map.insert($key.to_owned(), ToSpannerValue::to_spanner_value(&$value));
+                _type_map.insert($key.to_owned(), ToSpannerValue::spanner_type(&$value));
             )*
-            _map
-        }
-    };
-}
-
-macro_rules! param_types {
-    (@single $($x:tt)*) => (());
-    (@count $($rest:expr),*) => (<[()]>::len(&[$(param_types!(@single $rest)),*]));
-
-    ($($key:expr => $value:expr,)+) => { param_types!($($key => $value),+) };
-    ($($key:expr => $value:expr),*) => {
-        {
-            let _cap = param_types!(@count $($key),*);
-            let mut _map = ::std::collections::HashMap::with_capacity(_cap);
-            $(
-                _map.insert($key.to_owned(), crate::db::spanner::support::as_type($value));
-            )*
-            _map
+            (_value_map, _type_map)
         }
     };
 }

--- a/src/db/spanner/models.rs
+++ b/src/db/spanner/models.rs
@@ -144,13 +144,15 @@ impl SpannerDb {
         if let Some(id) = self.coll_cache.get_id(name).await {
             return Ok(id);
         }
+        let (sqlparams, sqlparam_types) = params! { "name" => name.to_string() };
         let result = self
             .sql(
                 "SELECT collection_id
                    FROM collections
                   WHERE name = @name",
             )?
-            .params(params! {"name" => name.to_string()})
+            .params(sqlparams)
+            .param_types(sqlparam_types)
             .execute_async(&self.conn)?
             .one_or_none()
             .await?
@@ -185,15 +187,17 @@ impl SpannerDb {
             .parse::<i32>()
             .map_err(|e| DbErrorKind::Integrity(e.to_string()))?;
         let id = FIRST_CUSTOM_COLLECTION_ID.max(max + 1);
+        let (sqlparams, sqlparam_types) = params! {
+            "name" => name.to_string(),
+            "collection_id" => id,
+        };
 
         self.sql(
             "INSERT INTO collections (collection_id, name)
              VALUES (@collection_id, @name)",
         )?
-        .params(params! {
-            "name" => name.to_string(),
-            "collection_id" => id.to_string(),
-        })
+        .params(sqlparams)
+        .param_types(sqlparam_types)
         .execute_dml_async(&self.conn)
         .await?;
         Ok(id)
@@ -260,6 +264,13 @@ impl SpannerDb {
         {
             Err(DbError::internal("Can't escalate read-lock to write-lock"))?
         }
+        let (sqlparams, mut sqlparam_types) = params! {
+            "fxa_uid" => params.user_id.fxa_uid.clone(),
+            "fxa_kid" => params.user_id.fxa_kid.clone(),
+            "collection_id" => collection_id,
+            "pretouch_ts" => PRETOUCH_TS.to_owned(),
+        };
+        sqlparam_types.insert("pretouch_ts".to_owned(), as_type(TypeCode::TIMESTAMP));
 
         let result = self
             .sql(
@@ -270,15 +281,8 @@ impl SpannerDb {
                     AND collection_id = @collection_id
                     AND modified > @pretouch_ts",
             )?
-            .params(params! {
-                "fxa_uid" => params.user_id.fxa_uid.clone(),
-                "fxa_kid" => params.user_id.fxa_kid.clone(),
-                "collection_id" => collection_id.to_string(),
-                "pretouch_ts" => PRETOUCH_TS.to_owned(),
-            })
-            .param_types(param_types! {
-                "pretouch_ts" => TypeCode::TIMESTAMP,
-            })
+            .params(sqlparams)
+            .param_types(sqlparam_types)
             .execute_async(&self.conn)?
             .one_or_none()
             .await?;
@@ -550,6 +554,13 @@ impl SpannerDb {
         {
             return Ok(*modified);
         }
+        let (sqlparams, mut sqlparam_types) = params! {
+            "fxa_uid" => params.user_id.fxa_uid,
+            "fxa_kid" => params.user_id.fxa_kid,
+            "collection_id" => collection_id,
+            "pretouch_ts" => PRETOUCH_TS.to_owned(),
+        };
+        sqlparam_types.insert("pretouch_ts".to_owned(), as_type(TypeCode::TIMESTAMP));
 
         let result = self
             .sql(
@@ -560,15 +571,8 @@ impl SpannerDb {
                     AND collection_id = @collection_id
                     AND modified > @pretouch_ts",
             )?
-            .params(params! {
-                "fxa_uid" => params.user_id.fxa_uid,
-                "fxa_kid" => params.user_id.fxa_kid,
-                "collection_id" => collection_id.to_string(),
-                "pretouch_ts" => PRETOUCH_TS.to_owned(),
-            })
-            .param_types(param_types! {
-                "pretouch_ts" => TypeCode::TIMESTAMP,
-            })
+            .params(sqlparams)
+            .param_types(sqlparam_types)
             .execute_async(&self.conn)?
             .one_or_none()
             .await?
@@ -581,6 +585,13 @@ impl SpannerDb {
         &self,
         user_id: params::GetCollectionTimestamps,
     ) -> Result<results::GetCollectionTimestamps> {
+        let (sqlparams, mut sqlparam_types) = params! {
+            "fxa_uid" => user_id.fxa_uid,
+            "fxa_kid" => user_id.fxa_kid,
+            "collection_id" => TOMBSTONE,
+            "pretouch_ts" => PRETOUCH_TS.to_owned(),
+        };
+        sqlparam_types.insert("pretouch_ts".to_owned(), as_type(TypeCode::TIMESTAMP));
         let mut streaming = self
             .sql(
                 "SELECT collection_id, modified
@@ -590,15 +601,8 @@ impl SpannerDb {
                     AND collection_id != @collection_id
                     AND modified > @pretouch_ts",
             )?
-            .params(params! {
-                "fxa_uid" => user_id.fxa_uid,
-                "fxa_kid" => user_id.fxa_kid,
-                "collection_id" => TOMBSTONE.to_string(),
-                "pretouch_ts" => PRETOUCH_TS.to_owned(),
-            })
-            .param_types(param_types! {
-                "pretouch_ts" => TypeCode::TIMESTAMP,
-            })
+            .params(sqlparams)
+            .param_types(sqlparam_types)
             .execute_async(&self.conn)?;
         let mut results = HashMap::new();
         while let Some(row) = streaming.next_async().await {
@@ -674,6 +678,10 @@ impl SpannerDb {
         &self,
         user_id: params::GetCollectionCounts,
     ) -> Result<results::GetCollectionCounts> {
+        let (sqlparams, sqlparam_types) = params! {
+            "fxa_uid" => user_id.fxa_uid,
+            "fxa_kid" => user_id.fxa_kid,
+        };
         let mut streaming = self
             .sql(
                 "SELECT collection_id, COUNT(collection_id)
@@ -683,10 +691,8 @@ impl SpannerDb {
                     AND expiry > CURRENT_TIMESTAMP()
                   GROUP BY collection_id",
             )?
-            .params(params! {
-                "fxa_uid" => user_id.fxa_uid,
-                "fxa_kid" => user_id.fxa_kid,
-            })
+            .params(sqlparams)
+            .param_types(sqlparam_types)
             .execute_async(&self.conn)?;
         let mut counts = HashMap::new();
         while let Some(row) = streaming.next_async().await {
@@ -708,6 +714,10 @@ impl SpannerDb {
         &self,
         user_id: params::GetCollectionUsage,
     ) -> Result<results::GetCollectionUsage> {
+        let (sqlparams, sqlparam_types) = params! {
+            "fxa_uid" => user_id.fxa_uid,
+            "fxa_kid" => user_id.fxa_kid
+        };
         let mut streaming = self
             .sql(
                 "SELECT collection_id, SUM(BYTE_LENGTH(payload))
@@ -717,10 +727,8 @@ impl SpannerDb {
                     AND expiry > CURRENT_TIMESTAMP()
                   GROUP BY collection_id",
             )?
-            .params(params! {
-                "fxa_uid" => user_id.fxa_uid,
-                "fxa_kid" => user_id.fxa_kid
-            })
+            .params(sqlparams)
+            .param_types(sqlparam_types)
             .execute_async(&self.conn)?;
         let mut usages = HashMap::new();
         while let Some(row) = streaming.next_async().await {
@@ -742,6 +750,12 @@ impl SpannerDb {
         &self,
         user_id: params::GetStorageTimestamp,
     ) -> Result<SyncTimestamp> {
+        let (sqlparams, mut sqlparam_types) = params! {
+            "fxa_uid" => user_id.fxa_uid,
+            "fxa_kid" => user_id.fxa_kid,
+            "pretouch_ts" => PRETOUCH_TS.to_owned(),
+        };
+        sqlparam_types.insert("pretouch_ts".to_owned(), as_type(TypeCode::TIMESTAMP));
         let row = self
             .sql(
                 "SELECT MAX(modified)
@@ -750,14 +764,8 @@ impl SpannerDb {
                     AND fxa_kid = @fxa_kid
                     AND modified > @pretouch_ts",
             )?
-            .params(params! {
-                "fxa_uid" => user_id.fxa_uid,
-                "fxa_kid" => user_id.fxa_kid,
-                "pretouch_ts" => PRETOUCH_TS.to_owned(),
-            })
-            .param_types(param_types! {
-                "pretouch_ts" => TypeCode::TIMESTAMP,
-            })
+            .params(sqlparams)
+            .param_types(sqlparam_types)
             .execute_async(&self.conn)?
             .one()
             .await?;
@@ -772,6 +780,10 @@ impl SpannerDb {
         &self,
         user_id: params::GetStorageUsage,
     ) -> Result<results::GetStorageUsage> {
+        let (sqlparams, sqlparam_types) = params! {
+            "fxa_uid" => user_id.fxa_uid,
+            "fxa_kid" => user_id.fxa_kid
+        };
         let result = self
             .sql(
                 "SELECT SUM(BYTE_LENGTH(payload))
@@ -781,10 +793,8 @@ impl SpannerDb {
                     AND expiry > CURRENT_TIMESTAMP()
                   GROUP BY fxa_uid",
             )?
-            .params(params! {
-                "fxa_uid" => user_id.fxa_uid,
-                "fxa_kid" => user_id.fxa_kid
-            })
+            .params(sqlparams)
+            .param_types(sqlparam_types)
             .execute_async(&self.conn)?
             .one_or_none()
             .await?;
@@ -811,13 +821,15 @@ impl SpannerDb {
            WHERE fxa_uid = @fxa_uid
              AND fxa_kid = @fxa_kid
              AND collection_id = @collection_id";
+        let (sqlparams, sqlparam_types) = params! {
+            "fxa_uid" => params.user_id.fxa_uid.clone(),
+            "fxa_kid" => params.user_id.fxa_kid.clone(),
+            "collection_id" => params.collection_id,
+        };
         let result = self
             .sql(check_sql)?
-            .params(params! {
-                "fxa_uid" => params.user_id.fxa_uid.clone(),
-                "fxa_kid" => params.user_id.fxa_kid.clone(),
-                "collection_id" => params.collection_id.to_string(),
-            })
+            .params(sqlparams)
+            .param_types(sqlparam_types)
             .execute_async(&self.conn)?
             .one_or_none()
             .await?;
@@ -851,15 +863,13 @@ impl SpannerDb {
         // specifying a TOMBSTONE collection_id.
         // This function should be called after any write operation.
         let timestamp = self.timestamp()?;
-        let mut sqlparams = params! {
+        let (mut sqlparams, mut sqltypes) = params! {
             "fxa_uid" => user.fxa_uid.clone(),
             "fxa_kid" => user.fxa_kid.clone(),
-            "collection_id" => collection_id.to_string(),
+            "collection_id" => collection_id,
             "modified" => timestamp.as_rfc3339()?,
         };
-        let mut sqltypes = param_types! {
-            "modified" => TypeCode::TIMESTAMP,
-        };
+        sqltypes.insert("modified".to_owned(), as_type(TypeCode::TIMESTAMP));
 
         self.metrics
             .clone()
@@ -879,16 +889,22 @@ impl SpannerDb {
              AND collection_id = @collection_id
            GROUP BY fxa_uid"
         };
-        let result = self
-            .sql(calc_sql)?
-            .params(params! {
+
+        let result = {
+            let (sqlparams, sqlparam_types) = params! {
                 "fxa_uid" => user.fxa_uid.clone(),
                 "fxa_kid" => user.fxa_kid.clone(),
-                "collection_id" => collection_id.to_string(),
-            })
-            .execute_async(&self.conn)?
-            .one_or_none()
-            .await?;
+                "collection_id" => collection_id,
+            };
+
+            self
+                .sql(calc_sql)?
+                .params(sqlparams)
+                .param_types(sqlparam_types)
+                .execute_async(&self.conn)?
+                .one_or_none()
+                .await?
+        };
         let set_sql = if let Some(mut result) = result {
             // Update the user_collections table to reflect current numbers.
             // If there are BSOs, there are user_collections (or else something
@@ -968,16 +984,13 @@ impl SpannerDb {
 
     async fn erect_tombstone(&self, user_id: &HawkIdentifier) -> Result<SyncTimestamp> {
         // Delete the old tombstone (if it exists)
-        let params = params! {
+        let (params, mut param_types) = params! {
             "fxa_uid" => user_id.fxa_uid.clone(),
             "fxa_kid" => user_id.fxa_kid.clone(),
-            "collection_id" => TOMBSTONE.to_string(),
+            "collection_id" => TOMBSTONE,
             "modified" => self.timestamp()?.as_rfc3339()?
         };
-        let types = param_types! {
-            "collection_id" => TypeCode::INT64,
-            "modified" => TypeCode::TIMESTAMP,
-        };
+        param_types.insert("modified".to_owned(), as_type(TypeCode::TIMESTAMP));
         self.sql(
             "DELETE FROM user_collections
               WHERE fxa_uid = @fxa_uid
@@ -985,7 +998,7 @@ impl SpannerDb {
                 AND collection_id = @collection_id",
         )?
         .params(params.clone())
-        .param_types(types.clone())
+        .param_types(param_types.clone())
         .execute_dml_async(&self.conn)
         .await?;
         self.update_user_collection_quotas(user_id, TOMBSTONE)
@@ -998,15 +1011,17 @@ impl SpannerDb {
     pub async fn delete_storage_async(&self, user_id: params::DeleteStorage) -> Result<()> {
         // Also deletes child bsos/batch rows (INTERLEAVE IN PARENT
         // user_collections ON DELETE CASCADE)
+        let (sqlparams, sqlparam_types) = params! {
+            "fxa_uid" => user_id.fxa_uid,
+            "fxa_kid" => user_id.fxa_kid
+        };
         self.sql(
             "DELETE FROM user_collections
               WHERE fxa_uid = @fxa_uid
                 AND fxa_kid = @fxa_kid",
         )?
-        .params(params! {
-            "fxa_uid" => user_id.fxa_uid,
-            "fxa_kid" => user_id.fxa_kid,
-        })
+        .params(sqlparams)
+        .param_types(sqlparam_types)
         .execute_dml_async(&self.conn)
         .await?;
         Ok(())
@@ -1027,8 +1042,14 @@ impl SpannerDb {
         // user_collections ON DELETE CASCADE)
         let collection_id = self
             .get_collection_id_async(&params.collection)
-            .await?
-            .to_string();
+            .await?;
+        let (sqlparams, mut sqlparam_types) = params! {
+            "fxa_uid" => params.user_id.fxa_uid.clone(),
+            "fxa_kid" => params.user_id.fxa_kid.clone(),
+            "collection_id" => collection_id.clone(),
+            "pretouch_ts" => PRETOUCH_TS.to_owned(),
+        };
+        sqlparam_types.insert("pretouch_ts".to_owned(), as_type(TypeCode::TIMESTAMP));
         let affected_rows = self
             .sql(
                 "DELETE FROM user_collections
@@ -1037,15 +1058,8 @@ impl SpannerDb {
                     AND collection_id = @collection_id
                     AND modified > @pretouch_ts",
             )?
-            .params(params! {
-                "fxa_uid" => params.user_id.fxa_uid.clone(),
-                "fxa_kid" => params.user_id.fxa_kid.clone(),
-                "collection_id" => collection_id.clone(),
-                "pretouch_ts" => PRETOUCH_TS.to_owned(),
-            })
-            .param_types(param_types! {
-                "pretouch_ts" => TypeCode::TIMESTAMP,
-            })
+            .params(sqlparams)
+            .param_types(sqlparam_types)
             .execute_dml_async(&self.conn)
             .await?;
         if affected_rows > 0 {
@@ -1082,15 +1096,13 @@ impl SpannerDb {
             return Ok(timestamp);
         }
 
-        let sqlparams = params! {
+        let (sqlparams, mut sqlparam_types) = params! {
             "fxa_uid" => user_id.fxa_uid.clone(),
             "fxa_kid" => user_id.fxa_kid.clone(),
-            "collection_id" => collection_id.to_string(),
+            "collection_id" => collection_id,
             "modified" => timestamp.as_rfc3339()?,
         };
-        let sql_types = param_types! {
-            "modified" => TypeCode::TIMESTAMP,
-        };
+        sqlparam_types.insert("modified".to_owned(), as_type(TypeCode::TIMESTAMP));
         let result = self
             .sql(
                 "SELECT 1
@@ -1100,6 +1112,7 @@ impl SpannerDb {
                     AND collection_id = @collection_id",
             )?
             .params(sqlparams.clone())
+            .param_types(sqlparam_types.clone())
             .execute_async(&self.conn)?
             .one_or_none()
             .await?;
@@ -1114,7 +1127,7 @@ impl SpannerDb {
                     AND collection_id = @collection_id";
             self.sql(sql)?
                 .params(sqlparams)
-                .param_types(sql_types)
+                .param_types(sqlparam_types)
                 .execute_dml_async(&self.conn)
                 .await?;
         } else {
@@ -1133,7 +1146,7 @@ impl SpannerDb {
             };
             self.sql(update_sql)?
                 .params(sqlparams)
-                .param_types(sql_types)
+                .param_types(sqlparam_types)
                 .execute_dml_async(&self.conn)
                 .await?;
         }
@@ -1144,6 +1157,12 @@ impl SpannerDb {
     pub async fn delete_bso_async(&self, params: params::DeleteBso) -> Result<results::DeleteBso> {
         let collection_id = self.get_collection_id_async(&params.collection).await?;
         let user_id = params.user_id.clone();
+        let (sqlparams, sqlparam_types) = params! {
+            "fxa_uid" => params.user_id.fxa_uid,
+            "fxa_kid" => params.user_id.fxa_kid,
+            "collection_id" => collection_id,
+            "bso_id" => params.id,
+        };
         let affected_rows = self
             .sql(
                 "DELETE FROM bsos
@@ -1152,12 +1171,8 @@ impl SpannerDb {
                     AND collection_id = @collection_id
                     AND bso_id = @bso_id",
             )?
-            .params(params! {
-                "fxa_uid" => params.user_id.fxa_uid,
-                "fxa_kid" => params.user_id.fxa_kid,
-                "collection_id" => collection_id.to_string(),
-                "bso_id" => params.id,
-            })
+            .params(sqlparams)
+            .param_types(sqlparam_types)
             .execute_dml_async(&self.conn)
             .await?;
         if affected_rows == 0 {
@@ -1177,12 +1192,12 @@ impl SpannerDb {
         let user_id = params.user_id.clone();
         let collection_id = self.get_collection_id_async(&params.collection).await?;
 
-        let mut sqlparams = params! {
+        let (sqlparams, sqlparam_types) = params! {
             "fxa_uid" => user_id.fxa_uid,
             "fxa_kid" => user_id.fxa_kid,
-            "collection_id" => collection_id.to_string(),
+            "collection_id" => collection_id,
+            "ids" => params.ids,
         };
-        sqlparams.insert("ids".to_owned(), params.ids.to_spanner_value());
         self.sql(
             "DELETE FROM bsos
               WHERE fxa_uid = @fxa_uid
@@ -1191,6 +1206,7 @@ impl SpannerDb {
                 AND bso_id IN UNNEST(@ids)",
         )?
         .params(sqlparams)
+        .param_types(sqlparam_types)
         .execute_dml_async(&self.conn)
         .await?;
         let mut tags = Tags::default();
@@ -1208,10 +1224,10 @@ impl SpannerDb {
         params: params::GetBsos,
     ) -> Result<StreamedResultSetAsync> {
         let mut query = query_str.to_owned();
-        let mut sqlparams = params! {
+        let (mut sqlparams, mut sqlparam_types) = params! {
             "fxa_uid" => params.user_id.fxa_uid,
             "fxa_kid" => params.user_id.fxa_kid,
-            "collection_id" => self.get_collection_id_async(&params.collection).await?.to_string(),
+            "collection_id" => self.get_collection_id_async(&params.collection).await?,
         };
         let BsoQueryParams {
             newer,
@@ -1223,11 +1239,10 @@ impl SpannerDb {
             ..
         } = params.params;
 
-        let mut sqltypes = HashMap::new();
-
         if !ids.is_empty() {
             query = format!("{} AND bso_id IN UNNEST(@ids)", query);
             sqlparams.insert("ids".to_owned(), ids.to_spanner_value());
+            sqlparam_types.insert("ids".to_owned(), ids.spanner_type());
         }
 
         // issue559: Dead code (timestamp always None)
@@ -1251,12 +1266,12 @@ impl SpannerDb {
         if let Some(older) = older {
             query = format!("{} AND modified < @older", query);
             sqlparams.insert("older".to_string(), older.as_rfc3339()?.to_spanner_value());
-            sqltypes.insert("older".to_string(), as_type(TypeCode::TIMESTAMP));
+            sqlparam_types.insert("older".to_string(), as_type(TypeCode::TIMESTAMP));
         }
         if let Some(newer) = newer {
             query = format!("{} AND modified > @newer", query);
             sqlparams.insert("newer".to_string(), newer.as_rfc3339()?.to_spanner_value());
-            sqltypes.insert("newer".to_string(), as_type(TypeCode::TIMESTAMP));
+            sqlparam_types.insert("newer".to_string(), as_type(TypeCode::TIMESTAMP));
         }
         query = match sort {
             // issue559: Revert to previous sorting
@@ -1295,7 +1310,7 @@ impl SpannerDb {
         }
         self.sql(&query)?
             .params(sqlparams)
-            .param_types(sqltypes)
+            .param_types(sqlparam_types)
             .execute_async(&self.conn)
     }
 
@@ -1436,6 +1451,12 @@ impl SpannerDb {
 
     pub async fn get_bso_async(&self, params: params::GetBso) -> Result<Option<results::GetBso>> {
         let collection_id = self.get_collection_id_async(&params.collection).await?;
+        let (sqlparams, sqlparam_types) = params! {
+            "fxa_uid" => params.user_id.fxa_uid,
+            "fxa_kid" => params.user_id.fxa_kid,
+            "collection_id" => collection_id,
+            "bso_id" => params.id,
+        };
         self.sql(
             "SELECT bso_id, sortindex, payload, modified, expiry
                FROM bsos
@@ -1445,12 +1466,8 @@ impl SpannerDb {
                 AND bso_id = @bso_id
                 AND expiry > CURRENT_TIMESTAMP()",
         )?
-        .params(params! {
-            "fxa_uid" => params.user_id.fxa_uid,
-            "fxa_kid" => params.user_id.fxa_kid,
-            "collection_id" => collection_id.to_string(),
-            "bso_id" => params.id,
-        })
+        .params(sqlparams)
+        .param_types(sqlparam_types)
         .execute_async(&self.conn)?
         .one_or_none()
         .await?
@@ -1463,6 +1480,12 @@ impl SpannerDb {
         params: params::GetBsoTimestamp,
     ) -> Result<SyncTimestamp> {
         let collection_id = self.get_collection_id_async(&params.collection).await?;
+        let (sqlparams, sqlparam_types) = params! {
+            "fxa_uid" => params.user_id.fxa_uid,
+            "fxa_kid" => params.user_id.fxa_kid,
+            "collection_id" => collection_id,
+            "bso_id" => params.id,
+        };
 
         let result = self
             .sql(
@@ -1474,12 +1497,8 @@ impl SpannerDb {
                     AND bso_id = @bso_id
                     AND expiry > CURRENT_TIMESTAMP()",
             )?
-            .params(params! {
-                "fxa_uid" => params.user_id.fxa_uid,
-                "fxa_kid" => params.user_id.fxa_kid,
-                "collection_id" => collection_id.to_string(),
-                "bso_id" => params.id.to_string(),
-            })
+            .params(sqlparams)
+            .param_types(sqlparam_types)
             .execute_async(&self.conn)?
             .one_or_none()
             .await?;
@@ -1527,20 +1546,16 @@ impl SpannerDb {
             .update_collection_async(&user_id, collection_id, &params.collection)
             .await?;
 
-        let mut sqlparams = params! {
+        let (sqlparams, sqlparam_types) = params! {
             "fxa_uid" => user_id.fxa_uid.clone(),
             "fxa_kid" => user_id.fxa_kid.clone(),
-            "collection_id" => collection_id.to_string(),
-        };
-        sqlparams.insert(
-            "ids".to_owned(),
-            params
+            "collection_id" => collection_id,
+            "ids" => params
                 .bsos
                 .iter()
                 .map(|pbso| pbso.id.clone())
-                .collect::<Vec<String>>()
-                .to_spanner_value(),
-        );
+                .collect::<Vec<String>>(),
+        };
         let mut streaming = self
             .sql(
                 "SELECT bso_id
@@ -1551,6 +1566,7 @@ impl SpannerDb {
                     AND bso_id IN UNNEST(@ids)",
             )?
             .params(sqlparams)
+            .param_types(sqlparam_types)
             .execute_async(&self.conn)?;
         let mut existing = HashSet::new();
         while let Some(row) = streaming.next_async().await {
@@ -1677,13 +1693,12 @@ impl SpannerDb {
         self.check_quota(&bso.user_id, &bso.collection, collection_id)
             .await?;
 
-        let mut sqlparams = params! {
+        let (mut sqlparams, mut sqlparam_types) = params! {
             "fxa_uid" => bso.user_id.fxa_uid.clone(),
             "fxa_kid" => bso.user_id.fxa_kid.clone(),
-            "collection_id" => collection_id.to_string(),
-            "bso_id" => bso.id.to_string(),
+            "collection_id" => collection_id,
+            "bso_id" => bso.id,
         };
-        let mut sqltypes = HashMap::new();
         // prewarm the collections table by ensuring that the row is added if not present.
         self.update_collection_async(&bso.user_id, collection_id, &bso.collection)
             .await?;
@@ -1699,6 +1714,7 @@ impl SpannerDb {
                     AND bso_id = @bso_id",
             )?
             .params(sqlparams.clone())
+            .param_types(sqlparam_types.clone())
             .execute_async(&self.conn)?
             .one_or_none()
             .await?;
@@ -1713,7 +1729,7 @@ impl SpannerDb {
                 q,
                 if let Some(sortindex) = bso.sortindex {
                     sqlparams.insert("sortindex".to_string(), sortindex.to_spanner_value());
-                    sqltypes.insert("sortindex".to_string(), as_type(TypeCode::INT64));
+                    sqlparam_types.insert("sortindex".to_string(), sortindex.spanner_type());
 
                     format!("{}{}", comma(&q), "sortindex = @sortindex")
                 } else {
@@ -1727,7 +1743,7 @@ impl SpannerDb {
                 if let Some(ttl) = bso.ttl {
                     let expiry = timestamp.as_i64() + (i64::from(ttl) * 1000);
                     sqlparams.insert("expiry".to_string(), to_rfc3339(expiry)?.to_spanner_value());
-                    sqltypes.insert("expiry".to_string(), as_type(TypeCode::TIMESTAMP));
+                    sqlparam_types.insert("expiry".to_string(), as_type(TypeCode::TIMESTAMP));
                     format!("{}{}", comma(&q), "expiry = @expiry")
                 } else {
                     "".to_string()
@@ -1742,7 +1758,7 @@ impl SpannerDb {
                         "modified".to_string(),
                         timestamp.as_rfc3339()?.to_spanner_value(),
                     );
-                    sqltypes.insert("modified".to_string(), as_type(TypeCode::TIMESTAMP));
+                    sqlparam_types.insert("modified".to_string(), as_type(TypeCode::TIMESTAMP));
                     format!("{}{}", comma(&q), "modified = @modified")
                 } else {
                     "".to_string()
@@ -1754,6 +1770,7 @@ impl SpannerDb {
                 q,
                 if let Some(payload) = bso.payload {
                     sqlparams.insert("payload".to_string(), payload.to_spanner_value());
+                    sqlparam_types.insert("payload".to_string(), payload.spanner_type());
                     format!("{}{}", comma(&q), "payload = @payload")
                 } else {
                     "".to_string()
@@ -1800,14 +1817,14 @@ impl SpannerDb {
                     .map(|sortindex| sortindex.to_spanner_value())
                     .unwrap_or_else(null_value);
                 sqlparams.insert("sortindex".to_string(), sortindex);
-                sqltypes.insert("sortindex".to_string(), as_type(TypeCode::INT64));
+                sqlparam_types.insert("sortindex".to_string(), as_type(TypeCode::INT64));
             }
+            let payload = bso.payload.unwrap_or_else(|| "".to_owned());
             sqlparams.insert(
                 "payload".to_string(),
-                bso.payload
-                    .unwrap_or_else(|| "".to_owned())
-                    .to_spanner_value(),
+                payload.to_spanner_value()
             );
+            sqlparam_types.insert("payload".to_owned(), payload.spanner_type());
             let now_millis = timestamp.as_i64();
             let ttl = bso.ttl.map_or(i64::from(DEFAULT_BSO_TTL), |ttl| {
                 ttl.try_into()
@@ -1819,19 +1836,19 @@ impl SpannerDb {
                 &expirystring, timestamp, ttl
             );
             sqlparams.insert("expiry".to_string(), expirystring.to_spanner_value());
-            sqltypes.insert("expiry".to_string(), as_type(TypeCode::TIMESTAMP));
+            sqlparam_types.insert("expiry".to_string(), as_type(TypeCode::TIMESTAMP));
 
             sqlparams.insert(
                 "modified".to_string(),
                 timestamp.as_rfc3339()?.to_spanner_value(),
             );
-            sqltypes.insert("modified".to_string(), as_type(TypeCode::TIMESTAMP));
+            sqlparam_types.insert("modified".to_string(), as_type(TypeCode::TIMESTAMP));
             sql.to_owned()
         };
 
         self.sql(&sql)?
             .params(sqlparams)
-            .param_types(sqltypes)
+            .param_types(sqlparam_types)
             .execute_dml_async(&self.conn)
             .await?;
         // update the counts for the user_collections table.

--- a/src/db/spanner/models.rs
+++ b/src/db/spanner/models.rs
@@ -897,8 +897,7 @@ impl SpannerDb {
                 "collection_id" => collection_id,
             };
 
-            self
-                .sql(calc_sql)?
+            self.sql(calc_sql)?
                 .params(sqlparams)
                 .param_types(sqlparam_types)
                 .execute_async(&self.conn)?
@@ -1040,9 +1039,7 @@ impl SpannerDb {
     ) -> Result<results::DeleteCollection> {
         // Also deletes child bsos/batch rows (INTERLEAVE IN PARENT
         // user_collections ON DELETE CASCADE)
-        let collection_id = self
-            .get_collection_id_async(&params.collection)
-            .await?;
+        let collection_id = self.get_collection_id_async(&params.collection).await?;
         let (sqlparams, mut sqlparam_types) = params! {
             "fxa_uid" => params.user_id.fxa_uid.clone(),
             "fxa_kid" => params.user_id.fxa_kid.clone(),
@@ -1820,10 +1817,7 @@ impl SpannerDb {
                 sqlparam_types.insert("sortindex".to_string(), as_type(TypeCode::INT64));
             }
             let payload = bso.payload.unwrap_or_else(|| "".to_owned());
-            sqlparams.insert(
-                "payload".to_string(),
-                payload.to_spanner_value()
-            );
+            sqlparams.insert("payload".to_string(), payload.to_spanner_value());
             sqlparam_types.insert("payload".to_owned(), payload.spanner_type());
             let now_millis = timestamp.as_i64();
             let ttl = bso.ttl.map_or(i64::from(DEFAULT_BSO_TTL), |ttl| {

--- a/src/db/spanner/support.rs
+++ b/src/db/spanner/support.rs
@@ -27,10 +27,20 @@ use crate::{
 use super::{models::Result, pool::Conn};
 
 pub trait ToSpannerValue {
+    const TYPE_CODE: TypeCode;
+
     fn to_spanner_value(&self) -> Value;
+
+    fn spanner_type(&self) -> Type {
+        let mut t = Type::new();
+        t.set_code(Self::TYPE_CODE);
+        t
+    }
 }
 
 impl ToSpannerValue for String {
+    const TYPE_CODE: TypeCode = TypeCode::STRING;
+
     fn to_spanner_value(&self) -> Value {
         let mut value = Value::new();
         value.set_string_value(self.clone());
@@ -39,12 +49,16 @@ impl ToSpannerValue for String {
 }
 
 impl ToSpannerValue for i32 {
+    const TYPE_CODE: TypeCode = TypeCode::INT64;
+
     fn to_spanner_value(&self) -> Value {
         self.to_string().to_spanner_value()
     }
 }
 
 impl ToSpannerValue for u32 {
+    const TYPE_CODE: TypeCode = TypeCode::INT64;
+
     fn to_spanner_value(&self) -> Value {
         self.to_string().to_spanner_value()
     }
@@ -53,7 +67,10 @@ impl ToSpannerValue for u32 {
 impl<T> ToSpannerValue for Vec<T>
 where
     T: ToSpannerValue + Clone,
+    Vec<T>: SpannerArrayElementType,
 {
+    const TYPE_CODE: TypeCode = TypeCode::ARRAY;
+
     fn to_spanner_value(&self) -> Value {
         let mut list = ListValue::new();
         list.set_values(RepeatedField::from_vec(
@@ -63,6 +80,35 @@ where
         value.set_list_value(list);
         value
     }
+
+    fn spanner_type(&self) -> Type {
+        let mut t = Type::new();
+        t.set_code(Self::TYPE_CODE);
+        t.set_array_element_type(self.array_element_type());
+        t
+    }
+}
+
+pub trait SpannerArrayElementType {
+    const ARRAY_ELEMENT_TYPE_CODE: TypeCode;
+
+    fn array_element_type(&self) -> Type {
+        let mut t = Type::new();
+        t.set_code(Self::ARRAY_ELEMENT_TYPE_CODE);
+        t
+    }
+}
+
+impl SpannerArrayElementType for Vec<String> {
+    const ARRAY_ELEMENT_TYPE_CODE: TypeCode = TypeCode::STRING;
+}
+
+impl SpannerArrayElementType for Vec<i32> {
+    const ARRAY_ELEMENT_TYPE_CODE: TypeCode = TypeCode::STRING;
+}
+
+impl SpannerArrayElementType for Vec<u32> {
+    const ARRAY_ELEMENT_TYPE_CODE: TypeCode = TypeCode::STRING;
 }
 
 pub fn as_type(v: TypeCode) -> Type {

--- a/src/db/spanner/support.rs
+++ b/src/db/spanner/support.rs
@@ -104,11 +104,11 @@ impl SpannerArrayElementType for Vec<String> {
 }
 
 impl SpannerArrayElementType for Vec<i32> {
-    const ARRAY_ELEMENT_TYPE_CODE: TypeCode = TypeCode::STRING;
+    const ARRAY_ELEMENT_TYPE_CODE: TypeCode = TypeCode::INT64;
 }
 
 impl SpannerArrayElementType for Vec<u32> {
-    const ARRAY_ELEMENT_TYPE_CODE: TypeCode = TypeCode::STRING;
+    const ARRAY_ELEMENT_TYPE_CODE: TypeCode = TypeCode::INT64;
 }
 
 pub fn as_type(v: TypeCode) -> Type {

--- a/src/db/spanner/support.rs
+++ b/src/db/spanner/support.rs
@@ -40,17 +40,13 @@ impl ToSpannerValue for String {
 
 impl ToSpannerValue for i32 {
     fn to_spanner_value(&self) -> Value {
-        let mut value = Value::new();
-        value.set_number_value(*self as f64);
-        value
+        self.to_string().to_spanner_value()
     }
 }
 
 impl ToSpannerValue for u32 {
     fn to_spanner_value(&self) -> Value {
-        let mut value = Value::new();
-        value.set_number_value(*self as f64);
-        value
+        self.to_string().to_spanner_value()
     }
 }
 


### PR DESCRIPTION
## Description

In the `ToSpannerValue` implementations for `i32` and `u32`, we were using `Value::set_number_value()` to construct a `Value` from an integer. In doing so, we coerced the integers into floats, which is what created the errors on Spanner. To resolve this, I convert the integral values to strings prior to creating a `Value`.

## Testing

The issue can be reproduced on the main branch by adding a new bookmark and syncing (your local server should throw the [same error that appeared in Sentry](https://sentry.prod.mozaws.net/operations/syncstorage-dev/issues/11102490/?query=is%3Aunresolved). Switching to this feature branch, adding a new bookmark, (recompiling,) and syncing should result in a successful sync, with no errors reported.

## Issue(s)

Closes #1055
