### PR TITLE
fix: update deadpool w/ the incorrect pool stats fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,10 @@ bytes = "1.0"
 cadence = "0.24"
 chrono = "0.4"
 config = "0.10"
-# Pin to 0.5 for now, to keep it under tokio 0.2 (issue977)
-deadpool = "0.5"  # pin to 0.5
+# Pin to 0.5 for now, to keep it under tokio 0.2 (issue977).
+# Fix for #803 (deadpool#92) points to our fork for now
+#deadpool = "0.5"  # pin to 0.5
+deadpool = { git = "https://github.com/mozilla-services/deadpool", branch = "deadpool-v0.5.2-issue92" }
 diesel = { version = "1.4", features = ["mysql", "r2d2"] }
 diesel_logger = "0.1.1"
 diesel_migrations = { version = "1.4.0", features = ["mysql"] }


### PR DESCRIPTION
## Description

we're blocked from updating to the latest deadpool (due to its tokio 1.0 usage,
blocked on actix-web 4) so bring in our fork of the older deadpool-v0.5.2 for
now

## Testing

stage/prod idle connection metrics should stop unbounded growth over time

## Issue(s)

Closes #803

NOTE: merging to a release/0.10 branch