### PR TITLE
feat: Support SYNC_SPANNER_EMULATOR_HOST

### DIFF
--- a/src/db/spanner/manager/deadpool.rs
+++ b/src/db/spanner/manager/deadpool.rs
@@ -25,6 +25,7 @@ pub struct SpannerSessionManager {
     test_transactions: bool,
     max_lifespan: Option<u32>,
     max_idle: Option<u32>,
+    emulator_host: Option<String>,
 }
 
 impl fmt::Debug for SpannerSessionManager {
@@ -56,6 +57,7 @@ impl SpannerSessionManager {
             test_transactions,
             max_lifespan: settings.database_pool_connection_lifespan,
             max_idle: settings.database_pool_connection_max_idle,
+            emulator_host: settings.spanner_emulator_host.clone(),
         })
     }
 }
@@ -68,6 +70,7 @@ impl Manager<SpannerSession, DbError> for SpannerSessionManager {
             self.metrics.clone(),
             &self.database_name,
             self.test_transactions,
+            self.emulator_host.clone(),
         )
         .await?;
         Ok(session)

--- a/src/db/spanner/manager/session.rs
+++ b/src/db/spanner/manager/session.rs
@@ -43,14 +43,14 @@ pub async fn create_spanner_session(
     // ChannelBuilder::secure_connect) block?!
     let chan = block(move || -> Result<grpcio::Channel, grpcio::Error> {
         metrics.start_timer("storage.pool.grpc_auth", None);
-        // Requires
-        // GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
         if let Some(spanner_emulator_address) = emulator_host {
             Ok(ChannelBuilder::new(env)
                 .max_send_message_len(100 << 20)
                 .max_receive_message_len(100 << 20)
                 .connect(&spanner_emulator_address))
         } else {
+            // Requires
+            // GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
             let creds = ChannelCredentials::google_default_credentials()?;
             Ok(ChannelBuilder::new(env)
                 .max_send_message_len(100 << 20)

--- a/src/db/spanner/manager/session.rs
+++ b/src/db/spanner/manager/session.rs
@@ -37,6 +37,7 @@ pub async fn create_spanner_session(
     mut metrics: Metrics,
     database_name: &str,
     use_test_transactions: bool,
+    emulator_host: Option<String>,
 ) -> Result<SpannerSession, DbError> {
     // XXX: issue732: Could google_default_credentials (or
     // ChannelBuilder::secure_connect) block?!
@@ -44,11 +45,18 @@ pub async fn create_spanner_session(
         metrics.start_timer("storage.pool.grpc_auth", None);
         // Requires
         // GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
-        let creds = ChannelCredentials::google_default_credentials()?;
-        Ok(ChannelBuilder::new(env)
-            .max_send_message_len(100 << 20)
-            .max_receive_message_len(100 << 20)
-            .secure_connect(SPANNER_ADDRESS, creds))
+        if let Some(spanner_emulator_address) = emulator_host {
+            Ok(ChannelBuilder::new(env)
+                .max_send_message_len(100 << 20)
+                .max_receive_message_len(100 << 20)
+                .connect(&spanner_emulator_address))
+        } else {
+            let creds = ChannelCredentials::google_default_credentials()?;
+            Ok(ChannelBuilder::new(env)
+                .max_send_message_len(100 << 20)
+                .max_receive_message_len(100 << 20)
+                .secure_connect(SPANNER_ADDRESS, creds))
+        }
     })
     .await
     .map_err(|e| match e {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -80,6 +80,8 @@ pub struct Settings {
 
     pub enable_quota: bool,
     pub enforce_quota: bool,
+
+    pub spanner_emulator_host: Option<String>,
 }
 
 impl Default for Settings {
@@ -109,6 +111,7 @@ impl Default for Settings {
             human_logs: false,
             enable_quota: false,
             enforce_quota: false,
+            spanner_emulator_host: None,
         }
     }
 }


### PR DESCRIPTION
## Description

Adds support for a `SYNC_SPANNER_EMULATOR_HOST` environment variable. When the environment variable is set, the session manager will attempt to create an insecure gRPC channel to the Spanner instance running at that host. If it is not set, it will create a secure connection to the default Spanner instance as it previously did.

## Testing

I was able to test this by adding `println!`s in `session::create_spanner_session()` like so:
```rust
pub async fn create_spanner_session(
    env: Arc<Environment>,
    mut metrics: Metrics,
    database_name: &str,
    use_test_transactions: bool,
    emulator_host: Option<String>,
) -> Result<SpannerSession, DbError> {
    // XXX: issue732: Could google_default_credentials (or
    // ChannelBuilder::secure_connect) block?!
    let chan = block(move || -> Result<grpcio::Channel, grpcio::Error> {
        metrics.start_timer("storage.pool.grpc_auth", None);
        // Requires
        // GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
        if let Some(spanner_emulator_address) = emulator_host {
            println!("connecting to emulator")

            Ok(ChannelBuilder::new(env)
                .max_send_message_len(100 << 20)
                .max_receive_message_len(100 << 20)
                .connect(&spanner_emulator_address))
        } else {
            println!("connecting to remote instance")

            let creds = ChannelCredentials::google_default_credentials()?;
            Ok(ChannelBuilder::new(env)
                .max_send_message_len(100 << 20)
                .max_receive_message_len(100 << 20)
                .secure_connect(SPANNER_ADDRESS, creds))
        }
...
}
```
When the `SYNC_SPANNER_EMULATOR_HOST` environment variable is set, the session manager correctly connects to the local Spanner instance running on my machine. When that variable is not set, it correctly connects to the remote Spanner dev instance.

To set up the Spanner emulator on Ubuntu, I installed the `google-cloud-sdk-spanner-emulator` apt package. [Google recommends](https://cloud.google.com/spanner/docs/emulator#using_the_gcloud_cli_with_the_emulator) creating a separate configuration for emulator work, so you can easily switch between the emulator config and the remote config. To do this, I ran the following:
```bash
gcloud config configurations create emulator
gcloud config set auth/disable_credentials true
gcloud config set project test-project
gcloud config set api_endpoint_overrides/spanner http://localhost:9020/
```
Start the emulator with the following:
```bash
gcloud emulators spanner start
```
Create a test instance and database on your local emulator:
```bash
gcloud spanner instances create test-instance \
   --config=emulator-config --description="Test Instance" --nodes=1
gcloud spanner databases create testdb --instance=test-instance
```
Update the `database_url` setting in your local config to `spanner://projects/test-project/instances/test-instance/databases/testdb`. Finally, attempt a sync. It should fail with an error that reads:
>Table not found: user_collections [at 2:25]

This confirms that the application server is connected to the Spanner emulator.

## Issue(s)

Closes #915
