### PR TITLE
bug: Fix build for Rust 1.53.0

### DIFF
--- a/src/db/spanner/manager/session.rs
+++ b/src/db/spanner/manager/session.rs
@@ -166,7 +166,7 @@ pub async fn recycle_spanner_session(
                 conn.session = create_session(&conn.client, database_name).await?;
                 Ok(())
             }
-            _ => return Err(e.into()),
+            _ => Err(e.into()),
         },
     }
 }

--- a/src/db/spanner/support.rs
+++ b/src/db/spanner/support.rs
@@ -307,7 +307,7 @@ impl StreamedResultSetAsync {
         for value in values {
             self.current_row.push(value);
             if self.current_row.len() == width {
-                let current_row = mem::replace(&mut self.current_row, vec![]);
+                let current_row = mem::take(&mut self.current_row);
                 self.rows.push_back(current_row);
             }
         }

--- a/src/db/tests/db.rs
+++ b/src/db/tests/db.rs
@@ -176,7 +176,7 @@ async fn get_bsos_limit_offset() -> Result<()> {
         .await?;
     assert_eq!(bsos.items.len(), 5);
     if let Some(ref offset) = bsos.offset {
-        if offset.chars().position(|c| c == ':').is_none() {
+        if !offset.chars().any(|c| c == ':') {
             assert_eq!(offset, &"5".to_string());
         }
     }
@@ -198,7 +198,7 @@ async fn get_bsos_limit_offset() -> Result<()> {
         .await?;
     assert_eq!(bsos2.items.len(), 5);
     if let Some(ref offset) = bsos2.offset {
-        if offset.chars().position(|c| c == ':').is_none() {
+        if !offset.chars().any(|c| c == ':') {
             assert_eq!(offset, &"10".to_owned());
         }
     }

--- a/src/web/extractors.rs
+++ b/src/web/extractors.rs
@@ -2133,7 +2133,7 @@ mod tests {
             .batch
             .expect("Could not get batch in test_valid_collection_batch_post_request");
         assert!(batch.id.is_none());
-        assert!(batch.commit);
+        assert!(!batch.commit);
 
         let result2 = post_collection("batch", &bso_body)
             .await
@@ -2142,7 +2142,7 @@ mod tests {
             .batch
             .expect("Could not get batch2 in test_valid_collection_batch_post_request");
         assert!(batch2.id.is_none());
-        assert!(batch2.commit);
+        assert!(!batch2.commit);
 
         let result3 = post_collection("batch=MTI%3D&commit=true", &bso_body)
             .await

--- a/src/web/extractors.rs
+++ b/src/web/extractors.rs
@@ -1876,7 +1876,7 @@ mod tests {
         assert_eq!(result.ids, vec!["1", "2"]);
         assert_eq!(result.sort, Sorting::Index);
         assert_eq!(result.older.unwrap(), SyncTimestamp::from_seconds(2.43));
-        assert_eq!(result.full, true);
+        assert!(result.full);
     }
 
     #[test]
@@ -2133,7 +2133,7 @@ mod tests {
             .batch
             .expect("Could not get batch in test_valid_collection_batch_post_request");
         assert!(batch.id.is_none());
-        assert_eq!(batch.commit, false);
+        assert!(batch.commit);
 
         let result2 = post_collection("batch", &bso_body)
             .await
@@ -2142,7 +2142,7 @@ mod tests {
             .batch
             .expect("Could not get batch2 in test_valid_collection_batch_post_request");
         assert!(batch2.id.is_none());
-        assert_eq!(batch2.commit, false);
+        assert!(batch2.commit);
 
         let result3 = post_collection("batch=MTI%3D&commit=true", &bso_body)
             .await
@@ -2151,7 +2151,7 @@ mod tests {
             .batch
             .expect("Could not get batch3 in test_valid_collection_batch_post_request");
         assert!(batch3.id.is_some());
-        assert_eq!(batch3.commit, true);
+        assert!(batch3.commit);
     }
 
     #[actix_rt::test]

--- a/src/web/middleware/rejectua.rs
+++ b/src/web/middleware/rejectua.rs
@@ -32,7 +32,7 @@ $
     .unwrap();
 }
 
-#[allow(clippy::clippy::upper_case_acronyms)]
+#[allow(clippy::upper_case_acronyms)]
 #[derive(Debug, Default)]
 pub struct RejectUA;
 
@@ -53,7 +53,7 @@ where
         future::ok(RejectUAMiddleware { service })
     }
 }
-#[allow(clippy::clippy::upper_case_acronyms)]
+#[allow(clippy::upper_case_acronyms)]
 pub struct RejectUAMiddleware<S> {
     service: S,
 }


### PR DESCRIPTION
## Description

These changes fix build errors caused by the new Rust version.

## Testing

These changes are trivial -- in each case, I used Clippy's suggested fix. If the tests pass and the build succeeds, the changes should be sound.

## Issue(s)

Closes #1105 
