### PR TITLE
refactor: Tokenserver: Add mature MySQL adapter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,6 +62,18 @@ commands:
       - run:
           name: Install grpcio dependencies
           command: sudo apt-get update && sudo apt-get install -y cmake golang-go
+  setup-mysql:
+    steps:
+      - run:
+          name: Install MySQL client
+          command: sudo apt-get update && sudo apt-get install -y default-mysql-client
+  create-tokenserver-database:
+    steps:
+      - run:
+          name: Create Tokenserver database
+          command: |
+            mysql -u root -ppassword -h 127.0.0.1 -e 'CREATE DATABASE tokenserver;'   
+            mysql -u root -ppassword -h 127.0.0.1 -e "GRANT ALL ON tokenserver.* to 'test'@'%';"
 
   write-version:
     steps:
@@ -163,6 +175,7 @@ jobs:
           password: $DOCKER_PASS
         environment:
             SYNC_DATABASE_URL: mysql://test:test@127.0.0.1/syncstorage
+            SYNC_TOKENSERVER__DATABASE_URL: mysql://test:test@127.0.0.1/tokenserver
             RUST_BACKTRACE: 1
             # XXX: begin_test_transaction doesn't play nice over threaded tests
             RUST_TEST_THREADS: 1
@@ -171,7 +184,7 @@ jobs:
           username: $DOCKER_USER
           password: $DOCKER_PASS
         environment:
-            MYSQL_ROOT_PASSWORD: random
+            MYSQL_ROOT_PASSWORD: password
             MYSQL_USER: test
             MYSQL_PASSWORD: test
             MYSQL_DATABASE: syncstorage
@@ -190,6 +203,8 @@ jobs:
       - setup-rust
       - setup-python
       - setup-gcp-grpc
+      - setup-mysql
+      - create-tokenserver-database
       # XXX: currently the time needed to setup-sccache negates its savings
       #- setup-sccache
       #- restore-sccache-cache

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 ##
 
 SYNC_DATABASE_URL = 'mysql://sample_user:sample_password@localhost/syncstorage_rs'
+SYNC_TOKENSERVER__DATABASE_URL = 'mysql://sample_user:sample_password@localhost/tokenserver_rs'
 
 # This key can live anywhere on your machine. Adjust path as needed.
 PATH_TO_SYNC_SPANNER_KEYS = `pwd`/service-account.json
@@ -41,4 +42,4 @@ run_spanner:
 	GOOGLE_APPLICATION_CREDENTIALS=$(PATH_TO_SYNC_SPANNER_KEYS) GRPC_DEFAULT_SSL_ROOTS_FILE_PATH=$(PATH_TO_GRPC_CERT) make run
 
 test:
-	SYNC_DATABASE_URL=$(SYNC_DATABASE_URL) RUST_TEST_THREADS=1 cargo test
+	SYNC_DATABASE_URL=$(SYNC_DATABASE_URL) SYNC_TOKENSERVER__DATABASE_URL=$(SYNC_TOKENSERVER__DATABASE_URL) RUST_TEST_THREADS=1 cargo test

--- a/docker-compose.e2e.mysql.yaml
+++ b/docker-compose.e2e.mysql.yaml
@@ -1,9 +1,11 @@
 version: '3'
 services:
-    db:
+    sync-db:
+    tokenserver-db:
     syncstorage-rs:
         depends_on:
-          - db
+          - sync-db
+          - tokenserver-db
         # TODO: either syncstorage-rs should retry the db connection
         # itself a few times or should include a wait-for-it.sh script
         # inside its docker that would do this for us. Same (probably
@@ -22,11 +24,8 @@ services:
         environment:
           SYNC_HOST: 0.0.0.0
           SYNC_MASTER_SECRET: secret0
-          SYNC_DATABASE_URL: mysql://test:test@db:3306/syncstorage
-          SYNC_TOKENSERVER_DATABASE_URL: mysql://username:pw@localhost/tokenserver
-          SYNC_TOKENSERVER_JWKS_RSA_MODULUS: 2lDphW0lNZ4w1m9CfmIhC1AxYG9iwihxBdQZo7_6e0TBAi8_TNaoHHI90G9n5d8BQQnNcF4j2vOs006zlXcqGrP27b49KkN3FmbcOMovvfesMseghaqXqqFLALL9us3Wstt_fV_qV7ceRcJq5Hd_Mq85qUgYSfb9qp0vyePb26KEGy4cwO7c9nCna1a_i5rzUEJu6bAtcLS5obSvmsOOpTLHXojKKOnC4LRC3osdR6AU6v3UObKgJlkk_-8LmPhQZqOXiI_TdBpNiw6G_-eishg8V_poPlAnLNd8mfZBam-_7CdUS4-YoOvJZfYjIoboOuVmUrBjogFyDo72EPTReQ
-          SYNC_TOKENSERVER_JWKS_RSA_EXPONENT: AQAB
-          SYNC_FXA_METRICS_HASH_SECRET: insecure
+          SYNC_DATABASE_URL: mysql://test:test@sync-db:3306/syncstorage
+          SYNC_TOKENSERVER__DATABASE_URL: mysql://test:test@tokenserver-db:3307/tokenserver
         entrypoint: >
           /bin/sh -c "
             sleep 28; pip3 install -r /app/tools/integration_tests/requirements.txt && python3 /app/tools/integration_tests/run.py 'http://localhost:8000#secret0'

--- a/docker-compose.e2e.spanner.yaml
+++ b/docker-compose.e2e.spanner.yaml
@@ -1,10 +1,11 @@
 version: '3'
 services:
-    db:
-    db-setup:
+    sync-db:
+    sync-db-setup:
+    tokenserver-db:
     syncstorage-rs:
         depends_on:
-          - db-setup
+          - sync-db-setup
         # TODO: either syncstorage-rs should retry the db connection
         # itself a few times or should include a wait-for-it.sh script
         # inside its docker that would do this for us. Same (probably
@@ -24,11 +25,8 @@ services:
           SYNC_HOST: 0.0.0.0
           SYNC_MASTER_SECRET: secret0
           SYNC_DATABASE_URL: spanner://projects/test-project/instances/test-instance/databases/test-database
-          SYNC_SPANNER_EMULATOR_HOST: db:9010
-          SYNC_TOKENSERVER_DATABASE_URL: mysql://username:pw@localhost/tokenserver
-          SYNC_TOKENSERVER_JWKS_RSA_MODULUS: 2lDphW0lNZ4w1m9CfmIhC1AxYG9iwihxBdQZo7_6e0TBAi8_TNaoHHI90G9n5d8BQQnNcF4j2vOs006zlXcqGrP27b49KkN3FmbcOMovvfesMseghaqXqqFLALL9us3Wstt_fV_qV7ceRcJq5Hd_Mq85qUgYSfb9qp0vyePb26KEGy4cwO7c9nCna1a_i5rzUEJu6bAtcLS5obSvmsOOpTLHXojKKOnC4LRC3osdR6AU6v3UObKgJlkk_-8LmPhQZqOXiI_TdBpNiw6G_-eishg8V_poPlAnLNd8mfZBam-_7CdUS4-YoOvJZfYjIoboOuVmUrBjogFyDo72EPTReQ
-          SYNC_TOKENSERVER_JWKS_RSA_EXPONENT: AQAB
-          SYNC_FXA_METRICS_HASH_SECRET: insecure
+          SYNC_TOKENSERVER__DATABASE_URL: mysql://test:test@tokenserver-db:3306/tokenserver
+          SYNC_SPANNER_EMULATOR_HOST: sync-db:9010
         entrypoint: >
           /bin/sh -c "
             sleep 28; pip3 install -r /app/tools/integration_tests/requirements.txt && python3 /app/tools/integration_tests/run.py 'http://localhost:8000#secret0'

--- a/docker-compose.mysql.yaml
+++ b/docker-compose.mysql.yaml
@@ -1,9 +1,9 @@
 version: '3'
 services:
-    db:
+    sync-db:
         image: mysql:5.7
         volumes:
-            - db_data:/var/lib/mysql
+            - sync_db_data:/var/lib/mysql
         restart: always
         ports:
             - "3306"
@@ -14,24 +14,37 @@ services:
             MYSQL_USER: test
             MYSQL_PASSWORD: test
 
+    tokenserver-db:
+        image: mysql:5.7
+        volumes:
+            - tokenserver_db_data:/var/lib/mysql
+        restart: always
+        ports:
+            - "3307"
+        environment:
+            #MYSQL_RANDOM_ROOT_PASSWORD: yes
+            MYSQL_ROOT_PASSWORD: random
+            MYSQL_DATABASE: tokenserver
+            MYSQL_USER: test
+            MYSQL_PASSWORD: test
+
     syncstorage-rs:
         image: ${SYNCSTORAGE_RS_IMAGE:-syncstorage-rs:latest}
         restart: always
         ports:
           - "8000:8000"
         depends_on:
-          - db
+          - sync-db
+          - tokenserver-db
         environment:
           SYNC_HOST: 0.0.0.0
           SYNC_MASTER_SECRET: secret0
-          SYNC_DATABASE_URL: mysql://test:test@db:3306/syncstorage
-          SYNC_TOKENSERVER_DATABASE_URL: mysql://username:pw@localhost/tokenserver
-          SYNC_TOKENSERVER_JWKS_RSA_MODULUS: 2lDphW0lNZ4w1m9CfmIhC1AxYG9iwihxBdQZo7_6e0TBAi8_TNaoHHI90G9n5d8BQQnNcF4j2vOs006zlXcqGrP27b49KkN3FmbcOMovvfesMseghaqXqqFLALL9us3Wstt_fV_qV7ceRcJq5Hd_Mq85qUgYSfb9qp0vyePb26KEGy4cwO7c9nCna1a_i5rzUEJu6bAtcLS5obSvmsOOpTLHXojKKOnC4LRC3osdR6AU6v3UObKgJlkk_-8LmPhQZqOXiI_TdBpNiw6G_-eishg8V_poPlAnLNd8mfZBam-_7CdUS4-YoOvJZfYjIoboOuVmUrBjogFyDo72EPTReQ
-          SYNC_TOKENSERVER_JWKS_RSA_EXPONENT: AQAB
-          SYNC_FXA_METRICS_HASH_SECRET: insecure
+          SYNC_DATABASE_URL: mysql://test:test@sync-db:3306/syncstorage
+          SYNC_TOKENSERVER__DATABASE_URL: mysql://test:test@tokenserver-db:3307/tokenserver
 
 volumes:
-    db_data:
+    sync_db_data:
+    tokenserver_db_data:
 
 # Application runs off of port 8000.
 # you can test if it's available with

--- a/docker-compose.spanner.yaml
+++ b/docker-compose.spanner.yaml
@@ -1,39 +1,49 @@
 version: '3'
 services:
-    db:
+    sync-db:
         image: gcr.io/cloud-spanner-emulator/emulator
         ports:
             - "9010:9010"
             - "9020:9020"
         environment:
             PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-    db-setup:
+    sync-db-setup:
         image: app:build
         depends_on:
-          - db
+          - sync-db
         restart: "no"
         entrypoint: "/app/scripts/prepare-spanner.sh"
         environment:
-            SYNC_SPANNER_EMULATOR_HOST: db:9020
+            SYNC_SPANNER_EMULATOR_HOST: sync-db:9020
+    tokenserver-db:
+        image: mysql:5.7
+        volumes:
+            - tokenserver_db_data:/var/lib/mysql
+        restart: always
+        ports:
+            - "3306"
+        environment:
+            #MYSQL_RANDOM_ROOT_PASSWORD: yes
+            MYSQL_ROOT_PASSWORD: random
+            MYSQL_DATABASE: tokenserver
+            MYSQL_USER: test
+            MYSQL_PASSWORD: test
     syncstorage-rs:
         image: ${SYNCSTORAGE_RS_IMAGE:-syncstorage-rs:latest}
         restart: always
         ports:
           - "8000:8000"
         depends_on:
-          - db-setup
+          - sync-db-setup
         environment:
           SYNC_HOST: 0.0.0.0
           SYNC_MASTER_SECRET: secret0
           SYNC_DATABASE_URL: spanner://projects/test-project/instances/test-instance/databases/test-database
-          SYNC_SPANNER_EMULATOR_HOST: db:9010
-          SYNC_TOKENSERVER_DATABASE_URL: mysql://username:pw@localhost/tokenserver
-          SYNC_TOKENSERVER_JWKS_RSA_MODULUS: 2lDphW0lNZ4w1m9CfmIhC1AxYG9iwihxBdQZo7_6e0TBAi8_TNaoHHI90G9n5d8BQQnNcF4j2vOs006zlXcqGrP27b49KkN3FmbcOMovvfesMseghaqXqqFLALL9us3Wstt_fV_qV7ceRcJq5Hd_Mq85qUgYSfb9qp0vyePb26KEGy4cwO7c9nCna1a_i5rzUEJu6bAtcLS5obSvmsOOpTLHXojKKOnC4LRC3osdR6AU6v3UObKgJlkk_-8LmPhQZqOXiI_TdBpNiw6G_-eishg8V_poPlAnLNd8mfZBam-_7CdUS4-YoOvJZfYjIoboOuVmUrBjogFyDo72EPTReQ
-          SYNC_TOKENSERVER_JWKS_RSA_EXPONENT: AQAB
-          SYNC_FXA_METRICS_HASH_SECRET: insecure
+          SYNC_SPANNER_EMULATOR_HOST: sync-db:9010
+          SYNC_TOKENSERVER__DATABASE_URL: mysql://test:test@tokenserver-db:3306/tokenserver
 
 volumes:
-    db_data:
+    tokenserver_db_data:
 
 # Application runs off of port 8000.
 # you can test if it's available with

--- a/src/db/mysql/mod.rs
+++ b/src/db/mysql/mod.rs
@@ -8,3 +8,5 @@ mod schema;
 mod test;
 
 pub use self::pool::MysqlDbPool;
+#[cfg(test)]
+pub use self::test::TestTransactionCustomizer;

--- a/src/db/mysql/models.rs
+++ b/src/db/mysql/models.rs
@@ -994,6 +994,7 @@ impl MysqlDb {
     }
 }
 
+#[macro_export]
 macro_rules! sync_db_method {
     ($name:ident, $sync_name:ident, $type:ident) => {
         sync_db_method!($name, $sync_name, $type, results::$type);

--- a/src/db/mysql/pool.rs
+++ b/src/db/mysql/pool.rs
@@ -35,8 +35,8 @@ embed_migrations!();
 ///
 /// Mysql DDL statements implicitly commit which could disrupt MysqlPool's
 /// begin_test_transaction during tests. So this runs on its own separate conn.
-pub fn run_embedded_migrations(settings: &Settings) -> Result<()> {
-    let conn = MysqlConnection::establish(&settings.database_url)?;
+pub fn run_embedded_migrations(database_url: &str) -> Result<()> {
+    let conn = MysqlConnection::establish(database_url)?;
     #[cfg(test)]
     // XXX: this doesn't show the DDL statements
     // https://github.com/shssoichiro/diesel-logger/issues/1
@@ -63,7 +63,7 @@ impl MysqlDbPool {
     ///
     /// Also initializes the Mysql db, ensuring all migrations are ran.
     pub fn new(settings: &Settings, metrics: &Metrics) -> Result<Self> {
-        run_embedded_migrations(settings)?;
+        run_embedded_migrations(&settings.database_url)?;
         Self::new_without_migrations(settings, metrics)
     }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -138,14 +138,12 @@ macro_rules! build_app {
                     .route(web::get().to(handlers::get_bso))
                     .route(web::put().to(handlers::put_bso)),
             )
-
             // XXX: This route will be enabled when we are ready to roll out Tokenserver
             // Tokenserver
             // .service(
             //     web::resource("/1.0/sync/1.5".to_string())
             //         .route(web::get().to(tokenserver::handlers::get_tokenserver_result)),
             // )
-
             // Dockerflow
             // Remember to update .::web::middleware::DOCKER_FLOW_ENDPOINTS
             // when applying changes to endpoint names.

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -186,7 +186,7 @@ impl Server {
             max_size: settings.database_pool_max_size,
             ..Default::default()
         }));
-        let tokenserver_state = if settings.enable_tokenserver {
+        let tokenserver_state = if settings.tokenserver.enabled {
             Some(tokenserver::ServerState::from_settings(
                 &settings.tokenserver,
             )?)

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -138,11 +138,14 @@ macro_rules! build_app {
                     .route(web::get().to(handlers::get_bso))
                     .route(web::put().to(handlers::put_bso)),
             )
+
+            // XXX: This route will be enabled when we are ready to roll out Tokenserver
             // Tokenserver
-            .service(
-                web::resource("/1.0/sync/1.5".to_string())
-                    .route(web::get().to(tokenserver::handlers::get_tokenserver_result)),
-            )
+            // .service(
+            //     web::resource("/1.0/sync/1.5".to_string())
+            //         .route(web::get().to(tokenserver::handlers::get_tokenserver_result)),
+            // )
+
             // Dockerflow
             // Remember to update .::web::middleware::DOCKER_FLOW_ENDPOINTS
             // when applying changes to endpoint names.

--- a/src/server/test.rs
+++ b/src/server/test.rs
@@ -24,7 +24,6 @@ use crate::db::pool_from_settings;
 use crate::db::results::{DeleteBso, GetBso, PostBsos, PutBso};
 use crate::db::util::SyncTimestamp;
 use crate::settings::{test_settings, Secrets, ServerLimits};
-use crate::tokenserver::MockOAuthVerifier;
 use crate::web::{auth::HawkPayload, extractors::BsoBody, X_LAST_MODIFIED};
 
 lazy_static! {
@@ -70,9 +69,7 @@ async fn get_test_state(settings: &Settings) -> ServerState {
         limits: Arc::clone(&SERVER_LIMITS),
         limits_json: serde_json::to_string(&**SERVER_LIMITS).unwrap(),
         secrets: Arc::clone(&SECRETS),
-        tokenserver_database_url: None,
-        fxa_metrics_hash_secret: None,
-        tokenserver_oauth_verifier: Box::new(MockOAuthVerifier::default()),
+        tokenserver_state: None,
         metrics: Box::new(metrics),
         port: settings.port,
         quota_enabled: settings.enable_quota,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -162,7 +162,10 @@ impl Settings {
         s.set_default("enforce_quota", false)?;
 
         // Set Tokenserver defaults
-        s.set_default("tokenserver.database_url", "mysql://root@127.0.0.1/tokenserver")?;
+        s.set_default(
+            "tokenserver.database_url",
+            "mysql://root@127.0.0.1/tokenserver",
+        )?;
         s.set_default("tokenserver.enabled", false)?;
         s.set_default("tokenserver.fxa_email_domain", "test.com")?;
         s.set_default("tokenserver.fxa_metrics_hash_secret", "secret")?;

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -82,11 +82,6 @@ pub struct Settings {
 
     /// Settings specific to Tokenserver
     pub tokenserver: TokenserverSettings,
-
-    // XXX: This is a temporary setting used to enable Tokenserver-related features. In
-    // the future, Tokenserver will always be enabled, and this setting will be
-    // removed.
-    pub enable_tokenserver: bool,
 }
 
 impl Default for Settings {
@@ -114,7 +109,6 @@ impl Default for Settings {
             enforce_quota: false,
             spanner_emulator_host: None,
             tokenserver: TokenserverSettings::default(),
-            enable_tokenserver: false,
         }
     }
 }
@@ -168,9 +162,10 @@ impl Settings {
         s.set_default("enforce_quota", false)?;
 
         // Set Tokenserver defaults
-        s.set_default("enable_tokenserver", false)?;
-        s.set_default("tokenserver.fxa_metrics_hash_secret", "secret")?;
+        s.set_default("tokenserver.database_url", "mysql://root@127.0.0.1/tokenserver")?;
+        s.set_default("tokenserver.enabled", false)?;
         s.set_default("tokenserver.fxa_email_domain", "test.com")?;
+        s.set_default("tokenserver.fxa_metrics_hash_secret", "secret")?;
 
         // Merge the config file if supplied
         if let Some(config_filename) = filename {

--- a/src/tokenserver/db/mock.rs
+++ b/src/tokenserver/db/mock.rs
@@ -1,0 +1,58 @@
+#![allow(clippy::new_without_default)]
+
+use futures::future;
+
+use super::models::{Db, DbFuture};
+#[cfg(test)]
+use super::params;
+use super::pool::DbPool;
+use super::results;
+use crate::db::error::DbError;
+
+#[derive(Clone, Debug)]
+pub struct MockDbPool;
+
+impl MockDbPool {
+    pub fn new() -> Self {
+        MockDbPool
+    }
+}
+
+impl DbPool for MockDbPool {
+    fn get(&self) -> Result<Box<dyn Db>, DbError> {
+        Ok(Box::new(MockDb::new()))
+    }
+
+    fn box_clone(&self) -> Box<dyn DbPool> {
+        Box::new(self.clone())
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct MockDb;
+
+impl MockDb {
+    pub fn new() -> Self {
+        MockDb
+    }
+}
+
+impl Db for MockDb {
+    fn get_user(&self, _email: String) -> DbFuture<'_, results::GetUser> {
+        Box::pin(future::ok(results::GetUser::default()))
+    }
+
+    #[cfg(test)]
+    fn post_node(&self, _node: params::PostNode) -> DbFuture<'_, results::PostNode> {
+        Box::pin(future::ok(results::PostNode::default()))
+    }
+
+    #[cfg(test)]
+    fn post_service(&self, _service: params::PostService) -> DbFuture<'_, results::PostService> {
+        Box::pin(future::ok(results::PostService::default()))
+    }
+    #[cfg(test)]
+    fn post_user(&self, _user: params::PostUser) -> DbFuture<'_, results::PostUser> {
+        Box::pin(future::ok(results::PostUser::default()))
+    }
+}

--- a/src/tokenserver/db/mod.rs
+++ b/src/tokenserver/db/mod.rs
@@ -1,2 +1,5 @@
+pub mod mock;
 pub mod models;
+mod params;
+pub mod pool;
 pub mod results;

--- a/src/tokenserver/db/models.rs
+++ b/src/tokenserver/db/models.rs
@@ -64,10 +64,11 @@ impl TokenserverDb {
     fn get_user_sync(&self, email: String) -> DbResult<results::GetUser> {
         let query = r#"
             SELECT users.uid, users.email, users.client_state, users.generation,
-                users.keys_changed_at, users.created_at, nodes.node
-            FROM users
-            JOIN nodes ON nodes.id = users.nodeid
-            WHERE users.email = ?
+                   users.keys_changed_at, users.created_at, nodes.node
+              FROM users
+              JOIN nodes
+                ON nodes.id = users.nodeid
+             WHERE users.email = ?
         "#;
         let mut user_records = diesel::sql_query(query)
             .bind::<Text, _>(email)
@@ -87,9 +88,8 @@ impl TokenserverDb {
     fn post_node_sync(&self, node: params::PostNode) -> DbResult<results::PostNode> {
         let query = r#"
             INSERT INTO nodes (service, node, available, current_load, capacity, downed, backoff)
-               VALUES (?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
         "#;
-
         diesel::sql_query(query)
             .bind::<Integer, _>(node.service_id)
             .bind::<Text, _>(&node.node)
@@ -101,16 +101,16 @@ impl TokenserverDb {
             .execute(&self.inner.conn)?;
 
         let query = r#"
-            SELECT id FROM nodes
-            WHERE service = ? AND
-                  node = ? AND
-                  available = ? AND
-                  current_load = ? AND
-                  capacity = ? AND
-                  downed = ? AND
-                  backoff = ?
+            SELECT id
+              FROM nodes
+             WHERE service = ?
+               AND node = ?
+               AND available = ?
+               AND current_load = ?
+               AND capacity = ?
+               AND downed = ?
+               AND backoff = ?
         "#;
-
         diesel::sql_query(query)
             .bind::<Integer, _>(node.service_id)
             .bind::<Text, _>(&node.node)
@@ -125,13 +125,21 @@ impl TokenserverDb {
 
     #[cfg(test)]
     fn post_service_sync(&self, service: params::PostService) -> DbResult<results::PostService> {
-        let query = "INSERT INTO services (service, pattern) VALUES (?, ?)";
+        let query = r#"
+            INSERT INTO services (service, pattern)
+            VALUES (?, ?)
+        "#;
         diesel::sql_query(query)
             .bind::<Text, _>(&service.service)
             .bind::<Text, _>(service.pattern)
             .execute(&self.inner.conn)?;
 
-        let query = "SELECT id FROM services WHERE service = ? AND pattern = ?";
+        let query = r#"
+            SELECT id
+              FROM services
+             WHERE service = ?
+               AND pattern = ?
+        "#;
         diesel::sql_query(query)
             .bind::<Text, _>(&service.service)
             .bind::<Text, _>(&service.service)
@@ -143,9 +151,8 @@ impl TokenserverDb {
     fn post_user_sync(&self, user: params::PostUser) -> DbResult<results::PostUser> {
         let query = r#"
             INSERT INTO users (service, email, generation, client_state, created_at, replaced_at, nodeid, keys_changed_at)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
         "#;
-
         diesel::sql_query(query)
             .bind::<Integer, _>(user.service_id)
             .bind::<Text, _>(&user.email)
@@ -157,7 +164,11 @@ impl TokenserverDb {
             .bind::<Nullable<Bigint>, _>(user.keys_changed_at)
             .execute(&self.inner.conn)?;
 
-        let query = "SELECT uid FROM users WHERE email = ?";
+        let query = r#"
+            SELECT uid
+              FROM users
+             WHERE email = ?
+        "#;
         diesel::sql_query(query)
             .bind::<Text, _>(&user.email)
             .get_result::<results::PostUser>(&self.inner.conn)

--- a/src/tokenserver/db/models.rs
+++ b/src/tokenserver/db/models.rs
@@ -1,37 +1,262 @@
-use diesel::mysql::MysqlConnection;
-use diesel::sql_types::Text;
-use diesel::{Connection, RunQueryDsl};
+use actix_web::web::block;
+#[cfg(test)]
+use diesel::sql_types::{Bigint, Integer, Nullable};
+use diesel::{
+    mysql::MysqlConnection,
+    r2d2::{ConnectionManager, PooledConnection},
+    sql_types::Text,
+    RunQueryDsl,
+};
+#[cfg(test)]
+use diesel_logger::LoggingConnection;
+use futures::future::LocalBoxFuture;
+use futures::TryFutureExt;
 
-use super::results::GetTokenserverUser;
+use std::{self, sync::Arc};
+
+use super::{params, results};
 use crate::db::error::{DbError, DbErrorKind};
+use crate::error::ApiError;
+use crate::sync_db_method;
 
-// TODO: Connecting to the database like this is only temporary. In #1054, we
-// will add a more mature database adapter for Tokenserver.
-pub fn get_tokenserver_user_sync(
-    email: &str,
-    database_url: &str,
-) -> Result<GetTokenserverUser, DbError> {
-    let connection = MysqlConnection::establish(database_url)
-        .unwrap_or_else(|_| panic!("Error connecting to {}", database_url));
+pub type DbFuture<'a, T> = LocalBoxFuture<'a, Result<T, ApiError>>;
+pub type DbResult<T> = std::result::Result<T, DbError>;
+type Conn = PooledConnection<ConnectionManager<MysqlConnection>>;
 
-    let mut user_records = diesel::sql_query(
-        r#"
-        SELECT users.uid, users.email, users.client_state, users.generation,
-            users.keys_changed_at, users.created_at, nodes.node
-        FROM users
-        JOIN nodes ON nodes.id = users.nodeid
-        WHERE users.email = ?
-    "#,
-    )
-    .bind::<Text, _>(&email)
-    .load::<GetTokenserverUser>(&connection)?;
+#[derive(Clone)]
+pub struct TokenserverDb {
+    /// Synchronous Diesel calls are executed in actix_web::web::block to satisfy
+    /// the Db trait's asynchronous interface.
+    ///
+    /// Arc<MysqlDbInner> provides a Clone impl utilized for safely moving to
+    /// the thread pool but does not provide Send as the underlying db
+    /// conn. structs are !Sync (Arc requires both for Send). See the Send impl
+    /// below.
+    pub(super) inner: Arc<DbInner>,
+}
 
-    if user_records.is_empty() {
-        return Err(DbErrorKind::TokenserverUserNotFound.into());
+/// Despite the db conn structs being !Sync (see Arc<MysqlDbInner> above) we
+/// don't spawn multiple MysqlDb calls at a time in the thread pool. Calls are
+/// queued to the thread pool via Futures, naturally serialized.
+unsafe impl Send for TokenserverDb {}
+
+pub struct DbInner {
+    #[cfg(not(test))]
+    pub(super) conn: Conn,
+    #[cfg(test)]
+    pub(super) conn: LoggingConnection<Conn>, // display SQL when RUST_LOG="diesel_logger=trace"
+}
+
+impl TokenserverDb {
+    pub fn new(conn: Conn) -> Self {
+        let inner = DbInner {
+            #[cfg(not(test))]
+            conn,
+            #[cfg(test)]
+            conn: LoggingConnection::new(conn),
+        };
+
+        Self {
+            inner: Arc::new(inner),
+        }
     }
 
-    user_records.sort_by_key(|user_record| (user_record.generation, user_record.created_at));
-    let user_record = user_records[0].clone();
+    fn get_user_sync(&self, email: String) -> DbResult<results::GetUser> {
+        let query = r#"
+            SELECT users.uid, users.email, users.client_state, users.generation,
+                users.keys_changed_at, users.created_at, nodes.node
+            FROM users
+            JOIN nodes ON nodes.id = users.nodeid
+            WHERE users.email = ?
+        "#;
+        let mut user_records = diesel::sql_query(query)
+            .bind::<Text, _>(email)
+            .load::<results::GetUser>(&self.inner.conn)?;
 
-    Ok(user_record)
+        if user_records.is_empty() {
+            return Err(DbErrorKind::TokenserverUserNotFound.into());
+        }
+
+        user_records.sort_by_key(|user_record| (user_record.generation, user_record.created_at));
+        let user_record = user_records[0].clone();
+
+        Ok(user_record)
+    }
+
+    #[cfg(test)]
+    fn post_node_sync(&self, node: params::PostNode) -> DbResult<results::PostNode> {
+        let query = r#"
+            INSERT INTO nodes (service, node, available, current_load, capacity, downed, backoff)
+               VALUES (?, ?, ?, ?, ?, ?, ?)
+        "#;
+
+        diesel::sql_query(query)
+            .bind::<Integer, _>(node.service_id)
+            .bind::<Text, _>(&node.node)
+            .bind::<Integer, _>(node.available)
+            .bind::<Integer, _>(node.current_load)
+            .bind::<Integer, _>(node.capacity)
+            .bind::<Integer, _>(node.downed)
+            .bind::<Integer, _>(node.backoff)
+            .execute(&self.inner.conn)?;
+
+        let query = r#"
+            SELECT id FROM nodes
+            WHERE service = ? AND
+                  node = ? AND
+                  available = ? AND
+                  current_load = ? AND
+                  capacity = ? AND
+                  downed = ? AND
+                  backoff = ?
+        "#;
+
+        diesel::sql_query(query)
+            .bind::<Integer, _>(node.service_id)
+            .bind::<Text, _>(&node.node)
+            .bind::<Integer, _>(node.available)
+            .bind::<Integer, _>(node.current_load)
+            .bind::<Integer, _>(node.capacity)
+            .bind::<Integer, _>(node.downed)
+            .bind::<Integer, _>(node.backoff)
+            .get_result::<results::PostNode>(&self.inner.conn)
+            .map_err(Into::into)
+    }
+
+    #[cfg(test)]
+    fn post_service_sync(&self, service: params::PostService) -> DbResult<results::PostService> {
+        let query = "INSERT INTO services (service, pattern) VALUES (?, ?)";
+        diesel::sql_query(query)
+            .bind::<Text, _>(&service.service)
+            .bind::<Text, _>(service.pattern)
+            .execute(&self.inner.conn)?;
+
+        let query = "SELECT id FROM services WHERE service = ? AND pattern = ?";
+        diesel::sql_query(query)
+            .bind::<Text, _>(&service.service)
+            .bind::<Text, _>(&service.service)
+            .get_result::<results::PostService>(&self.inner.conn)
+            .map_err(Into::into)
+    }
+
+    #[cfg(test)]
+    fn post_user_sync(&self, user: params::PostUser) -> DbResult<results::PostUser> {
+        let query = r#"
+            INSERT INTO users (service, email, generation, client_state, created_at, replaced_at, nodeid, keys_changed_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        "#;
+
+        diesel::sql_query(query)
+            .bind::<Integer, _>(user.service_id)
+            .bind::<Text, _>(&user.email)
+            .bind::<Bigint, _>(user.generation)
+            .bind::<Text, _>(&user.client_state)
+            .bind::<Bigint, _>(user.created_at)
+            .bind::<Nullable<Bigint>, _>(user.replaced_at)
+            .bind::<Bigint, _>(user.node_id)
+            .bind::<Nullable<Bigint>, _>(user.keys_changed_at)
+            .execute(&self.inner.conn)?;
+
+        let query = "SELECT uid FROM users WHERE email = ?";
+        diesel::sql_query(query)
+            .bind::<Text, _>(&user.email)
+            .get_result::<results::PostUser>(&self.inner.conn)
+            .map_err(Into::into)
+    }
+}
+
+impl Db for TokenserverDb {
+    sync_db_method!(get_user, get_user_sync, GetUser);
+
+    #[cfg(test)]
+    sync_db_method!(post_node, post_node_sync, PostNode);
+
+    #[cfg(test)]
+    sync_db_method!(post_service, post_service_sync, PostService);
+
+    #[cfg(test)]
+    sync_db_method!(post_user, post_user_sync, PostUser);
+}
+
+pub trait Db {
+    fn get_user(&self, email: String) -> DbFuture<'_, results::GetUser>;
+
+    #[cfg(test)]
+    fn post_node(&self, node: params::PostNode) -> DbFuture<'_, results::PostNode>;
+
+    #[cfg(test)]
+    fn post_service(&self, service: params::PostService) -> DbFuture<'_, results::PostService>;
+
+    #[cfg(test)]
+    fn post_user(&self, user: params::PostUser) -> DbFuture<'_, results::PostUser>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::settings::test_settings;
+    use crate::tokenserver::db::pool::{DbPool, TokenserverPool};
+
+    type Result<T> = std::result::Result<T, ApiError>;
+
+    #[tokio::test]
+    async fn get_user() -> Result<()> {
+        let pool = db_pool().await?;
+        let db = pool.get()?;
+
+        // Add a service
+        let service_id = db.post_service(params::PostService::default()).await?;
+
+        // Add a node
+        let node_id = {
+            let node = params::PostNode {
+                service_id: service_id.id,
+                ..Default::default()
+            };
+            db.post_node(node).await?
+        };
+
+        // Add a user
+        let email1 = "test_user_1";
+        let user_id = {
+            let user = params::PostUser {
+                service_id: service_id.id,
+                node_id: node_id.id,
+                email: email1.to_owned(),
+                ..Default::default()
+            };
+
+            db.post_user(user).await?
+        };
+
+        // Add another user
+        {
+            let email2 = "test_user_2";
+            let user = params::PostUser {
+                service_id: service_id.id,
+                node_id: node_id.id,
+                email: email2.to_owned(),
+                ..Default::default()
+            };
+
+            db.post_user(user).await?;
+        }
+
+        let user = db.get_user(email1.to_owned()).await?;
+
+        // Ensure that the correct user has been returned
+        assert_eq!(user.uid, user_id.uid);
+
+        Ok(())
+    }
+
+    pub async fn db_pool() -> DbResult<TokenserverPool> {
+        let _ = env_logger::try_init();
+
+        let tokenserver_settings = test_settings().tokenserver;
+        let use_test_transactions = true;
+
+        TokenserverPool::new(&tokenserver_settings, use_test_transactions)
+    }
 }

--- a/src/tokenserver/db/params.rs
+++ b/src/tokenserver/db/params.rs
@@ -1,0 +1,32 @@
+//! Parameter types for database methods.
+
+pub type GetUser = String;
+
+#[derive(Default)]
+pub struct PostNode {
+    pub service_id: i32,
+    pub node: String,
+    pub available: i32,
+    pub current_load: i32,
+    pub capacity: i32,
+    pub downed: i32,
+    pub backoff: i32,
+}
+
+#[derive(Default)]
+pub struct PostService {
+    pub service: String,
+    pub pattern: String,
+}
+
+#[derive(Default)]
+pub struct PostUser {
+    pub service_id: i32,
+    pub email: String,
+    pub generation: i64,
+    pub client_state: String,
+    pub created_at: i64,
+    pub replaced_at: Option<i64>,
+    pub node_id: i64,
+    pub keys_changed_at: Option<i64>,
+}

--- a/src/tokenserver/db/pool.rs
+++ b/src/tokenserver/db/pool.rs
@@ -1,0 +1,88 @@
+use diesel::{
+    mysql::MysqlConnection,
+    r2d2::{ConnectionManager, Pool},
+    Connection,
+};
+#[cfg(test)]
+use diesel_logger::LoggingConnection;
+use std::time::Duration;
+
+use super::models::{Db, DbResult, TokenserverDb};
+use crate::db::error::DbError;
+use crate::tokenserver::settings::Settings;
+
+#[cfg(test)]
+use crate::db::mysql::TestTransactionCustomizer;
+
+embed_migrations!("src/tokenserver/migrations");
+
+/// Run the diesel embedded migrations
+///
+/// Mysql DDL statements implicitly commit which could disrupt MysqlPool's
+/// begin_test_transaction during tests. So this runs on its own separate conn.
+pub fn run_embedded_migrations(database_url: &str) -> DbResult<()> {
+    let conn = MysqlConnection::establish(database_url)?;
+
+    #[cfg(test)]
+    embedded_migrations::run(&LoggingConnection::new(conn))?;
+    #[cfg(not(test))]
+    embedded_migrations::run(&conn)?;
+
+    Ok(())
+}
+
+#[derive(Clone)]
+pub struct TokenserverPool {
+    /// Pool of db connections
+    inner: Pool<ConnectionManager<MysqlConnection>>,
+}
+
+impl TokenserverPool {
+    pub fn new(settings: &Settings, _use_test_transactions: bool) -> DbResult<Self> {
+        run_embedded_migrations(&settings.database_url)?;
+
+        let manager = ConnectionManager::<MysqlConnection>::new(settings.database_url.clone());
+        let builder = Pool::builder()
+            .max_size(settings.database_pool_max_size.unwrap_or(10))
+            .connection_timeout(Duration::from_secs(
+                settings.database_pool_connection_timeout.unwrap_or(30) as u64,
+            ))
+            .min_idle(settings.database_pool_min_idle);
+
+        #[cfg(test)]
+        let builder = if _use_test_transactions {
+            builder.connection_customizer(Box::new(TestTransactionCustomizer))
+        } else {
+            builder
+        };
+
+        Ok(Self {
+            inner: builder.build(manager)?,
+        })
+    }
+}
+
+impl DbPool for TokenserverPool {
+    fn get(&self) -> Result<Box<dyn Db>, DbError> {
+        self.inner
+            .get()
+            .map(|db_pool| Box::new(TokenserverDb::new(db_pool)) as Box<dyn Db>)
+            .map_err(DbError::from)
+    }
+
+    fn box_clone(&self) -> Box<dyn DbPool> {
+        Box::new(self.clone())
+    }
+}
+
+pub trait DbPool: Sync + Send {
+    fn get(&self) -> Result<Box<dyn Db>, DbError>;
+
+    fn box_clone(&self) -> Box<dyn DbPool>;
+}
+
+impl Clone for Box<dyn DbPool> {
+    fn clone(&self) -> Box<dyn DbPool> {
+        self.box_clone()
+    }
+}

--- a/src/tokenserver/db/results.rs
+++ b/src/tokenserver/db/results.rs
@@ -4,8 +4,11 @@ use diesel::{
 };
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Deserialize, QueryableByName, Serialize)]
-pub struct GetTokenserverUser {
+#[cfg(test)]
+use diesel::sql_types::Integer;
+
+#[derive(Clone, Debug, Default, Deserialize, QueryableByName, Serialize)]
+pub struct GetUser {
     #[sql_type = "Bigint"]
     pub uid: i64,
     #[sql_type = "Text"]
@@ -18,4 +21,25 @@ pub struct GetTokenserverUser {
     pub keys_changed_at: Option<i64>,
     #[sql_type = "Bigint"]
     pub created_at: i64,
+}
+
+#[cfg(test)]
+#[derive(Default, QueryableByName)]
+pub struct PostNode {
+    #[sql_type = "Bigint"]
+    pub id: i64,
+}
+
+#[cfg(test)]
+#[derive(Default, QueryableByName)]
+pub struct PostService {
+    #[sql_type = "Integer"]
+    pub id: i32,
+}
+
+#[cfg(test)]
+#[derive(Default, QueryableByName)]
+pub struct PostUser {
+    #[sql_type = "Bigint"]
+    pub uid: i64,
 }

--- a/src/tokenserver/migrations/2021-07-16-001122_init/down.sql
+++ b/src/tokenserver/migrations/2021-07-16-001122_init/down.sql
@@ -1,0 +1,3 @@
+DROP TABLE IF EXISTS `users`;
+DROP TABLE IF EXISTS `nodes`;
+DROP TABLE IF EXISTS `services`;

--- a/src/tokenserver/migrations/2021-07-16-001122_init/up.sql
+++ b/src/tokenserver/migrations/2021-07-16-001122_init/up.sql
@@ -1,0 +1,36 @@
+CREATE TABLE `services` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `service` varchar(30) DEFAULT NULL,
+  `pattern` varchar(128) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `service` (`service`)
+);
+
+CREATE TABLE `nodes` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `service` int NOT NULL,
+  `node` varchar(64) NOT NULL,
+  `available` int NOT NULL DEFAULT '0',
+  `current_load` int NOT NULL DEFAULT '0',
+  `capacity` int NOT NULL DEFAULT '0',
+  `downed` int NOT NULL DEFAULT '0',
+  `backoff` int NOT NULL DEFAULT '0',
+  PRIMARY KEY (`id`),
+  KEY `service` (`service`),
+  CONSTRAINT `nodes_ibfk_1` FOREIGN KEY (`service`) REFERENCES `services` (`id`)
+);
+
+CREATE TABLE `users` (
+  `uid` bigint NOT NULL AUTO_INCREMENT,
+  `service` int NOT NULL,
+  `email` varchar(255) NOT NULL,
+  `generation` bigint NOT NULL,
+  `client_state` varchar(32) NOT NULL,
+  `created_at` bigint NOT NULL,
+  `replaced_at` bigint DEFAULT NULL,
+  `nodeid` bigint NOT NULL,
+  `keys_changed_at` bigint DEFAULT NULL,
+  PRIMARY KEY (`uid`),
+  KEY `nodeid` (`nodeid`),
+  CONSTRAINT `users_ibfk_1` FOREIGN KEY (`nodeid`) REFERENCES `nodes` (`id`)
+) ENGINE=InnoDB AUTO_INCREMENT=4 DEFAULT CHARSET=utf8

--- a/src/tokenserver/mod.rs
+++ b/src/tokenserver/mod.rs
@@ -1,6 +1,38 @@
 pub mod db;
 pub mod extractors;
 pub mod handlers;
+pub mod settings;
 pub mod support;
 
 pub use self::support::{MockOAuthVerifier, OAuthVerifier, VerifyToken};
+
+use db::pool::{DbPool, TokenserverPool};
+use settings::Settings;
+
+use crate::error::ApiError;
+
+#[derive(Clone)]
+pub struct ServerState {
+    pub db_pool: Box<dyn DbPool>,
+    pub fxa_email_domain: String,
+    pub fxa_metrics_hash_secret: String,
+    pub oauth_verifier: Box<dyn VerifyToken>,
+}
+
+impl ServerState {
+    pub fn from_settings(settings: &Settings) -> Result<Self, ApiError> {
+        let oauth_verifier = OAuthVerifier {
+            fxa_oauth_server_url: settings.fxa_oauth_server_url.clone(),
+        };
+        let use_test_transactions = false;
+
+        TokenserverPool::new(settings, use_test_transactions)
+            .map(|db_pool| ServerState {
+                fxa_email_domain: settings.fxa_email_domain.clone(),
+                fxa_metrics_hash_secret: settings.fxa_metrics_hash_secret.clone(),
+                oauth_verifier: Box::new(oauth_verifier),
+                db_pool: Box::new(db_pool),
+            })
+            .map_err(Into::into)
+    }
+}

--- a/src/tokenserver/settings.rs
+++ b/src/tokenserver/settings.rs
@@ -3,11 +3,20 @@ use serde::Deserialize;
 #[derive(Clone, Debug, Deserialize)]
 pub struct Settings {
     pub database_url: String,
+
     pub database_pool_max_size: Option<u32>,
+
     // NOTE: Not supported by deadpool!
     pub database_pool_min_idle: Option<u32>,
+
     /// Pool timeout when waiting for a slot to become available, in seconds
     pub database_pool_connection_timeout: Option<u32>,
+
+    // XXX: This is a temporary setting used to enable Tokenserver-related features. In
+    // the future, Tokenserver will always be enabled, and this setting will be
+    // removed.
+    pub enabled: bool,
+
     pub fxa_metrics_hash_secret: String,
 
     /// The email domain for users' FxA accounts. This should be set according to the
@@ -25,6 +34,7 @@ impl Default for Settings {
             database_pool_max_size: None,
             database_pool_min_idle: None,
             database_pool_connection_timeout: Some(30),
+            enabled: false,
             fxa_email_domain: "api.accounts.firefox.com".to_owned(),
             fxa_metrics_hash_secret: "secret".to_owned(),
             fxa_oauth_server_url: None,

--- a/src/tokenserver/settings.rs
+++ b/src/tokenserver/settings.rs
@@ -1,0 +1,33 @@
+use serde::Deserialize;
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct Settings {
+    pub database_url: String,
+    pub database_pool_max_size: Option<u32>,
+    // NOTE: Not supported by deadpool!
+    pub database_pool_min_idle: Option<u32>,
+    /// Pool timeout when waiting for a slot to become available, in seconds
+    pub database_pool_connection_timeout: Option<u32>,
+    pub fxa_metrics_hash_secret: String,
+
+    /// The email domain for users' FxA accounts. This should be set according to the
+    /// desired FxA environment (production or stage).
+    pub fxa_email_domain: String,
+
+    /// The URL of the FxA server used for verifying Tokenserver OAuth tokens.
+    pub fxa_oauth_server_url: Option<String>,
+}
+
+impl Default for Settings {
+    fn default() -> Settings {
+        Settings {
+            database_url: "mysql://root@127.0.0.1/tokenserver_rs".to_owned(),
+            database_pool_max_size: None,
+            database_pool_min_idle: None,
+            database_pool_connection_timeout: Some(30),
+            fxa_email_domain: "api.accounts.firefox.com".to_owned(),
+            fxa_metrics_hash_secret: "secret".to_owned(),
+            fxa_oauth_server_url: None,
+        }
+    }
+}

--- a/src/web/extractors.rs
+++ b/src/web/extractors.rs
@@ -1693,7 +1693,6 @@ mod tests {
     };
     use crate::server::{metrics, ServerState};
     use crate::settings::{Deadman, Secrets, ServerLimits, Settings};
-    use crate::tokenserver::MockOAuthVerifier;
 
     use crate::web::auth::{hkdf_expand_32, HawkPayload};
 
@@ -1722,9 +1721,7 @@ mod tests {
             limits: Arc::clone(&SERVER_LIMITS),
             limits_json: serde_json::to_string(&**SERVER_LIMITS).unwrap(),
             secrets: Arc::clone(&SECRETS),
-            tokenserver_database_url: None,
-            fxa_metrics_hash_secret: None,
-            tokenserver_oauth_verifier: Box::new(MockOAuthVerifier::default()),
+            tokenserver_state: None,
             port: 8000,
             metrics: Box::new(metrics::metrics_from_opts(&settings).unwrap()),
             quota_enabled: settings.enable_quota,


### PR DESCRIPTION
## Description

Adds mature infrastructure for a Tokenserver-specific MySQL database.

## How should reviewers test?
* Create an account on FxA stage: https://accounts.stage.mozaws.net/signup
* Set `identity.fxaccounts.remote.oauth.uri` to https://oauth.stage.mozaws.net
* Set `identity.fxaccounts.remote.root` to https://accounts.stage.mozaws.net
* Set `identity.fxaccounts.auth.uri` to https://api-accounts.stage.mozaws.net/v1
* Set `identity.fxaccounts.remote.profile.uri` to https://profile.stage.mozaws.net/v1
* Set `identity.sync.tokenserver.uri` to http://localhost:8000/1.0/sync/1.5
* Create a Tokenserver database:
```sql
CREATE DATABASE tokenserver_rs;
```
* Add a service and a node to your database:
```sql
INSERT INTO services (service) VALUES("sync-1.5");
INSERT INTO nodes (service, node, available, capacity) VALUES([service ID from previous step], "http://localhost:8000/", 100, 100);
```
* Set the following values in local.toml:
```toml
enable_tokenserver = true
tokenserver.database_url = "mysql://sample_user:sample_password@localhost/tokenserver_rs"
tokenserver.fxa_oauth_server_url = "https://oauth.stage.mozaws.net"
```
* Add `println!("{}", user_email)` to L47 in `src/tokenserver/handlers.rs`
* Start syncstorage via `make run`
* Restart Firefox, log in to sync, and attempt a sync
* Using the email address from the server logs, add a user to the database:
```sql
INSERT INTO users (service, email, generation, client_state, created_at, nodeid) VALUES([service ID from prior step], "[email address from logs]", 0, "yes", 1620924095, [node ID from prior step]);
```
* Remove the `println!` and recompile/restart the server
* Attempt a sync
* Ensure that the sync was successful via about:sync-log

## Issue(s)

Closes #1054 
