### PR TITLE
docs: Add Apache 2.0 license to prepare-spanner.sh

### DIFF
--- a/scripts/prepare-spanner.sh
+++ b/scripts/prepare-spanner.sh
@@ -1,5 +1,23 @@
 #!/bin/sh
 
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This file contains modifications of the original version.
+#
+
 sleep 5
 
 set -e


### PR DESCRIPTION
## Description

Adds an Apache 2.0 license to `prepare-spanner.sh`. The file from which `prepare-spanner.sh` was derived is here: https://github.com/cloudspannerecosystem/emulator-samples/blob/master/docker/start_emulator_with_instance_and_database.sh

## Testing
N/A

## Issue(s)
N/A
