### PR TITLE
removed send from async_trait for DbPool

### DIFF
--- a/src/db/mock.rs
+++ b/src/db/mock.rs
@@ -14,7 +14,7 @@ impl MockDbPool {
     }
 }
 
-#[async_trait(?Send)]
+#[async_trait]
 impl DbPool for MockDbPool {
     async fn get<'a>(&'a self) -> ApiResult<Box<dyn Db<'a>>> {
         Ok(Box::new(MockDb::new()) as Box<dyn Db<'a>>)

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -59,7 +59,7 @@ pub const BATCH_LIFETIME: i64 = 2 * 60 * 60 * 1000; // 2 hours, in milliseconds
 
 type DbFuture<'a, T> = LocalBoxFuture<'a, Result<T, ApiError>>;
 
-#[async_trait(?Send)]
+#[async_trait]
 pub trait DbPool: Sync + Send + Debug {
     async fn get(&self) -> ApiResult<Box<dyn Db<'_>>>;
 

--- a/src/db/mysql/pool.rs
+++ b/src/db/mysql/pool.rs
@@ -105,7 +105,7 @@ impl MysqlDbPool {
     }
 }
 
-#[async_trait(?Send)]
+#[async_trait]
 impl DbPool for MysqlDbPool {
     async fn get<'a>(&'a self) -> ApiResult<Box<dyn Db<'a>>> {
         let pool = self.clone();

--- a/src/db/spanner/pool.rs
+++ b/src/db/spanner/pool.rs
@@ -88,7 +88,7 @@ impl SpannerDbPool {
     }
 }
 
-#[async_trait(?Send)]
+#[async_trait]
 impl DbPool for SpannerDbPool {
     async fn get<'a>(&'a self) -> ApiResult<Box<dyn Db<'a>>> {
         let mut metrics = self.metrics.clone();


### PR DESCRIPTION
## Description

removed send from async_trait for DbPool so that send is required

## Testing

How should reviewers test?

## Issue(s)

Closes #1138.
