### PR TITLE
chore: update actix-http version due to RUSTSEC-2021-0081

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,9 +53,9 @@ dependencies = [
 
 [[package]]
 name = "actix-http"
-version = "2.2.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "452299e87817ae5673910e53c243484ca38be3828db819b6011736fc6982e874"
+checksum = "5cb8958da437716f3f31b0e76f8daf36554128517d7df37ceba7df00f09622ee"
 dependencies = [
  "actix-codec",
  "actix-connect",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ default-run = "syncstorage"
 debug = 1
 
 [dependencies]
-actix-http = "2"
+actix-http = "2.2.1"
 actix-web = "3"
 actix-web-httpauth = "0.5"
 actix-rt = "1"  # Pin to 1.0, due to dependencies on Tokio

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ default-run = "syncstorage"
 debug = 1
 
 [dependencies]
-actix-http = "2.2.1"
+actix-http = "2"
 actix-web = "3"
 actix-web-httpauth = "0.5"
 actix-rt = "1"  # Pin to 1.0, due to dependencies on Tokio


### PR DESCRIPTION
## Description
RUSTSEC-2021-0081 appeared due to current version of actix-http being 2.2.0. 

## Testing
RUSTSEC-2021-0081 should not be appearing in `cargo audit`

## Issue(s)

Closes [link](link).
