### PR TITLE
feat: Tokenserver: Implement extractors for generation, keys_changed_at, client_state

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ googleapis-raw = { version = "0", path = "vendor/mozilla-rust-sdk/googleapis-raw
 # `cargo build --features grpcio/openssl ...`
 grpcio = { version = "0.9" }
 lazy_static = "1.4.0"
-pyo3 = "0.14"
+pyo3 = { version = "0.14", features = ["auto-initialize"] }
 hawk = "3.2"
 hex = "0.4.3"
 hostname = "0.3.1"

--- a/src/tokenserver/error.rs
+++ b/src/tokenserver/error.rs
@@ -1,0 +1,181 @@
+use std::fmt;
+
+use actix_web::{error::ResponseError, http::StatusCode, HttpResponse};
+use serde::{
+    ser::{SerializeMap, Serializer},
+    Serialize,
+};
+
+#[derive(Debug)]
+pub struct TokenserverError {
+    status: &'static str,
+    location: ErrorLocation,
+    name: &'static str,
+    description: &'static str,
+    http_status: StatusCode,
+}
+
+impl TokenserverError {
+    pub fn invalid_generation() -> Self {
+        TokenserverError {
+            status: "invalid-generation",
+            location: ErrorLocation::Body,
+            name: "",
+            description: "Unauthorized",
+            http_status: StatusCode::UNAUTHORIZED,
+        }
+    }
+
+    pub fn invalid_keys_changed_at() -> Self {
+        TokenserverError {
+            status: "invalid-keysChangedAt",
+            location: ErrorLocation::Body,
+            name: "",
+            description: "Unauthorized",
+            http_status: StatusCode::UNAUTHORIZED,
+        }
+    }
+
+    pub fn invalid_key_id(description: &'static str) -> Self {
+        TokenserverError {
+            status: "invalid-key-id",
+            location: ErrorLocation::Header,
+            name: "",
+            description,
+            http_status: StatusCode::UNAUTHORIZED,
+        }
+    }
+
+    pub fn invalid_credentials(description: &'static str) -> Self {
+        Self {
+            status: "invalid-credentials",
+            location: ErrorLocation::Header,
+            name: "",
+            description,
+            http_status: StatusCode::UNAUTHORIZED,
+        }
+    }
+
+    pub fn invalid_client_state(description: &'static str) -> Self {
+        Self {
+            status: "invalid-client-state",
+            location: ErrorLocation::Header,
+            name: "",
+            description,
+            http_status: StatusCode::UNAUTHORIZED,
+        }
+    }
+
+    pub fn internal_error() -> Self {
+        Self {
+            status: "internal-error",
+            location: ErrorLocation::Internal,
+            name: "",
+            description: "Server error",
+            http_status: StatusCode::INTERNAL_SERVER_ERROR,
+        }
+    }
+
+    pub fn unsupported(description: &'static str) -> Self {
+        Self {
+            status: "error",
+            location: ErrorLocation::Url,
+            name: "",
+            description,
+            http_status: StatusCode::NOT_FOUND,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum ErrorLocation {
+    Header,
+    Url,
+    Body,
+    Internal,
+}
+
+impl fmt::Display for ErrorLocation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Header => write!(f, "header"),
+            Self::Url => write!(f, "url"),
+            Self::Body => write!(f, "body"),
+            Self::Internal => write!(f, "internal"),
+        }
+    }
+}
+
+impl fmt::Display for TokenserverError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", serde_json::to_string(&self).map_err(|_| fmt::Error)?)
+    }
+}
+
+impl ResponseError for TokenserverError {
+    fn error_response(&self) -> HttpResponse {
+        HttpResponse::build(self.http_status).json(ErrorResponse::from(self))
+    }
+
+    fn status_code(&self) -> StatusCode {
+        self.http_status
+    }
+}
+
+struct ErrorResponse {
+    status: &'static str,
+    errors: [ErrorInstance; 1],
+}
+
+struct ErrorInstance {
+    location: ErrorLocation,
+    name: &'static str,
+    description: &'static str,
+}
+
+impl From<&TokenserverError> for ErrorResponse {
+    fn from(error: &TokenserverError) -> Self {
+        ErrorResponse {
+            status: error.status,
+            errors: [ErrorInstance {
+                location: error.location,
+                name: error.name,
+                description: error.description,
+            }],
+        }
+    }
+}
+
+impl Serialize for ErrorInstance {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut map = serializer.serialize_map(Some(3))?;
+        map.serialize_entry("location", &self.location.to_string())?;
+        map.serialize_entry("name", &self.name)?;
+        map.serialize_entry("description", &self.description)?;
+        map.end()
+    }
+}
+
+impl Serialize for ErrorResponse {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut map = serializer.serialize_map(Some(2))?;
+        map.serialize_entry("status", &self.status)?;
+        map.serialize_entry("errors", &self.errors)?;
+        map.end()
+    }
+}
+
+impl Serialize for TokenserverError {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        ErrorResponse::from(self).serialize(serializer)
+    }
+}

--- a/src/tokenserver/error.rs
+++ b/src/tokenserver/error.rs
@@ -15,14 +15,24 @@ pub struct TokenserverError {
     http_status: StatusCode,
 }
 
+impl Default for TokenserverError {
+    fn default() -> Self {
+        Self {
+            status: "",
+            location: ErrorLocation::default(),
+            name: "",
+            description: "Unauthorized",
+            http_status: StatusCode::UNAUTHORIZED,
+        }
+    }
+}
+
 impl TokenserverError {
     pub fn invalid_generation() -> Self {
         TokenserverError {
             status: "invalid-generation",
             location: ErrorLocation::Body,
-            name: "",
-            description: "Unauthorized",
-            http_status: StatusCode::UNAUTHORIZED,
+            ..Self::default()
         }
     }
 
@@ -30,39 +40,31 @@ impl TokenserverError {
         TokenserverError {
             status: "invalid-keysChangedAt",
             location: ErrorLocation::Body,
-            name: "",
-            description: "Unauthorized",
-            http_status: StatusCode::UNAUTHORIZED,
+            ..Self::default()
         }
     }
 
     pub fn invalid_key_id(description: &'static str) -> Self {
         TokenserverError {
             status: "invalid-key-id",
-            location: ErrorLocation::Header,
-            name: "",
             description,
-            http_status: StatusCode::UNAUTHORIZED,
+            ..Self::default()
         }
     }
 
     pub fn invalid_credentials(description: &'static str) -> Self {
         Self {
             status: "invalid-credentials",
-            location: ErrorLocation::Header,
-            name: "",
             description,
-            http_status: StatusCode::UNAUTHORIZED,
+            ..Self::default()
         }
     }
 
     pub fn invalid_client_state(description: &'static str) -> Self {
         Self {
             status: "invalid-client-state",
-            location: ErrorLocation::Header,
-            name: "",
             description,
-            http_status: StatusCode::UNAUTHORIZED,
+            ..Self::default()
         }
     }
 
@@ -70,9 +72,9 @@ impl TokenserverError {
         Self {
             status: "internal-error",
             location: ErrorLocation::Internal,
-            name: "",
             description: "Server error",
             http_status: StatusCode::INTERNAL_SERVER_ERROR,
+            ..Self::default()
         }
     }
 
@@ -80,9 +82,9 @@ impl TokenserverError {
         Self {
             status: "error",
             location: ErrorLocation::Url,
-            name: "",
             description,
             http_status: StatusCode::NOT_FOUND,
+            ..Self::default()
         }
     }
 }
@@ -93,6 +95,12 @@ pub enum ErrorLocation {
     Url,
     Body,
     Internal,
+}
+
+impl Default for ErrorLocation {
+    fn default() -> Self {
+        Self::Header
+    }
 }
 
 impl fmt::Display for ErrorLocation {

--- a/src/tokenserver/error.rs
+++ b/src/tokenserver/error.rs
@@ -108,7 +108,11 @@ impl fmt::Display for ErrorLocation {
 
 impl fmt::Display for TokenserverError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", serde_json::to_string(&self).map_err(|_| fmt::Error)?)
+        write!(
+            f,
+            "{}",
+            serde_json::to_string(&self).map_err(|_| fmt::Error)?
+        )
     }
 }
 

--- a/src/tokenserver/extractors.rs
+++ b/src/tokenserver/extractors.rs
@@ -320,7 +320,7 @@ mod tests {
             fxa_uid: fxa_uid.to_owned(),
             generation: 1234,
             keys_changed_at: 1234,
-            client_state: "aaa".to_owned(),
+            client_state: "616161".to_owned(),
             shared_secret: "Ted Koppel is a robot".to_owned(),
             hashed_fxa_uid: "4d00ecae64b98dd7dc7dea68d0dd615d".to_owned(),
             hashed_device_id: "3a41cccbdd666ebc4199f1f9d1249d44".to_owned(),
@@ -588,7 +588,7 @@ mod tests {
         {
             let request = build_request()
                 .header("x-keyid", "0000000001234-YWFh")
-                .header("x-client-state", "bbb")
+                .header("x-client-state", "626262")
                 .to_http_request();
             let response: HttpResponse = KeyId::extract(&request).await.unwrap_err().into();
             assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
@@ -602,11 +602,11 @@ mod tests {
         {
             let request = build_request()
                 .header("x-keyid", "0000000001234-YWFh")
-                .header("x-client-state", "aaa")
+                .header("x-client-state", "616161")
                 .to_http_request();
             let key_id = KeyId::extract(&request).await.unwrap();
             let expected_key_id = KeyId {
-                client_state: "aaa".to_owned(),
+                client_state: "616161".to_owned(),
                 keys_changed_at: 1234,
             };
 
@@ -620,7 +620,7 @@ mod tests {
                 .to_http_request();
             let key_id = KeyId::extract(&request).await.unwrap();
             let expected_key_id = KeyId {
-                client_state: "aaa".to_owned(),
+                client_state: "616161".to_owned(),
                 keys_changed_at: 1234,
             };
 

--- a/src/tokenserver/extractors.rs
+++ b/src/tokenserver/extractors.rs
@@ -5,19 +5,26 @@
 
 use actix_web::{dev::Payload, web::Data, Error, FromRequest, HttpRequest};
 use actix_web_httpauth::extractors::bearer::BearerAuth;
-
 use futures::future::LocalBoxFuture;
+use hmac::{Hmac, Mac, NewMac};
+use sha2::Sha256;
 
-use super::db;
+use super::db::{self, models::Db, params, results};
+use super::error::TokenserverError;
 use super::support::TokenData;
 use crate::server::ServerState;
-use crate::web::error::ValidationErrorKind;
-use crate::web::extractors::RequestErrorLocation;
 
 /// Information from the request needed to process a Tokenserver request.
+#[derive(Debug, PartialEq)]
 pub struct TokenserverRequest {
+    pub user: results::GetUser,
     pub fxa_uid: String,
     pub generation: i64,
+    pub keys_changed_at: i64,
+    pub client_state: String,
+    pub shared_secret: String,
+    pub hashed_fxa_uid: String,
+    pub hashed_device_id: String,
     pub service_id: i32,
 }
 
@@ -26,38 +33,100 @@ impl FromRequest for TokenserverRequest {
     type Error = Error;
     type Future = LocalBoxFuture<'static, Result<Self, Self::Error>>;
 
-    fn from_request(req: &HttpRequest, payload: &mut Payload) -> Self::Future {
+    fn from_request(req: &HttpRequest, _payload: &mut Payload) -> Self::Future {
         let req = req.clone();
-        let mut payload = payload.take();
 
         Box::pin(async move {
-            let token_data = TokenData::from_request(&req, &mut payload).await?;
+            let token_data = TokenData::extract(&req).await?;
+            let state = get_server_state(&req)?;
+            let tokenserver_state = state.tokenserver_state.as_ref().unwrap();
+            let fxa_metrics_hash_secret = &tokenserver_state.fxa_metrics_hash_secret.as_bytes();
+            let shared_secret =
+                String::from_utf8(state.secrets.master_secret.clone()).map_err(|_| {
+                    error!("⚠️ Failed to read master secret");
+
+                    TokenserverError::internal_error()
+                })?;
+            let key_id = KeyId::extract(&req).await?;
+            let fxa_uid = token_data.user;
+            let hashed_fxa_uid = {
+                let hashed_fxa_uid_full = fxa_metrics_hash(&fxa_uid, fxa_metrics_hash_secret);
+                hashed_fxa_uid_full[0..32].to_owned()
+            };
+            let hashed_device_id = {
+                let device_id = "none".to_string();
+                hash_device_id(&hashed_fxa_uid, &device_id, fxa_metrics_hash_secret)
+            };
             let service_id = {
                 let path = req.match_info();
 
-                match (path.get("application"), path.get("version")) {
-                    (Some("sync"), Some("1.1")) => db::SYNC_1_1_SERVICE_ID,
-                    (Some("sync"), Some("1.5")) => db::SYNC_1_5_SERVICE_ID,
-                    // XXX: This error will be replaced with a more descriptive error as part of
-                    // #1133
-                    _ => {
-                        return Err(ValidationErrorKind::FromDetails(
-                            "Invalid application and version".to_owned(),
-                            RequestErrorLocation::Path,
-                            None,
-                            None,
+                // If we've reached this extractor, we know that the Tokenserver path was matched,
+                // meaning "application" and "version" are both present in the URL. So, we can use
+                // `unwrap()` here.
+                let application = path.get("application").unwrap();
+                let version = path.get("version").unwrap();
+
+                if application == "sync" {
+                    if version == "1.1" {
+                        db::SYNC_1_1_SERVICE_ID
+                    } else if version == "1.5" {
+                        db::SYNC_1_5_SERVICE_ID
+                    } else {
+                        return Err(TokenserverError::unsupported(
+                            "Unsupported application version",
                         )
-                        .into())
+                        .into());
                     }
+                } else {
+                    return Err(TokenserverError::unsupported("Unsupported application").into());
                 }
             };
-            let tokenserver_request = Self {
-                fxa_uid: token_data.user,
-                generation: token_data.generation,
+            let user = {
+                let db = tokenserver_state.db_pool.get().map_err(|_| {
+                    error!("⚠️ Could not acquire database connection");
+
+                    TokenserverError::internal_error()
+                })?;
+                let email = format!("{}@{}", fxa_uid, tokenserver_state.fxa_email_domain);
+
+                db.get_user(params::GetUser { email, service_id }).await?
+            };
+
+            let tokenserver_request = TokenserverRequest {
+                user,
+                fxa_uid,
+                generation: token_data.generation.unwrap_or(0),
+                keys_changed_at: key_id.keys_changed_at,
+                client_state: key_id.client_state,
+                shared_secret,
+                hashed_fxa_uid,
+                hashed_device_id,
                 service_id,
             };
 
             Ok(tokenserver_request)
+        })
+    }
+}
+
+impl FromRequest for Box<dyn Db> {
+    type Config = ();
+    type Error = Error;
+    type Future = LocalBoxFuture<'static, Result<Self, Self::Error>>;
+
+    fn from_request(req: &HttpRequest, _payload: &mut Payload) -> Self::Future {
+        let req = req.clone();
+
+        Box::pin(async move {
+            let state = get_server_state(&req)?;
+            let tokenserver_state = state.tokenserver_state.as_ref().unwrap();
+            let db = tokenserver_state.db_pool.get().map_err(|_| {
+                error!("⚠️ Could not acquire database connection");
+
+                TokenserverError::internal_error()
+            })?;
+
+            Ok(db)
         })
     }
 }
@@ -67,39 +136,135 @@ impl FromRequest for TokenData {
     type Error = Error;
     type Future = LocalBoxFuture<'static, Result<Self, Self::Error>>;
 
-    fn from_request(req: &HttpRequest, payload: &mut Payload) -> Self::Future {
+    fn from_request(req: &HttpRequest, _payload: &mut Payload) -> Self::Future {
         let req = req.clone();
-        let mut payload = payload.take();
 
         Box::pin(async move {
-            let auth = BearerAuth::from_request(&req, &mut payload).await?;
-            let state = match req.app_data::<Data<ServerState>>() {
-                Some(s) => s,
-                None => {
-                    error!("⚠️ Could not load the app state");
-                    return Err(ValidationErrorKind::FromDetails(
-                        "Internal error".to_owned(),
-                        RequestErrorLocation::Unknown,
-                        Some("state".to_owned()),
-                        None,
-                    )
-                    .into());
+            // The request must have a valid Authorization header
+            let authorization_header = req
+                .headers()
+                .get("Authorization")
+                .ok_or_else(|| TokenserverError::invalid_credentials("Unauthorized"))?
+                .to_str()
+                .map_err(|_| TokenserverError::invalid_credentials("Unauthorized"))?;
+    
+            // The request must use Bearer auth
+            if let Some((auth_type, _)) = authorization_header.split_once(" ") {
+                if auth_type.to_ascii_lowercase() != "bearer" {
+                    return Err(TokenserverError::invalid_credentials("Unsupported").into());
                 }
-            };
+            }
+
+            let auth = BearerAuth::extract(&req)
+                .await
+                .map_err(|_| TokenserverError::invalid_credentials("Unsupported"))?;
+            let state = get_server_state(&req)?;
+
             // XXX: tokenserver_state will no longer be an Option once the Tokenserver
             // code is rolled out, so we will eventually be able to remove this unwrap().
             let tokenserver_state = state.tokenserver_state.as_ref().unwrap();
-            tokenserver_state.oauth_verifier.verify_token(auth.token())
+            tokenserver_state
+                .oauth_verifier
+                .verify_token(auth.token())
+                .map_err(Into::into)
         })
     }
+}
+
+#[derive(Debug, PartialEq)]
+struct KeyId {
+    client_state: String,
+    keys_changed_at: i64,
+}
+
+impl FromRequest for KeyId {
+    type Config = ();
+    type Error = Error;
+    type Future = LocalBoxFuture<'static, Result<Self, Self::Error>>;
+
+    fn from_request(req: &HttpRequest, _payload: &mut Payload) -> Self::Future {
+        let req = req.clone();
+
+        Box::pin(async move {
+            let headers = req.headers();
+            let x_key_id = headers
+                .get("X-KeyId")
+                .ok_or_else(|| TokenserverError::invalid_key_id("Missing X-KeyID header"))?
+                .to_str()
+                .map_err(|_| TokenserverError::invalid_key_id("Invalid X-KeyID header"))?;
+
+            let (keys_changed_at_string, encoded_client_state) = x_key_id
+                .split_once("-")
+                .ok_or_else(|| TokenserverError::invalid_key_id("Invalid X-KeyID header"))?;
+
+            let client_state_bytes =
+                base64::decode_config(encoded_client_state, base64::URL_SAFE_NO_PAD)
+                    .map_err(|_| TokenserverError::invalid_key_id("Invalid base64 encoding"))?;
+
+            let client_state = String::from_utf8(client_state_bytes).map_err(|_| {
+                TokenserverError::invalid_client_state("Invalid client state bytes")
+            })?;
+
+            // If there's a client state value in the X-Client-State header, verify that it matches
+            // the value in X-KeyID.
+            let maybe_x_client_state = headers
+                .get("X-Client-State")
+                .and_then(|header| header.to_str().ok());
+            if let Some(x_client_state) = maybe_x_client_state {
+                if x_client_state != client_state {
+                    return Err(TokenserverError::invalid_client_state("Unauthorized").into());
+                }
+            }
+
+            let keys_changed_at = keys_changed_at_string
+                .parse::<i64>()
+                .map_err(|_| TokenserverError::invalid_credentials("invalid keysChangedAt"))?;
+
+            Ok(KeyId {
+                client_state,
+                keys_changed_at,
+            })
+        })
+    }
+}
+
+fn get_server_state(req: &HttpRequest) -> Result<&Data<ServerState>, Error> {
+    req.app_data::<Data<ServerState>>().ok_or_else(|| {
+        error!("⚠️ Could not load the app state");
+
+        TokenserverError::internal_error().into()
+    })
+}
+
+fn fxa_metrics_hash(fxa_uid: &str, hmac_key: &[u8]) -> String {
+    let mut mac = Hmac::<Sha256>::new_from_slice(hmac_key).expect("HMAC has no key size limit");
+    mac.update(fxa_uid.as_bytes());
+
+    let result = mac.finalize().into_bytes();
+    hex::encode(result)
+}
+
+fn hash_device_id(fxa_uid: &str, device: &str, hmac_key: &[u8]) -> String {
+    let mut to_hash = String::from(fxa_uid);
+    to_hash.push_str(device);
+    let fxa_metrics_hash = fxa_metrics_hash(&to_hash, hmac_key);
+
+    String::from(&fxa_metrics_hash[0..32])
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    use actix_web::{http::Method, test::TestRequest, HttpResponse};
+    use actix_web::{
+        dev::ServiceResponse,
+        http::{Method, StatusCode},
+        test::{self, TestRequest},
+        HttpResponse,
+    };
+    use futures::executor::block_on;
     use lazy_static::lazy_static;
+    use serde_json;
     use tokio::sync::RwLock;
 
     use crate::db::mock::MockDbPool;
@@ -121,14 +286,12 @@ mod tests {
     async fn test_valid_tokenserver_request() {
         let fxa_uid = "test123";
         let verifier = {
-            let start = SystemTime::now();
-            let current_time = start.duration_since(UNIX_EPOCH).unwrap();
             let token_data = TokenData {
                 user: fxa_uid.to_owned(),
                 client_id: "client id".to_owned(),
                 scope: vec!["scope".to_owned()],
-                generation: current_time.as_secs() as i64,
-                profile_changed_at: current_time.as_secs() as i64,
+                generation: Some(1234),
+                profile_changed_at: Some(1234),
             };
             let valid = true;
 
@@ -140,21 +303,33 @@ mod tests {
             .data(state)
             .header("authorization", "Bearer fake_token")
             .header("accept", "application/json,text/plain:q=0.5")
-            .method(Method::GET)
+            .header("x-keyid", "0000000001234-YWFh")
             .param("application", "sync")
             .param("version", "1.5")
+            .method(Method::GET)
             .to_http_request();
 
         let mut payload = Payload::None;
         let result = TokenserverRequest::from_request(&req, &mut payload)
             .await
             .unwrap();
+        let expected_tokenserver_request = TokenserverRequest {
+            user: results::GetUser::default(),
+            fxa_uid: fxa_uid.to_owned(),
+            generation: 1234,
+            keys_changed_at: 1234,
+            client_state: "aaa".to_owned(),
+            shared_secret: "Ted Koppel is a robot".to_owned(),
+            hashed_fxa_uid: "4d00ecae64b98dd7dc7dea68d0dd615d".to_owned(),
+            hashed_device_id: "3a41cccbdd666ebc4199f1f9d1249d44".to_owned(),
+            service_id: db::SYNC_1_5_SERVICE_ID,
+        };
 
-        assert_eq!(result.fxa_uid, fxa_uid);
+        assert_eq!(result, expected_tokenserver_request);
     }
 
     #[actix_rt::test]
-    async fn test_invalid_tokenserver_request() {
+    async fn test_invalid_auth_token() {
         let fxa_uid = "test123";
         let verifier = {
             let start = SystemTime::now();
@@ -163,8 +338,8 @@ mod tests {
                 user: fxa_uid.to_owned(),
                 client_id: "client id".to_owned(),
                 scope: vec!["scope".to_owned()],
-                generation: current_time.as_secs() as i64,
-                profile_changed_at: current_time.as_secs() as i64,
+                generation: Some(current_time.as_secs() as i64),
+                profile_changed_at: Some(current_time.as_secs() as i64),
             };
             let valid = false;
 
@@ -172,21 +347,287 @@ mod tests {
         };
         let state = make_state(verifier);
 
-        let req = TestRequest::default()
+        let request = TestRequest::default()
             .data(state)
             .header("authorization", "Bearer fake_token")
             .header("accept", "application/json,text/plain:q=0.5")
-            .method(Method::GET)
+            .header("x-keyid", "0000000001234-YWFh")
             .param("application", "sync")
             .param("version", "1.5")
+            .method(Method::GET)
             .to_http_request();
 
-        let mut payload = Payload::None;
-        let result = TokenserverRequest::from_request(&req, &mut payload).await;
-        assert!(result.is_err());
+        let response: HttpResponse = TokenserverRequest::extract(&request)
+            .await
+            .unwrap_err()
+            .into();
 
-        let response: HttpResponse = result.err().unwrap().into();
-        assert_eq!(response.status(), 400);
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+
+        let expected_error = TokenserverError::invalid_credentials("Unauthorized");
+        let body = extract_body_as_str(ServiceResponse::new(request, response));
+        assert_eq!(body, serde_json::to_string(&expected_error).unwrap());
+    }
+
+    #[actix_rt::test]
+    async fn test_application_and_version() {
+        fn build_request() -> TestRequest {
+            let fxa_uid = "test123";
+            let verifier = {
+                let start = SystemTime::now();
+                let current_time = start.duration_since(UNIX_EPOCH).unwrap();
+                let token_data = TokenData {
+                    user: fxa_uid.to_owned(),
+                    client_id: "client id".to_owned(),
+                    scope: vec!["scope".to_owned()],
+                    generation: Some(current_time.as_secs() as i64),
+                    profile_changed_at: Some(current_time.as_secs() as i64),
+                };
+                let valid = true;
+
+                MockOAuthVerifier { valid, token_data }
+            };
+
+            TestRequest::default()
+                .data(make_state(verifier))
+                .header("authorization", "Bearer fake_token")
+                .header("accept", "application/json,text/plain:q=0.5")
+                .header("x-keyid", "0000000001234-YWFh")
+                .method(Method::GET)
+        }
+
+        // Valid application and invalid version
+        {
+            let request = build_request()
+                .param("application", "sync")
+                .param("version", "1.0")
+                .to_http_request();
+
+            let response: HttpResponse = TokenserverRequest::extract(&request)
+                .await
+                .unwrap_err()
+                .into();
+
+            assert_eq!(response.status(), StatusCode::NOT_FOUND);
+
+            let expected_error = TokenserverError::unsupported("Unsupported application version");
+            let body = extract_body_as_str(ServiceResponse::new(request, response));
+            assert_eq!(body, serde_json::to_string(&expected_error).unwrap());
+        }
+
+        // Invalid application and valid version
+        {
+            let request = build_request()
+                .param("application", "push")
+                .param("version", "1.5")
+                .to_http_request();
+
+            let response: HttpResponse = TokenserverRequest::extract(&request)
+                .await
+                .unwrap_err()
+                .into();
+
+            assert_eq!(response.status(), StatusCode::NOT_FOUND);
+
+            let expected_error = TokenserverError::unsupported("Unsupported application");
+            let body = extract_body_as_str(ServiceResponse::new(request, response));
+            assert_eq!(body, serde_json::to_string(&expected_error).unwrap());
+        }
+
+        // Invalid application and invalid version
+        {
+            let request = build_request()
+                .param("application", "push")
+                .param("version", "1.0")
+                .to_http_request();
+
+            let response: HttpResponse = TokenserverRequest::extract(&request)
+                .await
+                .unwrap_err()
+                .into();
+
+            assert_eq!(response.status(), StatusCode::NOT_FOUND);
+
+            let expected_error = TokenserverError::unsupported("Unsupported application");
+            let body = extract_body_as_str(ServiceResponse::new(request, response));
+            assert_eq!(body, serde_json::to_string(&expected_error).unwrap());
+        }
+
+        // Valid application and valid version (1.5)
+        {
+            let request = build_request()
+                .param("application", "sync")
+                .param("version", "1.5")
+                .to_http_request();
+
+            let tokenserver_request = TokenserverRequest::extract(&request).await.unwrap();
+
+            assert_eq!(tokenserver_request.service_id, db::SYNC_1_5_SERVICE_ID);
+        }
+
+        // Valid application and valid version (1.1)
+        {
+            let request = build_request()
+                .param("application", "sync")
+                .param("version", "1.1")
+                .to_http_request();
+
+            let tokenserver_request = TokenserverRequest::extract(&request).await.unwrap();
+
+            assert_eq!(tokenserver_request.service_id, db::SYNC_1_1_SERVICE_ID);
+        }
+    }
+
+    #[actix_rt::test]
+    async fn test_key_id() {
+        fn build_request() -> TestRequest {
+            let fxa_uid = "test123";
+            let verifier = {
+                let start = SystemTime::now();
+                let current_time = start.duration_since(UNIX_EPOCH).unwrap();
+                let token_data = TokenData {
+                    user: fxa_uid.to_owned(),
+                    client_id: "client id".to_owned(),
+                    scope: vec!["scope".to_owned()],
+                    generation: Some(current_time.as_secs() as i64),
+                    profile_changed_at: Some(current_time.as_secs() as i64),
+                };
+                let valid = true;
+
+                MockOAuthVerifier { valid, token_data }
+            };
+
+            TestRequest::default()
+                .data(make_state(verifier))
+                .header("authorization", "Bearer fake_token")
+                .header("accept", "application/json,text/plain:q=0.5")
+                .param("application", "sync")
+                .param("version", "1.5")
+                .method(Method::GET)
+        }
+
+        // Request with no X-KeyID header
+        {
+            let request = build_request().to_http_request();
+            let response: HttpResponse = KeyId::extract(&request).await.unwrap_err().into();
+            assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+
+            let expected_error = TokenserverError::invalid_key_id("Missing X-KeyID header");
+            let body = extract_body_as_str(ServiceResponse::new(request, response));
+            assert_eq!(body, serde_json::to_string(&expected_error).unwrap());
+        }
+
+        // X-KeyID header with non-visible ASCII characters (\u{200B} is the zero-width space character)
+        {
+            let request = build_request()
+                .header("x-keyid", "\u{200B}")
+                .to_http_request();
+            let response: HttpResponse = KeyId::extract(&request).await.unwrap_err().into();
+            assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+
+            let expected_error = TokenserverError::invalid_key_id("Invalid X-KeyID header");
+            let body = extract_body_as_str(ServiceResponse::new(request, response));
+            assert_eq!(body, serde_json::to_string(&expected_error).unwrap());
+        }
+
+        // Improperly-formatted X-KeyID header
+        {
+            let request = build_request()
+                .header("x-keyid", "00000000")
+                .to_http_request();
+            let response: HttpResponse = KeyId::extract(&request).await.unwrap_err().into();
+            assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+
+            let expected_error = TokenserverError::invalid_key_id("Invalid X-KeyID header");
+            let body = extract_body_as_str(ServiceResponse::new(request, response));
+            assert_eq!(body, serde_json::to_string(&expected_error).unwrap());
+        }
+
+        // X-KeyID header with improperly-base64-encoded client state bytes
+        {
+            let request = build_request()
+                .header("x-keyid", "0000000001234-notbase64")
+                .to_http_request();
+            let response: HttpResponse = KeyId::extract(&request).await.unwrap_err().into();
+            assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+
+            let expected_error = TokenserverError::invalid_key_id("Invalid base64 encoding");
+            let body = extract_body_as_str(ServiceResponse::new(request, response));
+            assert_eq!(body, serde_json::to_string(&expected_error).unwrap());
+        }
+
+        // X-KeyID header with non-UTF-8 bytes
+        {
+            let request = build_request()
+                .header("x-keyid", &[0xFFu8, 0xFFu8, 0xFFu8, 0xFFu8][..])
+                .to_http_request();
+            let response: HttpResponse = KeyId::extract(&request).await.unwrap_err().into();
+            assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+
+            let expected_error = TokenserverError::invalid_key_id("Invalid X-KeyID header");
+            let body = extract_body_as_str(ServiceResponse::new(request, response));
+            assert_eq!(body, serde_json::to_string(&expected_error).unwrap());
+        }
+
+        // X-KeyID header with non-integral keys_changed_at
+        {
+            let request = build_request()
+                .header("x-keyid", "notanumber-YWFh")
+                .to_http_request();
+            let response: HttpResponse = KeyId::extract(&request).await.unwrap_err().into();
+            assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+
+            let expected_error = TokenserverError::invalid_credentials("invalid keysChangedAt");
+            let body = extract_body_as_str(ServiceResponse::new(request, response));
+            assert_eq!(body, serde_json::to_string(&expected_error).unwrap());
+        }
+
+        // X-KeyID header with client state that does not match that in the X-Client-State header
+        {
+            let request = build_request()
+                .header("x-keyid", "0000000001234-YWFh")
+                .header("x-client-state", "bbb")
+                .to_http_request();
+            let response: HttpResponse = KeyId::extract(&request).await.unwrap_err().into();
+            assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+
+            let expected_error = TokenserverError::invalid_client_state("Unauthorized");
+            let body = extract_body_as_str(ServiceResponse::new(request, response));
+            assert_eq!(body, serde_json::to_string(&expected_error).unwrap());
+        }
+
+        // Valid X-KeyID header with matching X-Client-State header
+        {
+            let request = build_request()
+                .header("x-keyid", "0000000001234-YWFh")
+                .header("x-client-state", "aaa")
+                .to_http_request();
+            let key_id = KeyId::extract(&request).await.unwrap();
+            let expected_key_id = KeyId {
+                client_state: "aaa".to_owned(),
+                keys_changed_at: 1234,
+            };
+
+            assert_eq!(key_id, expected_key_id);
+        }
+
+        // Valid X-KeyID header with no X-Client-State header
+        {
+            let request = build_request()
+                .header("x-keyid", "0000000001234-YWFh")
+                .to_http_request();
+            let key_id = KeyId::extract(&request).await.unwrap();
+            let expected_key_id = KeyId {
+                client_state: "aaa".to_owned(),
+                keys_changed_at: 1234,
+            };
+
+            assert_eq!(key_id, expected_key_id);
+        }
+    }
+
+    fn extract_body_as_str(sresponse: ServiceResponse) -> String {
+        String::from_utf8(block_on(test::read_body(sresponse)).to_vec()).unwrap()
     }
 
     fn make_state(verifier: MockOAuthVerifier) -> ServerState {

--- a/src/tokenserver/extractors.rs
+++ b/src/tokenserver/extractors.rs
@@ -147,7 +147,7 @@ impl FromRequest for TokenData {
                 .ok_or_else(|| TokenserverError::invalid_credentials("Unauthorized"))?
                 .to_str()
                 .map_err(|_| TokenserverError::invalid_credentials("Unauthorized"))?;
-    
+
             // The request must use Bearer auth
             if let Some((auth_type, _)) = authorization_header.split_once(" ") {
                 if auth_type.to_ascii_lowercase() != "bearer" {

--- a/src/tokenserver/mod.rs
+++ b/src/tokenserver/mod.rs
@@ -1,4 +1,5 @@
 pub mod db;
+pub mod error;
 pub mod extractors;
 pub mod handlers;
 pub mod settings;


### PR DESCRIPTION
## Description

* Implements a number of extractors to support adding validations in #866 
* Adds `TokenserverError` and `Serialize` `impl`s to support errors formatted the same as the errors on the legacy Tokenserver

## Testing
The unit tests cover the error cases pretty comprehensively, but to test end-to-end:
* Create an account on FxA stage: https://accounts.stage.mozaws.net/signup
* Set `identity.fxaccounts.remote.oauth.uri` to https://oauth.stage.mozaws.net
* Set `identity.fxaccounts.remote.root` to https://accounts.stage.mozaws.net
* Set `identity.fxaccounts.auth.uri` to https://api-accounts.stage.mozaws.net/v1
* Set `identity.fxaccounts.remote.profile.uri` to https://profile.stage.mozaws.net/v1
* Set `identity.sync.tokenserver.uri` to http://localhost:8000/1.0/sync/1.5
* Create a Tokenserver database:
```sql
CREATE DATABASE tokenserver_rs;
```
* Add a node to your database:
```sql
INSERT INTO nodes (service, node, available, capacity) VALUES(2, "http://localhost:8000/", 100, 100);
```
* Set the following values in local.toml:
```toml
enable_tokenserver = true
tokenserver.database_url = "mysql://sample_user:sample_password@localhost/tokenserver_rs"
tokenserver.fxa_oauth_server_url = "https://oauth.stage.mozaws.net"
```
* Add `println!("{}", email)` to L91 in `src/tokenserver/extractors.rs`
* Start syncstorage via `make run`
* Restart Firefox, log in to sync, and attempt a sync
* Using the email address from the server logs, add a user to the database:
```sql
INSERT INTO users (service, email, generation, client_state, created_at, nodeid) VALUES(2, "[email address from logs]", 0, "yes", 1620924095, [node ID from prior step]);
```
* Remove the `println!` and recompile/restart the server
* Attempt a sync
* Ensure that the sync was successful via about:sync-log

## Issue(s)

Closes #1133
