### PR TITLE
feat: Add test mode to Tokenserver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1523,6 +1523,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "7.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afabcc15e437a6484fc4f12d0fd63068fe457bf93f1c148d3d9649c60b103f32"
+dependencies = [
+ "base64 0.12.3",
+ "pem",
+ "ring",
+ "serde 1.0.126",
+ "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
 name = "kernel32-sys"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1788,6 +1802,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits 0.2.14",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1928,6 +1953,17 @@ name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
+name = "pem"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd56cbd21fea48d0c440b41cd69c589faacade08c992d9a54e471b79d0fd13eb"
+dependencies = [
+ "base64 0.13.0",
+ "once_cell",
+ "regex",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -2680,6 +2716,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "simple_asn1"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692ca13de57ce0613a363c8c2f1de925adebc81b04c923ac60c5488bb44abe4b"
+dependencies = [
+ "chrono",
+ "num-bigint",
+ "num-traits 0.2.14",
+]
+
+[[package]]
 name = "sized-chunks"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2929,6 +2976,7 @@ dependencies = [
  "hkdf",
  "hmac",
  "hostname",
+ "jsonwebtoken",
  "lazy_static",
  "log",
  "mime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,9 @@ validator = "0.14"
 validator_derive = "0.14"
 woothee = "0.11"
 
+[dev-dependencies]
+jsonwebtoken = "7.2.0"
+
 [features]
 no_auth = []
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -169,6 +169,7 @@ impl Settings {
         s.set_default("tokenserver.enabled", false)?;
         s.set_default("tokenserver.fxa_email_domain", "test.com")?;
         s.set_default("tokenserver.fxa_metrics_hash_secret", "secret")?;
+        s.set_default("tokenserver.test_mode_enabled", false)?;
 
         // Merge the config file if supplied
         if let Some(config_filename) = filename {

--- a/src/tokenserver/mod.rs
+++ b/src/tokenserver/mod.rs
@@ -5,7 +5,7 @@ pub mod handlers;
 pub mod settings;
 pub mod support;
 
-pub use self::support::{MockOAuthVerifier, OAuthVerifier, VerifyToken};
+pub use self::support::{MockOAuthVerifier, OAuthVerifier, TestModeOAuthVerifier, VerifyToken};
 
 use db::pool::{DbPool, TokenserverPool};
 use settings::Settings;
@@ -22,8 +22,20 @@ pub struct ServerState {
 
 impl ServerState {
     pub fn from_settings(settings: &Settings) -> Result<Self, ApiError> {
-        let oauth_verifier = OAuthVerifier {
-            fxa_oauth_server_url: settings.fxa_oauth_server_url.clone(),
+        let oauth_verifier: Box<dyn VerifyToken> = if settings.test_mode_enabled {
+            #[cfg(debug_assertions)]
+            let oauth_verifier = Box::new(TestModeOAuthVerifier);
+
+            #[cfg(not(debug_assertions))]
+            let oauth_verifier = Box::new(OAuthVerifier {
+                fxa_oauth_server_url: settings.fxa_oauth_server_url.clone(),
+            });
+
+            oauth_verifier
+        } else {
+            Box::new(OAuthVerifier {
+                fxa_oauth_server_url: settings.fxa_oauth_server_url.clone(),
+            })
         };
         let use_test_transactions = false;
 
@@ -31,7 +43,7 @@ impl ServerState {
             .map(|db_pool| ServerState {
                 fxa_email_domain: settings.fxa_email_domain.clone(),
                 fxa_metrics_hash_secret: settings.fxa_metrics_hash_secret.clone(),
-                oauth_verifier: Box::new(oauth_verifier),
+                oauth_verifier,
                 db_pool: Box::new(db_pool),
             })
             .map_err(Into::into)

--- a/src/tokenserver/settings.rs
+++ b/src/tokenserver/settings.rs
@@ -25,6 +25,9 @@ pub struct Settings {
 
     /// The URL of the FxA server used for verifying Tokenserver OAuth tokens.
     pub fxa_oauth_server_url: Option<String>,
+
+    /// When test mode is enabled, OAuth tokens are unpacked without being verified.
+    pub test_mode_enabled: bool,
 }
 
 impl Default for Settings {
@@ -38,6 +41,7 @@ impl Default for Settings {
             fxa_email_domain: "api.accounts.firefox.com".to_owned(),
             fxa_metrics_hash_secret: "secret".to_owned(),
             fxa_oauth_server_url: None,
+            test_mode_enabled: false,
         }
     }
 }


### PR DESCRIPTION
## Description

Adds a "test mode" to Tokenserver, which extracts information from JWT OAuth tokens without cryptographically verifying them.

## Testing

* Uncomment lines 143-146 in [src/server/mod.rs](https://github.com/mozilla-services/syncstorage-rs/blob/e6e2bbda3bde8f125729f237be27392835ce22c5/src/server/mod.rs#L143)
* Add `println!("{:?}", token_data);` to line 41 of [src/tokenserver/extractors.rs](https://github.com/mozilla-services/syncstorage-rs/blob/e6e2bbda3bde8f125729f237be27392835ce22c5/src/tokenserver/extractors.rs#L41)
* Add `tokenserver.test_mode_enabled = true` to `local.toml`
* Run the server with `make run`
* Send a request with a Tokenserver OAuth token (e.g. using HTTPie, `http GET localhost:8000/1.0/sync/1.5 'Authorization:Bearer <your token here>'`)
* Verify that the data extracted from the token was printed to the console
* Run the server using `RUST_LOG=debug RUST_BACKTRACE=full cargo run --release -- --config config/local.toml` (note the `--release` flag)
* Send a request with a Tokenserver OAuth token (e.g. using HTTPie, `http GET localhost:8000/1.0/sync/1.5 'Authorization:Bearer <your token here>'`)
* Ensure that a 401 error is returned (test mode should not be active even though `test_mode_enabled` is set to true, since the server was run in release mode)

## Issue(s)

Closes #1142 