### PR TITLE
feat: Tokenserver: Add support for client-specified token duration

### DIFF
--- a/src/tokenserver/extractors.rs
+++ b/src/tokenserver/extractors.rs
@@ -104,7 +104,7 @@ impl FromRequest for TokenserverRequest {
 
                 // An error in the "duration" query parameter should never cause a request to fail.
                 // Instead, we should simply resort to using the default token duration.
-                params.duration.clone().and_then(|duration_string| {
+                params.duration.as_ref().and_then(|duration_string| {
                     match duration_string.parse::<u64>() {
                         // The specified token duration should never be greater than the default
                         // token duration set on the server.

--- a/src/tokenserver/handlers.rs
+++ b/src/tokenserver/handlers.rs
@@ -17,15 +17,13 @@ use crate::{
     server::ServerState,
 };
 
-const DEFAULT_TOKEN_DURATION: u64 = 5 * 60;
-
 #[derive(Debug, Serialize)]
 pub struct TokenserverResult {
     id: String,
     key: String,
     uid: String,
     api_endpoint: String,
-    duration: String,
+    duration: u64,
 }
 
 pub async fn get_tokenserver_result(
@@ -88,7 +86,7 @@ pub async fn get_tokenserver_result(
             let expires = {
                 let start = SystemTime::now();
                 let current_time = start.duration_since(UNIX_EPOCH).unwrap();
-                let expires = current_time + Duration::new(DEFAULT_TOKEN_DURATION, 0);
+                let expires = current_time + Duration::new(tokenserver_request.duration, 0);
 
                 expires.as_secs()
             };
@@ -114,7 +112,7 @@ pub async fn get_tokenserver_result(
         key: derived_secret,
         uid: tokenserver_request.fxa_uid,
         api_endpoint,
-        duration: DEFAULT_TOKEN_DURATION.to_string(),
+        duration: tokenserver_request.duration,
     };
 
     Ok(HttpResponse::build(StatusCode::OK).json(result))


### PR DESCRIPTION
## Description

Setting the `duration` query parameter adjusts the expiry time of the token returned by Tokenserver. If the query parameter cannot be parsed or if the query parameter is greater than the default token duration set on the server, the default token duration is used instead.

## Testing

This can be tested by sending requests to Tokenserver using HTTPie like so:
```bash
http GET localhost:8000/1.0/sync/1.5 'Authorization:Bearer <insert JWT here>' 'X-KeyID:<insert kid here>' duration==100
```
You can inspect the 'duration' field of the JSON returned by the endpoint to ensure its value matches your expectations.

## Issue(s)

Closes #1050 
