### PR TITLE
feat: Tokenserver: Add node assignment logic

### DIFF
--- a/src/db/error.rs
+++ b/src/db/error.rs
@@ -94,6 +94,8 @@ impl From<DbErrorKind> for DbError {
             //  * android bug: https://bugzilla.mozilla.org/show_bug.cgi?id=959032
             DbErrorKind::Conflict => StatusCode::SERVICE_UNAVAILABLE,
             DbErrorKind::Quota => StatusCode::FORBIDDEN,
+            // NOTE: TokenserverUserRetired is an internal service error for compatibility reasons
+            // (the legacy Tokenserver returned an internal service error in this situation)
             _ => StatusCode::INTERNAL_SERVER_ERROR,
         };
 

--- a/src/db/error.rs
+++ b/src/db/error.rs
@@ -38,8 +38,8 @@ pub enum DbErrorKind {
     #[error("Specified batch does not exist")]
     BatchNotFound,
 
-    #[error("Tokenserver user not found")]
-    TokenserverUserNotFound,
+    #[error("Tokenserver user retired")]
+    TokenserverUserRetired,
 
     #[error("An attempt at a conflicting write")]
     Conflict,
@@ -84,9 +84,7 @@ impl DbError {
 impl From<DbErrorKind> for DbError {
     fn from(kind: DbErrorKind) -> Self {
         let status = match kind {
-            DbErrorKind::TokenserverUserNotFound
-            | DbErrorKind::CollectionNotFound
-            | DbErrorKind::BsoNotFound => StatusCode::NOT_FOUND,
+            DbErrorKind::CollectionNotFound | DbErrorKind::BsoNotFound => StatusCode::NOT_FOUND,
             // Matching the Python code here (a 400 vs 404)
             DbErrorKind::BatchNotFound | DbErrorKind::SpannerTooLarge(_) => StatusCode::BAD_REQUEST,
             // NOTE: the protocol specification states that we should return a

--- a/src/tokenserver/db/mock.rs
+++ b/src/tokenserver/db/mock.rs
@@ -37,8 +37,8 @@ impl MockDb {
 }
 
 impl Db for MockDb {
-    fn get_user(&self, _params: params::GetUser) -> DbFuture<'_, results::GetUser> {
-        Box::pin(future::ok(results::GetUser::default()))
+    fn replace_user(&self, _params: params::ReplaceUser) -> DbFuture<'_, results::ReplaceUser> {
+        Box::pin(future::ok(()))
     }
 
     fn replace_users(&self, _params: params::ReplaceUsers) -> DbFuture<'_, results::ReplaceUsers> {
@@ -47,6 +47,10 @@ impl Db for MockDb {
 
     fn post_user(&self, _params: params::PostUser) -> DbFuture<'_, results::PostUser> {
         Box::pin(future::ok(results::PostUser::default()))
+    }
+
+    fn allocate_user(&self, _params: params::AllocateUser) -> DbFuture<'_, results::AllocateUser> {
+        Box::pin(future::ok(results::AllocateUser::default()))
     }
 
     fn put_user(&self, _params: params::PutUser) -> DbFuture<'_, results::PutUser> {
@@ -61,12 +65,43 @@ impl Db for MockDb {
         Box::pin(future::ok(results::GetNodeId::default()))
     }
 
+    fn get_best_node(&self, _params: params::GetBestNode) -> DbFuture<'_, results::GetBestNode> {
+        Box::pin(future::ok(results::GetBestNode::default()))
+    }
+
+    fn add_user_to_node(
+        &self,
+        _params: params::AddUserToNode,
+    ) -> DbFuture<'_, results::AddUserToNode> {
+        Box::pin(future::ok(()))
+    }
+
+    fn get_or_create_user(
+        &self,
+        _params: params::GetOrCreateUser,
+    ) -> DbFuture<'_, results::GetOrCreateUser> {
+        Box::pin(future::ok(results::GetOrCreateUser::default()))
+    }
+
     #[cfg(test)]
     fn set_user_created_at(
         &self,
         _params: params::SetUserCreatedAt,
     ) -> DbFuture<'_, results::SetUserCreatedAt> {
         Box::pin(future::ok(()))
+    }
+
+    #[cfg(test)]
+    fn set_user_replaced_at(
+        &self,
+        _params: params::SetUserReplacedAt,
+    ) -> DbFuture<'_, results::SetUserReplacedAt> {
+        Box::pin(future::ok(()))
+    }
+
+    #[cfg(test)]
+    fn get_user(&self, _params: params::GetUser) -> DbFuture<'_, results::GetUser> {
+        Box::pin(future::ok(results::GetUser::default()))
     }
 
     #[cfg(test)]
@@ -77,6 +112,21 @@ impl Db for MockDb {
     #[cfg(test)]
     fn post_node(&self, _params: params::PostNode) -> DbFuture<'_, results::PostNode> {
         Box::pin(future::ok(results::PostNode::default()))
+    }
+
+    #[cfg(test)]
+    fn get_node(&self, _params: params::GetNode) -> DbFuture<'_, results::GetNode> {
+        Box::pin(future::ok(results::GetNode::default()))
+    }
+
+    #[cfg(test)]
+    fn unassign_node(&self, _params: params::UnassignNode) -> DbFuture<'_, results::UnassignNode> {
+        Box::pin(future::ok(()))
+    }
+
+    #[cfg(test)]
+    fn remove_node(&self, _params: params::RemoveNode) -> DbFuture<'_, results::RemoveNode> {
+        Box::pin(future::ok(()))
     }
 
     #[cfg(test)]

--- a/src/tokenserver/db/params.rs
+++ b/src/tokenserver/db/params.rs
@@ -1,11 +1,5 @@
 //! Parameter types for database methods.
 
-#[derive(Default)]
-pub struct GetUser {
-    pub email: String,
-    pub service_id: i32,
-}
-
 #[derive(Clone, Default)]
 pub struct PostNode {
     pub service_id: i32,
@@ -17,11 +11,28 @@ pub struct PostNode {
     pub backoff: i32,
 }
 
+#[derive(Clone, Default)]
+pub struct GetNode {
+    pub id: i64,
+}
+
 #[derive(Default)]
 pub struct PostService {
     pub service: String,
     pub pattern: String,
 }
+
+#[derive(Clone, Default)]
+pub struct GetOrCreateUser {
+    pub service_id: i32,
+    pub email: String,
+    pub generation: i64,
+    pub client_state: String,
+    pub keys_changed_at: Option<i64>,
+    pub capacity_release_rate: Option<f32>,
+}
+
+pub type AllocateUser = GetOrCreateUser;
 
 #[derive(Clone, Default)]
 pub struct PostUser {
@@ -30,7 +41,6 @@ pub struct PostUser {
     pub generation: i64,
     pub client_state: String,
     pub created_at: i64,
-    pub replaced_at: Option<i64>,
     pub node_id: i64,
     pub keys_changed_at: Option<i64>,
 }
@@ -65,6 +75,18 @@ pub struct GetNodeId {
     pub node: String,
 }
 
+#[derive(Default)]
+pub struct GetBestNode {
+    pub service_id: i32,
+    pub capacity_release_rate: Option<f32>,
+}
+
+#[derive(Default)]
+pub struct AddUserToNode {
+    pub service_id: i32,
+    pub node: String,
+}
+
 #[cfg(test)]
 pub type GetRawUsers = String;
 
@@ -72,4 +94,26 @@ pub type GetRawUsers = String;
 pub struct SetUserCreatedAt {
     pub uid: i64,
     pub created_at: i64,
+}
+
+#[cfg(test)]
+pub struct SetUserReplacedAt {
+    pub uid: i64,
+    pub replaced_at: i64,
+}
+
+#[cfg(test)]
+#[derive(Default)]
+pub struct GetUser {
+    pub id: i64,
+}
+
+#[cfg(test)]
+pub struct UnassignNode {
+    pub node_id: i64,
+}
+
+#[cfg(test)]
+pub struct RemoveNode {
+    pub node_id: i64,
 }

--- a/src/tokenserver/db/results.rs
+++ b/src/tokenserver/db/results.rs
@@ -16,8 +16,8 @@ pub struct GetRawUser {
     pub client_state: String,
     #[sql_type = "Bigint"]
     pub generation: i64,
-    #[sql_type = "Text"]
-    pub node: String,
+    #[sql_type = "Nullable<Text>"]
+    pub node: Option<String>,
     #[sql_type = "Nullable<Bigint>"]
     pub keys_changed_at: Option<i64>,
     #[sql_type = "Bigint"]
@@ -26,35 +26,27 @@ pub struct GetRawUser {
     pub replaced_at: Option<i64>,
 }
 
-#[cfg(test)]
-pub type GetRawUsers = Vec<GetRawUser>;
+#[derive(Debug, Default, PartialEq)]
+pub struct AllocateUser {
+    pub uid: i64,
+    pub node: String,
+    pub created_at: i64,
+}
 
 /// Represents the relevant information from the most recently-created user record in the database
 /// for a given email and service ID, along with any previously-seen client states seen for the
 /// user.
 #[derive(Debug, Default, PartialEq)]
-pub struct GetUser {
+pub struct GetOrCreateUser {
     pub uid: i64,
+    pub email: String,
     pub client_state: String,
     pub generation: i64,
     pub node: String,
     pub keys_changed_at: Option<i64>,
     pub created_at: i64,
+    pub replaced_at: Option<i64>,
     pub old_client_states: Vec<String>,
-}
-
-#[cfg(test)]
-#[derive(Default, QueryableByName)]
-pub struct PostNode {
-    #[sql_type = "Bigint"]
-    pub id: i64,
-}
-
-#[cfg(test)]
-#[derive(Default, QueryableByName)]
-pub struct PostService {
-    #[sql_type = "Integer"]
-    pub id: i32,
 }
 
 #[derive(Default, QueryableByName)]
@@ -73,10 +65,89 @@ pub struct GetNodeId {
     pub id: i64,
 }
 
+#[derive(Default, QueryableByName)]
+pub struct GetBestNode {
+    #[sql_type = "Bigint"]
+    pub id: i64,
+    #[sql_type = "Text"]
+    pub node: String,
+}
+
+pub type AddUserToNode = ();
+
+#[cfg(test)]
+pub type GetRawUsers = Vec<GetRawUser>;
+
+#[cfg(test)]
+#[derive(Debug, Default, PartialEq, QueryableByName)]
+pub struct GetUser {
+    #[sql_type = "Integer"]
+    #[column_name = "service"]
+    pub service_id: i32,
+    #[sql_type = "Text"]
+    pub email: String,
+    #[sql_type = "Bigint"]
+    pub generation: i64,
+    #[sql_type = "Text"]
+    pub client_state: String,
+    #[sql_type = "Nullable<Bigint>"]
+    pub replaced_at: Option<i64>,
+    #[sql_type = "Bigint"]
+    #[column_name = "nodeid"]
+    pub node_id: i64,
+    #[sql_type = "Nullable<Bigint>"]
+    pub keys_changed_at: Option<i64>,
+}
+
+#[cfg(test)]
+#[derive(Default, QueryableByName)]
+pub struct PostNode {
+    #[sql_type = "Bigint"]
+    pub id: i64,
+}
+
+#[cfg(test)]
+#[derive(Default, QueryableByName)]
+pub struct GetNode {
+    #[sql_type = "Bigint"]
+    pub id: i64,
+    #[sql_type = "Integer"]
+    #[column_name = "service"]
+    pub service_id: i32,
+    #[sql_type = "Text"]
+    pub node: String,
+    #[sql_type = "Integer"]
+    pub available: i32,
+    #[sql_type = "Integer"]
+    pub current_load: i32,
+    #[sql_type = "Integer"]
+    pub capacity: i32,
+    #[sql_type = "Integer"]
+    pub downed: i32,
+    #[sql_type = "Integer"]
+    pub backoff: i32,
+}
+
+#[cfg(test)]
+#[derive(Default, QueryableByName)]
+pub struct PostService {
+    #[sql_type = "Integer"]
+    pub id: i32,
+}
+
 #[cfg(test)]
 pub type SetUserCreatedAt = ();
+
+#[cfg(test)]
+pub type SetUserReplacedAt = ();
 
 #[cfg(test)]
 pub type GetUsers = Vec<GetUser>;
 
 pub type Check = bool;
+
+#[cfg(test)]
+pub type UnassignNode = ();
+
+#[cfg(test)]
+pub type RemoveNode = ();

--- a/src/tokenserver/error.rs
+++ b/src/tokenserver/error.rs
@@ -8,17 +8,17 @@ use serde::{
 
 #[derive(Debug, PartialEq)]
 pub struct TokenserverError {
-    status: &'static str,
-    location: ErrorLocation,
-    name: String,
-    description: &'static str,
-    http_status: StatusCode,
+    pub status: &'static str,
+    pub location: ErrorLocation,
+    pub name: String,
+    pub description: &'static str,
+    pub http_status: StatusCode,
 }
 
 impl Default for TokenserverError {
     fn default() -> Self {
         Self {
-            status: "",
+            status: "error",
             location: ErrorLocation::default(),
             name: "".to_owned(),
             description: "Unauthorized",
@@ -55,6 +55,7 @@ impl TokenserverError {
     pub fn invalid_credentials(description: &'static str) -> Self {
         Self {
             status: "invalid-credentials",
+            location: ErrorLocation::Body,
             description,
             ..Self::default()
         }
@@ -63,7 +64,6 @@ impl TokenserverError {
     pub fn invalid_client_state(description: &'static str) -> Self {
         Self {
             status: "invalid-client-state",
-            location: ErrorLocation::Body,
             description,
             name: "X-Client-State".to_owned(),
             ..Self::default()
@@ -92,7 +92,7 @@ impl TokenserverError {
 
     pub fn unauthorized(description: &'static str) -> Self {
         Self {
-            status: "error",
+            location: ErrorLocation::Body,
             description,
             ..Self::default()
         }

--- a/src/tokenserver/handlers.rs
+++ b/src/tokenserver/handlers.rs
@@ -55,8 +55,11 @@ fn get_token_plaintext(
     let fxa_kid = {
         // If decoding the hex bytes fails, it means we did something wrong when we stored the
         // client state in the database
-        let client_state = hex::decode(req.client_state.clone())
-            .map_err(|_| TokenserverError::internal_error())?;
+        let client_state = hex::decode(req.client_state.clone()).map_err(|_| {
+            error!("⚠️ Failed to decode client state hex");
+
+            TokenserverError::internal_error()
+        })?;
         let client_state_b64 = base64::encode_config(&client_state, base64::URL_SAFE_NO_PAD);
 
         format!("{:013}-{:}", updates.keys_changed_at, client_state_b64)

--- a/src/tokenserver/handlers.rs
+++ b/src/tokenserver/handlers.rs
@@ -10,6 +10,7 @@ use serde_json::Value;
 
 use super::db::models::Db;
 use super::db::params::{GetNodeId, PostUser, PutUser, ReplaceUsers};
+use super::error::TokenserverError;
 use super::extractors::TokenserverRequest;
 use super::support::Tokenlib;
 use crate::tokenserver::support::MakeTokenPlaintext;
@@ -31,7 +32,7 @@ pub async fn get_tokenserver_result(
     let updates = update_user(&req, db).await?;
 
     let (token, derived_secret) = {
-        let token_plaintext = get_token_plaintext(&req, &updates);
+        let token_plaintext = get_token_plaintext(&req, &updates)?;
         Tokenlib::get_token_and_derived_secret(token_plaintext, &req.shared_secret)?
     };
 
@@ -47,9 +48,16 @@ pub async fn get_tokenserver_result(
     Ok(HttpResponse::build(StatusCode::OK).json(result))
 }
 
-fn get_token_plaintext(req: &TokenserverRequest, updates: &UserUpdates) -> MakeTokenPlaintext {
+fn get_token_plaintext(
+    req: &TokenserverRequest,
+    updates: &UserUpdates,
+) -> Result<MakeTokenPlaintext, TokenserverError> {
     let fxa_kid = {
-        let client_state_b64 = base64::encode_config(&req.client_state, base64::URL_SAFE_NO_PAD);
+        // If decoding the hex bytes fails, it means we did something wrong when we stored the
+        // client state in the database
+        let client_state = hex::decode(req.client_state.clone())
+            .map_err(|_| TokenserverError::internal_error())?;
+        let client_state_b64 = base64::encode_config(&client_state, base64::URL_SAFE_NO_PAD);
 
         format!("{:013}-{:}", updates.keys_changed_at, client_state_b64)
     };
@@ -62,7 +70,7 @@ fn get_token_plaintext(req: &TokenserverRequest, updates: &UserUpdates) -> MakeT
         expires.as_secs()
     };
 
-    MakeTokenPlaintext {
+    Ok(MakeTokenPlaintext {
         node: req.user.node.to_owned(),
         fxa_kid,
         fxa_uid: req.fxa_uid.clone(),
@@ -70,7 +78,7 @@ fn get_token_plaintext(req: &TokenserverRequest, updates: &UserUpdates) -> MakeT
         hashed_fxa_uid: req.hashed_fxa_uid.clone(),
         expires,
         uid: updates.uid.to_owned(),
-    }
+    })
 }
 
 struct UserUpdates {
@@ -115,7 +123,6 @@ async fn update_user(req: &TokenserverRequest, db: Box<dyn Db>) -> Result<UserUp
             email: req.email.clone(),
             generation,
             client_state: req.client_state.clone(),
-            replaced_at: None,
             node_id: db
                 .get_node_id(GetNodeId {
                     service_id: req.service_id,

--- a/src/tokenserver/mod.rs
+++ b/src/tokenserver/mod.rs
@@ -18,6 +18,7 @@ pub struct ServerState {
     pub fxa_email_domain: String,
     pub fxa_metrics_hash_secret: String,
     pub oauth_verifier: Box<dyn VerifyToken>,
+    pub node_capacity_release_rate: Option<f32>,
 }
 
 impl ServerState {
@@ -45,6 +46,7 @@ impl ServerState {
                 fxa_metrics_hash_secret: settings.fxa_metrics_hash_secret.clone(),
                 oauth_verifier,
                 db_pool: Box::new(db_pool),
+                node_capacity_release_rate: settings.node_capacity_release_rate,
             })
             .map_err(Into::into)
     }

--- a/src/tokenserver/settings.rs
+++ b/src/tokenserver/settings.rs
@@ -28,6 +28,9 @@ pub struct Settings {
 
     /// When test mode is enabled, OAuth tokens are unpacked without being verified.
     pub test_mode_enabled: bool,
+
+    /// The rate at which capacity should be released from nodes that are at capacity.
+    pub node_capacity_release_rate: Option<f32>,
 }
 
 impl Default for Settings {
@@ -42,6 +45,7 @@ impl Default for Settings {
             fxa_metrics_hash_secret: "secret".to_owned(),
             fxa_oauth_server_url: None,
             test_mode_enabled: false,
+            node_capacity_release_rate: None,
         }
     }
 }

--- a/tools/integration_tests/tokenserver/test_misc.py
+++ b/tools/integration_tests/tokenserver/test_misc.py
@@ -183,7 +183,7 @@ class TestMisc(TestCase, unittest.TestCase):
             'X-KeyID': '1234-YWFh'
         }
         # Retired users cannot make requests with a generation smaller than
-        # max generation
+        # the max generation
         res = self.app.get('/1.0/sync/1.5', headers=headers, status=401)
         expected_error_response = {
             "status": "invalid-generation",

--- a/tools/integration_tests/tokenserver/test_misc.py
+++ b/tools/integration_tests/tokenserver/test_misc.py
@@ -5,6 +5,8 @@ import unittest
 
 from tokenserver.test_support import TestCase
 
+MAX_GENERATION = 9223372036854775807
+
 
 class TestMisc(TestCase, unittest.TestCase):
     def setUp(self):
@@ -171,3 +173,72 @@ class TestMisc(TestCase, unittest.TestCase):
         user = self._get_user(uid)
         self.assertEqual(user['generation'], 1235)
         self.assertEqual(user['keys_changed_at'], 1235)
+
+    def test_retired_users_can_make_requests(self):
+        # Add a retired user to the database
+        self._add_user(generation=MAX_GENERATION)
+        oauth_token = self._forge_oauth_token(generation=1234)
+        headers = {
+            'Authorization': 'Bearer %s' % oauth_token,
+            'X-KeyID': '1234-YWFh'
+        }
+        # Retired users cannot make requests with a generation smaller than
+        # max generation
+        res = self.app.get('/1.0/sync/1.5', headers=headers, status=401)
+        expected_error_response = {
+            "status": "invalid-generation",
+            "errors": [
+                {
+                    "location": "body",
+                    "name": "",
+                    "description": "Unauthorized"
+                }
+            ]
+        }
+        self.assertEqual(res.json, expected_error_response)
+        # Retired users can make requests with a generation number equal to
+        # the max generation
+        oauth_token = self._forge_oauth_token(generation=MAX_GENERATION)
+        headers['Authorization'] = 'Bearer %s' % oauth_token
+        self.app.get('/1.0/sync/1.5', headers=headers)
+
+    def test_replaced_users_can_make_requests(self):
+        # Add a replaced user to the database
+        self._add_user(generation=1234, created_at=1234, replaced_at=1234)
+        oauth_token = self._forge_oauth_token(generation=1234)
+        headers = {
+            'Authorization': 'Bearer %s' % oauth_token,
+            'X-KeyID': '1234-YWFh'
+        }
+        # Replaced users can make requests
+        self.app.get('/1.0/sync/1.5', headers=headers)
+
+    def test_retired_users_with_no_node_cannot_make_requests(self):
+        # Add a retired user to the database
+        invalid_node_id = self.NODE_ID + 1
+        self._add_user(generation=MAX_GENERATION, nodeid=invalid_node_id)
+        oauth_token = self._forge_oauth_token(generation=1234)
+        headers = {
+            'Authorization': 'Bearer %s' % oauth_token,
+            'X-KeyID': '1234-YWFh'
+        }
+        # Retired users without a node cannot make requests
+        oauth_token = self._forge_oauth_token(generation=MAX_GENERATION)
+        headers['Authorization'] = 'Bearer %s' % oauth_token
+        self.app.get('/1.0/sync/1.5', headers=headers, status=500)
+
+    def test_replaced_users_with_no_node_can_make_requests(self):
+        # Add a replaced user to the database
+        invalid_node_id = self.NODE_ID + 1
+        self._add_user(created_at=1234, replaced_at=1234,
+                       nodeid=invalid_node_id)
+        oauth_token = self._forge_oauth_token(generation=1234)
+        headers = {
+            'Authorization': 'Bearer %s' % oauth_token,
+            'X-KeyID': '1234-YWFh'
+        }
+        # Replaced users without a node can make requests
+        res = self.app.get('/1.0/sync/1.5', headers=headers)
+        user = self._get_user(res.json['uid'])
+        # The user is assigned to a new node
+        self.assertEqual(user['nodeid'], self.NODE_ID)


### PR DESCRIPTION
## Description

Adds the logic used to create users and assign them to the correct nodes.

## Testing

I added integration and unit tests that provide comprehensive coverage, but the following cases are the important ones:

- Users are always allocated to the least-loaded node
- When a user is allocated to a node, `available` and `current_load` are adjusted accordingly
- When no nodes have capacity, Tokenserver attempts to release capacity on nodes where `available` is zero but `current_load` is less than `capacity`

## Issue(s)

Closes #1051
