### PR TITLE
feat: Add ability to disable syncstorage endpoints

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -47,7 +47,13 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     // Setup and run the server
     let banner = settings.banner();
-    let server = server::Server::with_settings(settings).await.unwrap();
+    let server = if settings.disable_syncstorage {
+        server::Server::tokenserver_only_with_settings(settings)
+            .await
+            .unwrap()
+    } else {
+        server::Server::with_settings(settings).await.unwrap()
+    };
     info!("Server running on {}", banner);
     server.await?;
     info!("Server closing");

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -13,7 +13,7 @@ use tokio::sync::RwLock;
 use crate::db::{pool_from_settings, spawn_pool_periodic_reporter, DbPool};
 use crate::error::ApiError;
 use crate::server::metrics::Metrics;
-use crate::settings::{Deadman, Secrets, ServerLimits, Settings};
+use crate::settings::{Deadman, ServerLimits, Settings};
 use crate::tokenserver;
 use crate::web::{handlers, middleware};
 
@@ -37,14 +37,6 @@ pub struct ServerState {
 
     /// limits rendered as JSON
     pub limits_json: String,
-
-    /// Secrets used during Hawk authentication.
-    pub secrets: Arc<Secrets>,
-
-    // XXX: This is only any Option temporarily. Once Tokenserver is rolled out to production,
-    // it will always be enabled, and syncstorage will always have state associated with
-    // Tokenserver.
-    pub tokenserver_state: Option<tokenserver::ServerState>,
 
     /// Metric reporting
     pub metrics: Box<StatsdClient>,
@@ -70,9 +62,11 @@ pub struct Server;
 
 #[macro_export]
 macro_rules! build_app {
-    ($state: expr, $limits: expr) => {
+    ($syncstorage_state: expr, $tokenserver_state: expr, $secrets: expr, $limits: expr) => {
         App::new()
-            .data($state)
+            .data($syncstorage_state)
+            .data($tokenserver_state)
+            .data($secrets)
             // Middleware is applied LIFO
             // These will wrap all outbound responses with matching status codes.
             .wrap(ErrorHandlers::new().handler(StatusCode::NOT_FOUND, ApiError::render_404))
@@ -171,16 +165,65 @@ macro_rules! build_app {
     };
 }
 
+#[macro_export]
+macro_rules! build_app_without_syncstorage {
+    ($state: expr, $secrets: expr) => {
+        App::new()
+            .data($state)
+            .data($secrets)
+            // Middleware is applied LIFO
+            // These will wrap all outbound responses with matching status codes.
+            .wrap(ErrorHandlers::new().handler(StatusCode::NOT_FOUND, ApiError::render_404))
+            // These are our wrappers
+            .wrap(middleware::sentry::SentryWrapper::default())
+            .wrap(middleware::rejectua::RejectUA::default())
+            // Followed by the "official middleware" so they run first.
+            // actix is getting increasingly tighter about CORS headers. Our server is
+            // not a huge risk but does deliver XHR JSON content.
+            // For now, let's be permissive and use NGINX (the wrapping server)
+            // for finer grained specification.
+            .wrap(Cors::permissive())
+            .service(
+                web::resource("/1.0/{application}/{version}")
+                    .route(web::get().to(tokenserver::handlers::get_tokenserver_result)),
+            )
+            // Dockerflow
+            // Remember to update .::web::middleware::DOCKER_FLOW_ENDPOINTS
+            // when applying changes to endpoint names.
+            .service(
+                web::resource("/__heartbeat__")
+                    .route(web::get().to(tokenserver::handlers::heartbeat)),
+            )
+            .service(
+                web::resource("/__lbheartbeat__").route(web::get().to(|_: HttpRequest| {
+                    // used by the load balancers, just return OK.
+                    HttpResponse::Ok()
+                        .content_type("application/json")
+                        .body("{}")
+                })),
+            )
+            .service(
+                web::resource("/__version__").route(web::get().to(|_: HttpRequest| {
+                    // return the contents of the version.json file created by circleci
+                    // and stored in the docker root
+                    HttpResponse::Ok()
+                        .content_type("application/json")
+                        .body(include_str!("../../version.json"))
+                })),
+            )
+    };
+}
+
 impl Server {
     pub async fn with_settings(settings: Settings) -> Result<dev::Server, ApiError> {
         let metrics = metrics::metrics_from_opts(&settings)?;
+        let host = settings.host.clone();
+        let port = settings.port;
         let db_pool = pool_from_settings(&settings, &Metrics::from(&metrics)).await?;
         let limits = Arc::new(settings.limits);
         let limits_json =
             serde_json::to_string(&*limits).expect("ServerLimits failed to serialize");
         let secrets = Arc::new(settings.master_secret);
-        let host = settings.host.clone();
-        let port = settings.port;
         let quota_enabled = settings.enable_quota;
         let actix_keep_alive = settings.actix_keep_alive;
         let deadman = Arc::new(RwLock::new(Deadman {
@@ -198,24 +241,47 @@ impl Server {
         spawn_pool_periodic_reporter(Duration::from_secs(10), metrics.clone(), db_pool.clone())?;
 
         let mut server = HttpServer::new(move || {
-            // Setup the server state
-            let state = ServerState {
+            let syncstorage_state = ServerState {
                 db_pool: db_pool.clone(),
                 limits: Arc::clone(&limits),
                 limits_json: limits_json.clone(),
-                secrets: Arc::clone(&secrets),
-                tokenserver_state: tokenserver_state.clone(),
                 metrics: Box::new(metrics.clone()),
                 port,
                 quota_enabled,
                 deadman: Arc::clone(&deadman),
             };
 
-            build_app!(state, limits)
+            build_app!(
+                syncstorage_state,
+                tokenserver_state.clone(),
+                Arc::clone(&secrets),
+                limits
+            )
         });
+
         if let Some(keep_alive) = actix_keep_alive {
             server = server.keep_alive(keep_alive as usize);
         }
+
+        let server = server
+            .bind(format!("{}:{}", host, port))
+            .expect("Could not get Server in Server::with_settings")
+            .run();
+        Ok(server)
+    }
+
+    pub async fn tokenserver_only_with_settings(
+        settings: Settings,
+    ) -> Result<dev::Server, ApiError> {
+        let host = settings.host.clone();
+        let port = settings.port;
+        let secrets = Arc::new(settings.master_secret);
+        let tokenserver_state = tokenserver::ServerState::from_settings(&settings.tokenserver)?;
+
+        let server = HttpServer::new(move || {
+            build_app_without_syncstorage!(Some(tokenserver_state.clone()), Arc::clone(&secrets))
+        });
+
         let server = server
             .bind(format!("{}:{}", host, port))
             .expect("Could not get Server in Server::with_settings")

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -80,6 +80,10 @@ pub struct Settings {
 
     pub spanner_emulator_host: Option<String>,
 
+    /// Disable all of the endpoints related to syncstorage. To be used when running Tokenserver
+    /// in isolation.
+    pub disable_syncstorage: bool,
+
     /// Settings specific to Tokenserver
     pub tokenserver: TokenserverSettings,
 }
@@ -108,6 +112,7 @@ impl Default for Settings {
             enable_quota: false,
             enforce_quota: false,
             spanner_emulator_host: None,
+            disable_syncstorage: false,
             tokenserver: TokenserverSettings::default(),
         }
     }
@@ -160,6 +165,7 @@ impl Settings {
         s.set_default("statsd_label", "syncstorage")?;
         s.set_default("enable_quota", false)?;
         s.set_default("enforce_quota", false)?;
+        s.set_default("disable_syncstorage", false)?;
 
         // Set Tokenserver defaults
         s.set_default(

--- a/src/tokenserver/db/mock.rs
+++ b/src/tokenserver/db/mock.rs
@@ -53,6 +53,10 @@ impl Db for MockDb {
         Box::pin(future::ok(()))
     }
 
+    fn check(&self) -> DbFuture<'_, results::Check> {
+        Box::pin(future::ok(true))
+    }
+
     #[cfg(test)]
     fn set_user_created_at(
         &self,

--- a/src/tokenserver/db/results.rs
+++ b/src/tokenserver/db/results.rs
@@ -72,3 +72,5 @@ pub type SetUserCreatedAt = ();
 
 #[cfg(test)]
 pub type GetUsers = Vec<GetUser>;
+
+pub type Check = bool;


### PR DESCRIPTION
## Description

- Adds a `disable_syncstorage` option that disables all of the syncstorage endpoints
- Adds Tokenserver-specific Dockerflow endpoints to be used when syncstorage is disabled

## Testing

Set `disable_syncstorage` to true and ensure that the syncstorage endpoints cannot be reached (they should 404). Ensure that the dockerflow endpoints are working as expected. Set `disable_syncstorage` to false and ensure that syncstorage works as usual.

## Issue(s)

Closes #1083 
