### PR TITLE
feat: Tokenserver: add per-node secrets

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ commands:
       - run:
           name: Core Python Checks
           command: |
-            flake8 src/tokenserver/verify.py
+            flake8 src/tokenserver
             flake8 tools/integration_tests
   rust-clippy:
     steps:

--- a/src/tokenserver/secrets.py
+++ b/src/tokenserver/secrets.py
@@ -1,0 +1,22 @@
+import binascii
+import hashlib
+from tokenlib import HKDF
+
+# Namespace prefix for HKDF "info" parameter.
+HKDF_INFO_NODE_SECRET = b"services.mozilla.com/mozsvc/v1/node_secret/"
+
+def derive_secrets(master_secrets, node):
+    hkdf_params = {
+        "salt": None,
+        "info": HKDF_INFO_NODE_SECRET + node.encode("utf-8"),
+        "hashmod": hashlib.sha256,
+    }
+    node_secrets = []
+    for master_secret in master_secrets:
+        # We want each hex-encoded derived secret to be the same
+        # size as its (presumably hex-encoded) master secret.
+        size = len(master_secret) // 2
+
+        node_secret = HKDF(master_secret.encode("utf-8"), size=size, **hkdf_params)
+        node_secrets.append(binascii.b2a_hex(node_secret).decode())
+    return node_secrets

--- a/src/tokenserver/secrets.py
+++ b/src/tokenserver/secrets.py
@@ -5,6 +5,7 @@ from tokenlib import HKDF
 # Namespace prefix for HKDF "info" parameter.
 HKDF_INFO_NODE_SECRET = b"services.mozilla.com/mozsvc/v1/node_secret/"
 
+
 def derive_secrets(master_secrets, node):
     hkdf_params = {
         "salt": None,
@@ -17,6 +18,7 @@ def derive_secrets(master_secrets, node):
         # size as its (presumably hex-encoded) master secret.
         size = len(master_secret) // 2
 
-        node_secret = HKDF(master_secret.encode("utf-8"), size=size, **hkdf_params)
+        node_secret = HKDF(master_secret.encode("utf-8"), size=size,
+                           **hkdf_params)
         node_secrets.append(binascii.b2a_hex(node_secret).decode())
     return node_secrets

--- a/src/tokenserver/support.rs
+++ b/src/tokenserver/support.rs
@@ -76,6 +76,25 @@ impl Tokenlib {
     }
 }
 
+pub fn derive_node_secrets(secrets: Vec<&str>, node: &str) -> Result<Vec<String>, Error> {
+    const FILENAME: &str = "secrets.py";
+
+    Python::with_gil(|py| {
+        let code = include_str!("secrets.py");
+        let module = PyModule::from_code(py, code, FILENAME, FILENAME)?;
+
+        module
+            .getattr("derive_secrets")?
+            .call((secrets, node), None)
+            .map_err(|e| {
+                e.print_and_set_sys_last_vars(py);
+                e
+            })
+            .and_then(|x| x.extract())
+    })
+    .map_err(pyerr_to_actix_error)
+}
+
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
 pub struct TokenData {
     pub user: String,
@@ -250,5 +269,17 @@ mod tests {
         };
 
         assert_eq!(expected_claims, decoded_claims);
+    }
+
+    #[test]
+    fn test_derive_secret_success() {
+        let secrets = vec!["deadbeefdeadbeefdeadbeefdeadbeef"];
+        let node = "https://node";
+        let derived_secrets = derive_node_secrets(secrets, node).unwrap();
+
+        assert_eq!(
+            derived_secrets,
+            vec!["a227eb0deb5fb4fd8002166f555c9071".to_owned()]
+        );
     }
 }

--- a/tools/integration_tests/tokenserver/test_e2e.py
+++ b/tools/integration_tests/tokenserver/test_e2e.py
@@ -203,8 +203,8 @@ class TestE2e(TestCase, unittest.TestCase):
         signature = raw[-32:]
         payload_dict = json.loads(payload.decode('utf-8'))
 
-        signing_secret = binascii. \
-            hexlify(self.TOKEN_SIGNING_SECRET.encode("utf-8")).decode()
+        signing_secret = binascii.hexlify(
+            self.TOKEN_SIGNING_SECRET.encode("utf-8")).decode()
         node_specific_secret = self._derive_secret(signing_secret,
                                                    self.NODE_URL)
         expected_token = tokenlib.make_token(payload_dict,
@@ -214,8 +214,8 @@ class TestE2e(TestCase, unittest.TestCase):
         # this is not a security-sensitive situation, but it's good practice
         self.assertTrue(hmac.compare_digest(expected_signature, signature))
         # Check that the given key is a secret derived from the hawk ID
-        expected_secret = tokenlib. \
-            get_derived_secret(res.json['id'], secret=node_specific_secret)
+        expected_secret = tokenlib.get_derived_secret(
+            res.json['id'], secret=node_specific_secret)
         self.assertEqual(res.json['key'], expected_secret)
         # Check to make sure the remainder of the fields are valid
         self.assertEqual(res.json['uid'], user['uid'])

--- a/tools/integration_tests/tokenserver/test_e2e.py
+++ b/tools/integration_tests/tokenserver/test_e2e.py
@@ -2,6 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 from base64 import urlsafe_b64decode
+import binascii
+import hashlib
 import hmac
 import json
 import jwt
@@ -19,6 +21,7 @@ from fxa.core import Client
 from fxa.oauth import Client as OAuthClient
 from fxa.tests.utils import TestEmailAccount
 from hashlib import sha256
+from tokenlib import HKDF
 
 from tokenserver.test_support import TestCase
 
@@ -121,6 +124,19 @@ class TestE2e(TestCase, unittest.TestCase):
         hasher.update(value.encode('utf-8'))
         return hasher.hexdigest()
 
+    def _derive_secret(self, master_secret, node):
+        info = "services.mozilla.com/mozsvc/v1/node_secret/%s" % self.NODE_URL
+        hkdf_params = {
+            "salt": None,
+            "info": info.encode("utf-8"),
+            "hashmod": hashlib.sha256,
+        }
+        size = len(master_secret) // 2
+        derived_secret = HKDF(master_secret.encode("utf-8"), size=size,
+                              **hkdf_params)
+
+        return binascii.b2a_hex(derived_secret).decode()
+
     def test_unauthorized_error_status(self):
         # Totally busted auth -> generic error.
         headers = {
@@ -186,16 +202,20 @@ class TestE2e(TestCase, unittest.TestCase):
         payload = raw[:-32]
         signature = raw[-32:]
         payload_dict = json.loads(payload.decode('utf-8'))
-        signing_secret = self.TOKEN_SIGNING_SECRET
+
+        signing_secret = binascii. \
+            hexlify(self.TOKEN_SIGNING_SECRET.encode("utf-8")).decode()
+        node_specific_secret = self._derive_secret(signing_secret,
+                                                   self.NODE_URL)
         expected_token = tokenlib.make_token(payload_dict,
-                                             secret=signing_secret)
+                                             secret=node_specific_secret)
         expected_signature = urlsafe_b64decode(expected_token)[-32:]
         # Using the #compare_digest method here is not strictly necessary, as
         # this is not a security-sensitive situation, but it's good practice
         self.assertTrue(hmac.compare_digest(expected_signature, signature))
         # Check that the given key is a secret derived from the hawk ID
-        expected_secret = tokenlib.get_derived_secret(res.json['id'],
-                                                      secret=signing_secret)
+        expected_secret = tokenlib. \
+            get_derived_secret(res.json['id'], secret=node_specific_secret)
         self.assertEqual(res.json['key'], expected_secret)
         # Check to make sure the remainder of the fields are valid
         self.assertEqual(res.json['uid'], user['uid'])

--- a/tools/integration_tests/tokenserver/test_e2e.py
+++ b/tools/integration_tests/tokenserver/test_e2e.py
@@ -203,7 +203,7 @@ class TestE2e(TestCase, unittest.TestCase):
         signature = raw[-32:]
         payload_dict = json.loads(payload.decode('utf-8'))
 
-        signing_secret = binascii.hexlify(
+        signing_secret = binascii.b2a_hex(
             self.TOKEN_SIGNING_SECRET.encode("utf-8")).decode()
         node_specific_secret = self._derive_secret(signing_secret,
                                                    self.NODE_URL)

--- a/tools/integration_tests/tokenserver/test_support.py
+++ b/tools/integration_tests/tokenserver/test_support.py
@@ -45,15 +45,6 @@ class TestCase:
         cursor = self._execute_sql(('DELETE FROM nodes'), ())
         cursor.close()
 
-        cursor = self._execute_sql(('DELETE FROM services'), ())
-        cursor.close()
-
-        # Ensure the necessary services exists in the db.
-        self._add_service('sync-1.1', '{node}/1.1/{uid}',
-                          self.SYNC_1_1_SERVICE_ID)
-        self._add_service('sync-1.5', '{node}/1.5/{uid}',
-                          self.SYNC_1_5_SERVICE_ID)
-
         # Ensure we have a node with enough capacity to run the tests.
         self._add_node(capacity=100, node=self.NODE_URL, id=self.NODE_ID)
 
@@ -63,9 +54,6 @@ class TestCase:
         cursor.close()
 
         cursor = self._execute_sql(('DELETE FROM nodes'), ())
-        cursor.close()
-
-        cursor = self._execute_sql(('DELETE FROM services'), ())
         cursor.close()
 
         self.database.close()


### PR DESCRIPTION
## Description

Instead of using a single secret for every node, this PR introduces a change such that a different secret is derived for each node.

## Testing

I updated an integration test to match the code change. You can verify that the test passes against both the legacy and new Tokenservers. (Note that the last two assertions of the test will fail on the new Tokenserver due to missing fields on the response (to be fixed in another PR), but the assertion having to do with the derived secret passes.)

## Issue(s)

Closes #1104
