### PR TITLE
feat: make Tokenserver DbPool#get async

### DIFF
--- a/src/tokenserver/db/mock.rs
+++ b/src/tokenserver/db/mock.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::new_without_default)]
 
+use async_trait::async_trait;
 use futures::future;
 
 use super::models::{Db, DbFuture};
@@ -17,8 +18,9 @@ impl MockDbPool {
     }
 }
 
+#[async_trait]
 impl DbPool for MockDbPool {
-    fn get(&self) -> Result<Box<dyn Db>, DbError> {
+    async fn get(&self) -> Result<Box<dyn Db>, DbError> {
         Ok(Box::new(MockDb::new()))
     }
 

--- a/src/tokenserver/db/models.rs
+++ b/src/tokenserver/db/models.rs
@@ -707,7 +707,7 @@ mod tests {
     #[tokio::test]
     async fn test_update_generation() -> Result<()> {
         let pool = db_pool().await?;
-        let db = pool.get()?;
+        let db = pool.get().await?;
 
         // Add a node
         let node_id = db
@@ -772,7 +772,7 @@ mod tests {
     #[tokio::test]
     async fn test_update_keys_changed_at() -> Result<()> {
         let pool = db_pool().await?;
-        let db = pool.get()?;
+        let db = pool.get().await?;
 
         // Add a node
         let node_id = db
@@ -840,7 +840,7 @@ mod tests {
         const MILLISECONDS_IN_AN_HOUR: i64 = MILLISECONDS_IN_A_MINUTE * 60;
 
         let pool = db_pool().await?;
-        let db = pool.get()?;
+        let db = pool.get().await?;
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap()
@@ -1002,7 +1002,7 @@ mod tests {
     #[tokio::test]
     async fn post_user() -> Result<()> {
         let pool = db_pool().await?;
-        let db = pool.get()?;
+        let db = pool.get().await?;
 
         // Add a node
         let post_node_params = params::PostNode {
@@ -1059,7 +1059,7 @@ mod tests {
     #[tokio::test]
     async fn get_node_id() -> Result<()> {
         let pool = db_pool().await?;
-        let db = pool.get()?;
+        let db = pool.get().await?;
 
         // Add a node
         let node_id1 = db
@@ -1097,7 +1097,7 @@ mod tests {
     #[tokio::test]
     async fn test_node_allocation() -> Result<()> {
         let pool = db_pool().await?;
-        let db = pool.get()?;
+        let db = pool.get().await?;
 
         // Add a node
         let node_id = db
@@ -1135,7 +1135,7 @@ mod tests {
     #[tokio::test]
     async fn test_allocation_to_least_loaded_node() -> Result<()> {
         let pool = db_pool().await?;
-        let db = pool.get()?;
+        let db = pool.get().await?;
 
         // Add two nodes
         db.post_node(params::PostNode {
@@ -1191,7 +1191,7 @@ mod tests {
     #[tokio::test]
     async fn test_allocation_is_not_allowed_to_downed_nodes() -> Result<()> {
         let pool = db_pool().await?;
-        let db = pool.get()?;
+        let db = pool.get().await?;
 
         // Add a downed node
         db.post_node(params::PostNode {
@@ -1225,7 +1225,7 @@ mod tests {
     #[tokio::test]
     async fn test_allocation_is_not_allowed_to_backoff_nodes() -> Result<()> {
         let pool = db_pool().await?;
-        let db = pool.get()?;
+        let db = pool.get().await?;
 
         // Add a backoff node
         db.post_node(params::PostNode {
@@ -1259,7 +1259,7 @@ mod tests {
     #[tokio::test]
     async fn test_node_reassignment_when_records_are_replaced() -> Result<()> {
         let pool = db_pool().await?;
-        let db = pool.get()?;
+        let db = pool.get().await?;
 
         // Add a node
         db.post_node(params::PostNode {
@@ -1324,7 +1324,7 @@ mod tests {
     #[tokio::test]
     async fn test_node_reassignment_not_done_for_retired_users() -> Result<()> {
         let pool = db_pool().await?;
-        let db = pool.get()?;
+        let db = pool.get().await?;
 
         // Add a node
         db.post_node(params::PostNode {
@@ -1371,7 +1371,7 @@ mod tests {
     #[tokio::test]
     async fn test_node_reassignment_and_removal() -> Result<()> {
         let pool = db_pool().await?;
-        let db = pool.get()?;
+        let db = pool.get().await?;
 
         // Add two nodes
         let node1_id = db
@@ -1513,7 +1513,7 @@ mod tests {
     #[tokio::test]
     async fn test_gradual_release_of_node_capacity() -> Result<()> {
         let pool = db_pool().await?;
-        let db = pool.get()?;
+        let db = pool.get().await?;
 
         // Add two nodes
         let node1_id = db
@@ -1670,7 +1670,7 @@ mod tests {
     #[tokio::test]
     async fn test_correct_created_at_used_during_node_reassignment() -> Result<()> {
         let pool = db_pool().await?;
-        let db = pool.get()?;
+        let db = pool.get().await?;
 
         // Add a node
         let node_id = db
@@ -1725,7 +1725,7 @@ mod tests {
     #[tokio::test]
     async fn test_correct_created_at_used_during_user_retrieval() -> Result<()> {
         let pool = db_pool().await?;
-        let db = pool.get()?;
+        let db = pool.get().await?;
 
         // Add a node
         db.post_node(params::PostNode {

--- a/src/tokenserver/db/pool.rs
+++ b/src/tokenserver/db/pool.rs
@@ -1,3 +1,5 @@
+use actix_web::web::block;
+use async_trait::async_trait;
 use diesel::{
     mysql::MysqlConnection,
     r2d2::{ConnectionManager, Pool},
@@ -8,7 +10,7 @@ use diesel_logger::LoggingConnection;
 use std::time::Duration;
 
 use super::models::{Db, DbResult, TokenserverDb};
-use crate::db::error::DbError;
+use crate::db::{error::DbError, DbErrorKind};
 use crate::tokenserver::settings::Settings;
 
 #[cfg(test)]
@@ -62,12 +64,25 @@ impl TokenserverPool {
     }
 }
 
+impl From<actix_web::error::BlockingError<DbError>> for DbError {
+    fn from(inner: actix_web::error::BlockingError<DbError>) -> Self {
+        match inner {
+            actix_web::error::BlockingError::Error(e) => e,
+            actix_web::error::BlockingError::Canceled => {
+                DbErrorKind::Internal("Db threadpool operation canceled".to_owned()).into()
+            }
+        }
+    }
+}
+
+#[async_trait]
 impl DbPool for TokenserverPool {
-    fn get(&self) -> Result<Box<dyn Db>, DbError> {
-        self.inner
-            .get()
-            .map(|conn| Box::new(TokenserverDb::new(conn)) as Box<dyn Db>)
-            .map_err(DbError::from)
+    async fn get(&self) -> Result<Box<dyn Db>, DbError> {
+        let pool = self.inner.clone();
+
+        let conn = block(move || pool.get().map_err(DbError::from)).await?;
+
+        Ok(Box::new(TokenserverDb::new(conn)) as Box<dyn Db>)
     }
 
     fn box_clone(&self) -> Box<dyn DbPool> {
@@ -75,8 +90,9 @@ impl DbPool for TokenserverPool {
     }
 }
 
+#[async_trait]
 pub trait DbPool: Sync + Send {
-    fn get(&self) -> Result<Box<dyn Db>, DbError>;
+    async fn get(&self) -> Result<Box<dyn Db>, DbError>;
 
     fn box_clone(&self) -> Box<dyn DbPool>;
 }

--- a/src/tokenserver/db/pool.rs
+++ b/src/tokenserver/db/pool.rs
@@ -79,7 +79,6 @@ impl From<actix_web::error::BlockingError<DbError>> for DbError {
 impl DbPool for TokenserverPool {
     async fn get(&self) -> Result<Box<dyn Db>, DbError> {
         let pool = self.inner.clone();
-
         let conn = block(move || pool.get().map_err(DbError::from)).await?;
 
         Ok(Box::new(TokenserverDb::new(conn)) as Box<dyn Db>)

--- a/src/tokenserver/extractors.rs
+++ b/src/tokenserver/extractors.rs
@@ -193,7 +193,7 @@ impl FromRequest for TokenserverRequest {
             };
             let email = format!("{}@{}", fxa_uid, state.fxa_email_domain);
             let user = {
-                let db = state.db_pool.get().map_err(|_| {
+                let db = state.db_pool.get().await.map_err(|_| {
                     error!("⚠️ Could not acquire database connection");
 
                     TokenserverError::internal_error()
@@ -262,7 +262,7 @@ impl FromRequest for Box<dyn Db> {
             // XXX: Tokenserver state will no longer be an Option once the Tokenserver
             // code is rolled out, so we will eventually be able to remove this unwrap().
             let state = get_server_state(&req)?.as_ref().as_ref().unwrap();
-            let db = state.db_pool.get().map_err(|_| {
+            let db = state.db_pool.get().await.map_err(|_| {
                 error!("⚠️ Could not acquire database connection");
 
                 TokenserverError::internal_error()

--- a/src/web/handlers.rs
+++ b/src/web/handlers.rs
@@ -565,7 +565,11 @@ pub async fn heartbeat(hb: HeartbeatRequest, req: HttpRequest) -> Result<HttpRes
 
     let mut tokenserver_service_unavailable = false;
     if let Some(tokenserver_state) = tokenserver_state.as_ref() {
-        let db = tokenserver_state.db_pool.get().map_err(ApiError::from)?;
+        let db = tokenserver_state
+            .db_pool
+            .get()
+            .await
+            .map_err(ApiError::from)?;
         let mut tokenserver_checklist = Map::new();
 
         match db.check().await {


### PR DESCRIPTION
## Description

Makes the `DbPool#get` method async

## Testing

This change should be transparent; no functionality was changed.

## Issue(s)

Closes #1172 
