### PR TITLE
test: add Tokenserver load tests

### DIFF
--- a/src/tokenserver/db/pool.rs
+++ b/src/tokenserver/db/pool.rs
@@ -78,8 +78,8 @@ impl From<actix_web::error::BlockingError<DbError>> for DbError {
 #[async_trait]
 impl DbPool for TokenserverPool {
     async fn get(&self) -> Result<Box<dyn Db>, DbError> {
-        let pool = self.inner.clone();
-        let conn = block(move || pool.get().map_err(DbError::from)).await?;
+        let pool = self.clone();
+        let conn = block(move || pool.inner.get().map_err(DbError::from)).await?;
 
         Ok(Box::new(TokenserverDb::new(conn)) as Box<dyn Db>)
     }

--- a/src/tokenserver/extractors.rs
+++ b/src/tokenserver/extractors.rs
@@ -348,7 +348,7 @@ impl FromRequest for KeyId {
             }
 
             let x_key_id = headers
-                .get("X-KeyId")
+                .get("X-KeyID")
                 .ok_or_else(|| TokenserverError::invalid_key_id("Missing X-KeyID header"))?
                 .to_str()
                 .map_err(|_| TokenserverError::invalid_key_id("Invalid X-KeyID header"))?;

--- a/tools/tokenserver/loadtests/README.md
+++ b/tools/tokenserver/loadtests/README.md
@@ -1,0 +1,35 @@
+# Tokenserver Load Tests
+
+This directory contains everything needed to run the suite of load tests for Tokenserver.
+
+## Building and Running
+1. Install the load testing dependencies:
+```sh
+pip3 install -r requirements.txt
+```
+1. Set up a mock FxA service, with which Tokenserver will verify OAuth tokens. This directory includes a `mock-oauth-cfn.yaml` file, which contains the AWS CloudFormation template needed to deploy the mock service. A service with this template has been preconfigured at [https://mock-oauth-stage.dev.lcip.org](), but you can deploy your own with the following command:
+```sh
+aws cloudformation deploy \
+    --template-file=mock-oauth-cfn.yml \
+    --stack-name my-mock-oauth-stack \
+    --capabilities CAPABILITY_IAM \
+    --parameter-overrides \
+        DomainName=my-mock-oauth.dev.lcip.org
+```
+1. Configure Tokenserver to verify tokens through the mock FxA service. This is done by setting the `tokenserver.fxa_oauth_server_url` setting or `SYNC_TOKENSERVER__FXA_OAUTH_SERVER_URL` environment variable to the URL of the desired mock service.
+1. Tokenserver uses [locust](https://locust.io/) for load testing. To run the load tests, simply run the following command in this directory:
+```sh
+locust
+```
+Next, navigate your browser to http://localhost:8090, where you'll find the locust GUI. Enter the following information:
+* Number of users: The peak number of simultaneous connections to Tokenserver
+* Spawn rate: The rate at which new connections are created
+* Host: The URL of the server to be load tested. Note that this URL must include the protocol (e.g. "http://").
+Click the "Start swarming" button to begin the load tests.
+
+## Populating the Database
+This directory includes an optional `populate_db.py` script that can be used to add test users to the database en masse. The script can be run like so:
+```sh
+python3 populate_db.py <sqlurl> <nodes> <number of users>
+```
+where `sqluri` is the URL of the Tokenserver database, `nodes` is a comma-separated list of nodes **that are already present in the database** to which the users will be randomly assigned, and `number of users` is the number of users to be created. 

--- a/tools/tokenserver/loadtests/README.md
+++ b/tools/tokenserver/loadtests/README.md
@@ -7,7 +7,7 @@ This directory contains everything needed to run the suite of load tests for Tok
 ```sh
 pip3 install -r requirements.txt
 ```
-1. Set up a mock FxA service, with which Tokenserver will verify OAuth tokens. This directory includes a `mock-oauth-cfn.yaml` file, which contains the AWS CloudFormation template needed to deploy the mock service. A service with this template has been preconfigured at [https://mock-oauth-stage.dev.lcip.org](), but you can deploy your own with the following command:
+2. Set up a mock FxA service, with which Tokenserver will verify OAuth tokens. This directory includes a `mock-oauth-cfn.yaml` file, which contains the AWS CloudFormation template needed to deploy the mock service. A service with this template has been preconfigured at [https://mock-oauth-stage.dev.lcip.org](), but you can deploy your own with the following command:
 ```sh
 aws cloudformation deploy \
     --template-file=mock-oauth-cfn.yml \
@@ -16,8 +16,8 @@ aws cloudformation deploy \
     --parameter-overrides \
         DomainName=my-mock-oauth.dev.lcip.org
 ```
-1. Configure Tokenserver to verify tokens through the mock FxA service. This is done by setting the `tokenserver.fxa_oauth_server_url` setting or `SYNC_TOKENSERVER__FXA_OAUTH_SERVER_URL` environment variable to the URL of the desired mock service.
-1. Tokenserver uses [locust](https://locust.io/) for load testing. To run the load tests, simply run the following command in this directory:
+3. Configure Tokenserver to verify tokens through the mock FxA service. This is done by setting the `tokenserver.fxa_oauth_server_url` setting or `SYNC_TOKENSERVER__FXA_OAUTH_SERVER_URL` environment variable to the URL of the desired mock service.
+4. Tokenserver uses [locust](https://locust.io/) for load testing. To run the load tests, simply run the following command in this directory:
 ```sh
 locust
 ```
@@ -25,6 +25,7 @@ Next, navigate your browser to http://localhost:8090, where you'll find the locu
 * Number of users: The peak number of simultaneous connections to Tokenserver
 * Spawn rate: The rate at which new connections are created
 * Host: The URL of the server to be load tested. Note that this URL must include the protocol (e.g. "http://").
+
 Click the "Start swarming" button to begin the load tests.
 
 ## Populating the Database

--- a/tools/tokenserver/loadtests/locustfile.py
+++ b/tools/tokenserver/loadtests/locustfile.py
@@ -6,10 +6,12 @@ DEFAULT_OAUTH_SCOPE = 'https://identity.mozilla.com/apps/oldsync'
 MOCKMYID_DOMAIN = "mockmyid.s3-us-west-2.amazonaws.com"
 TOKENSERVER_PATH = '/1.0/sync/1.5'
 
-# An instance of this class represents a single Tokenserver user. Instances 
+# An instance of this class represents a single Tokenserver user. Instances
 # will live for the entire duration of the load test. Based on the `wait_time`
 # class variable and the `@task` decorators, each user will make sporadic
 # requests to the server under test.
+
+
 class TokenserverTestUser(HttpUser):
     wait_time = between(1, 5)
 
@@ -95,7 +97,7 @@ class TokenserverTestUser(HttpUser):
         keys_changed_at = self.generation_counter
         client_state = b64encode(
             str(keys_changed_at).encode('utf8')).strip(b'=').decode('utf-8')
-        
+
         return '%s-%s' % (keys_changed_at, client_state)
 
     def _do_token_exchange(self, token, status=200):
@@ -104,6 +106,8 @@ class TokenserverTestUser(HttpUser):
             'X-KeyID': self.x_key_id,
         }
 
-        with self.client.get(TOKENSERVER_PATH, catch_response=True, headers=headers) as res:
+        with self.client.get(TOKENSERVER_PATH,
+                             catch_response=True,
+                             headers=headers) as res:
             if res.status_code == status:
                 res.success()

--- a/tools/tokenserver/loadtests/locustfile.py
+++ b/tools/tokenserver/loadtests/locustfile.py
@@ -54,6 +54,14 @@ class TokenserverTestUser(HttpUser):
 
         self._do_token_exchange(token)
 
+    @task(5)
+    def test_password_change(self):
+        # When a user's password changes, the generation number increases.
+        self.generation_counter += 1
+        token = self._make_oauth_token(self.email)
+
+        self._do_token_exchange(token)
+
     def _make_oauth_token(self, user=None, status=200, **fields):
         # For mock oauth tokens, we bundle the desired status code
         # and response body into a JSON blob for the mock verifier

--- a/tools/tokenserver/loadtests/locustfile.py
+++ b/tools/tokenserver/loadtests/locustfile.py
@@ -6,13 +6,13 @@ DEFAULT_OAUTH_SCOPE = 'https://identity.mozilla.com/apps/oldsync'
 MOCKMYID_DOMAIN = "mockmyid.s3-us-west-2.amazonaws.com"
 TOKENSERVER_PATH = '/1.0/sync/1.5'
 
-# An instance of this class represents a single Tokenserver user. Instances
-# will live for the entire duration of the load test. Based on the `wait_time`
-# class variable and the `@task` decorators, each user will make sporadic
-# requests to the server under test.
-
 
 class TokenserverTestUser(HttpUser):
+    # An instance of this class represents a single Tokenserver user. Instances
+    # will live for the entire duration of the load test. Based on the
+    # `wait_time` class variable and the `@task` decorators, each user will
+    # make sporadic requests to the server under test.
+
     wait_time = between(1, 5)
 
     def __init__(self, *args, **kwargs):

--- a/tools/tokenserver/loadtests/locustfile.py
+++ b/tools/tokenserver/loadtests/locustfile.py
@@ -1,0 +1,104 @@
+import json
+from base64 import urlsafe_b64encode as b64encode
+from locust import HttpUser, task, between
+
+DEFAULT_OAUTH_SCOPE = 'https://identity.mozilla.com/apps/oldsync'
+MOCKMYID_DOMAIN = "mockmyid.s3-us-west-2.amazonaws.com"
+TOKENSERVER_PATH = '/1.0/sync/1.5'
+
+# An instance of this class represents a single Tokenserver user. Instances 
+# will live for the entire duration of the load test. Based on the `wait_time`
+# class variable and the `@task` decorators, each user will make sporadic
+# requests to the server under test.
+class TokenserverTestUser(HttpUser):
+    wait_time = between(1, 5)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Keep track of this user's generation number.
+        self.generation_counter = 0
+        # Locust spawns a new instance of this class for each user. Using the
+        # object ID as the FxA UID guarantees uniqueness.
+        self.fxa_uid = id(self)
+        self.email = "loadtest-%s@%s" % (self.fxa_uid, MOCKMYID_DOMAIN)
+
+    @task(1000)
+    def test_success(self):
+        token = self._make_oauth_token(self.email)
+        x_key_id = self._make_x_key_id_header()
+
+        self._do_token_exchange(token, x_key_id)
+
+    @task(5)
+    def test_invalid_scope(self):
+        token = self._make_oauth_token(
+            user=str(self.fxa_uid),
+            scope=["unrelated", "scopes"],
+        )
+        x_key_id = self._make_x_key_id_header()
+
+        self._do_token_exchange(token, x_key_id, status=401)
+
+    @task(5)
+    def test_invalid_token(self):
+        token = self._make_oauth_token(status=400, errno=108)
+        x_key_id = self._make_x_key_id_header()
+
+        self._do_token_exchange(token, x_key_id, status=401)
+
+    @task(5)
+    def test_encryption_key_change(self):
+        # When a user's encryption keys change, the generation number and
+        # keys_changed_at for the user both increase.
+        self.generation_counter += 1
+
+        token = self._make_oauth_token(self.email, generation=self.generation_counter)
+        x_key_id = self._make_x_key_id_header(keys_changed_at=self.generation_counter)
+
+        self._do_token_exchange(token, x_key_id)
+
+    def _make_oauth_token(self, user=None, status=200, **fields):
+        # For mock oauth tokens, we bundle the desired status code
+        # and response body into a JSON blob for the mock verifier
+        # to echo back to us.
+        body = {}
+        if status < 400:
+            if user is None:
+                raise ValueError("Must specify user for valid oauth token")
+            if "scope" not in fields:
+                fields["scope"] = [DEFAULT_OAUTH_SCOPE]
+            if "client_id" not in fields:
+                fields["client_id"] = "x"
+        if user is not None:
+            parts = user.split("@", 1)
+            if len(parts) == 1:
+                body["user"] = user
+            else:
+                body["user"] = parts[0]
+                body["issuer"] = parts[1]
+        body['generation'] = self.generation_counter
+        body.update(fields)
+        return json.dumps({
+          "status": status,
+          "body": body
+        })
+
+    def _make_x_key_id_header(self, keys_changed_at=None):
+        # In practice, the generation number and keys_changed_at may not be
+        # the same, but for our purposes, making this assumption is sufficient:
+        # the accuracy of the load test is unaffected.
+        keys_changed_at = self.generation_counter
+        client_state = b64encode(
+            str(keys_changed_at).encode('utf8')).strip(b'=').decode('utf-8')
+        
+        return '%s-%s' % (keys_changed_at, client_state)
+
+    def _do_token_exchange(self, token, x_key_id, status=200):
+        headers = {
+            'Authorization': 'Bearer %s' % token,
+            'X-KeyID': x_key_id,
+        }
+
+        with self.client.get(TOKENSERVER_PATH, catch_response=True, headers=headers) as res:
+            if res.status_code == status:
+                res.success()

--- a/tools/tokenserver/loadtests/mock-oauth-cfn.yaml
+++ b/tools/tokenserver/loadtests/mock-oauth-cfn.yaml
@@ -1,0 +1,231 @@
+#
+# This is a CloudFormation script to deploy a tiny lambda+API-gateway
+# service that can mock out FxA OAuth verification responses.
+#
+# When deployed, this API will proxy all HTTP requests through to a live
+# FxA OAuth server except that `POST /v1/verify` will attempt to parse
+# the submitted token as JSON. If it succeeds, then it will use the `status`
+# and `body` fields from that JSON to return a mocked response.
+#
+# The idea is to let this API be used as a stand-in for the real FxA OAuth
+# server, and have it function correctly for manual testing with real accounts,
+# but then also to be able to make fake OAuth tokens during a loadtest, like
+# this:
+#
+#  requests.get("https://mock-oauth-stage.dev.lcip.org", json={
+#      "token": json.dumps({
+#        "status": 200,
+#        "body": {
+#          "user": "loadtest123456",
+#          "scope": ["myscope"],
+#          "client_id": "my_client_id",
+#        }
+#      })
+#  })
+#
+# Or to be able to simulate OAuth token failures like this:
+#
+#  requests.get("https://mock-oauth-stage.dev.lcip.org", json={
+#      "token": json.dumps({
+#        "status": 400,
+#        "body": {
+#          "errno": "108",
+#          "message": "invalid token",
+#        }
+#      })
+#  })
+#
+# You'll notice that there's some javascript written inline in this yaml file.
+# That does make it a little bit annoying to edit, but that's outweighed by
+# the advantage of have a single file that can be deployed with a single
+# command with no pre-processing palaver.
+#
+Parameters:
+  ProxyTarget:
+    Type: "String"
+    Default: "oauth.stage.mozaws.net"
+    Description: "The live OAuth server to which un-mocked requests should be proxied"
+  MockIssuer:
+    Type: "String"
+    Default: "mockmyid.s3-us-west-2.amazonaws.com"
+    Description: "The issuer domain to use for mock tokens"
+  DomainName:
+    Type: "String"
+    Default: "mock-oauth-stage.dev.lcip.org"
+    Description: "The domain name at which to expose the API"
+  CertificateArn:
+    Type: "String"
+    Default: "arn:aws:acm:us-east-1:927034868273:certificate/675e0ac8-23af-4153-8295-acb28ccc9f0f"
+    Description: "The certificate to use with $DomainName"
+  HostedZoneName:
+    Type: "String"
+    Default: "lcip.org"
+    Description: "The hosted zone in which to create a DNS record"
+  Owner:
+    Type: "String"
+    Default: "rfkelly@mozilla.com"
+    Description: "Email address of owner to tag resources with"
+
+Resources:
+  Handler:
+    Type: "AWS::Lambda::Function"
+    Properties: 
+      Description: "Mock FxA OAuth verifier"
+      Handler: "index.handler"
+      Role:  !GetAtt HandlerRole.Arn
+      Tags:
+        - Key: "Owner"
+          Value: !Ref Owner
+      Runtime: "nodejs6.10"
+      Code: 
+        ZipFile: !Sub |-
+
+          const https = require('https');
+          const url = require('url');
+
+          function proxy(event, context, callback) {
+            const output = []
+            const req = https.request({
+              hostname: "${ProxyTarget}",
+              post: 443,
+              path: url.format({
+                pathname: event.path,
+                query: event.queryStringParameters
+              }),
+              method: event.httpMethod,
+            }, res => {
+              res.setEncoding('utf8');
+              res.on('data', d => {
+                output.push(d);
+              })
+              res.on('end', () => {
+                callback(null, {
+                  statusCode: res.statusCode,
+                  headers: res.headers,
+                  body: output.join('')
+                });
+              })
+            });            
+            req.on('error', e => {
+              callback(e);
+            })
+            if (event.body) {
+              req.write(event.body, 'utf8');
+            }
+            req.end();
+          }
+
+          const HANDLERS = {
+            'POST:/v1/verify': function(event, context, callback) {
+              try {
+                const token = JSON.parse(event.body).token;
+                const mockResponse = JSON.parse(token);
+                const mockStatus = mockResponse.status || 200;
+                const mockBody = mockResponse.body || {};
+                // Ensure that successful responses always claim to be from
+                // the mock issuer. Otherwise you could use a mock token to
+                // any account, even accounts backed by accounts.firefox.com!
+                if (mockStatus < 400) {
+                  mockBody.issuer = "${MockIssuer}";
+                }
+                // Return the mocked response from the token.
+                return callback(null, {
+                  statusCode: mockStatus,
+                  headers: {
+                    "content-type": "application/json"
+                  },
+                  body: JSON.stringify(mockBody)
+                });
+              } catch (e) {
+                // If it's not a mock token, forward to real server.
+                return proxy(event, context, callback);
+              }
+            }
+          }
+
+          exports.handler = (event, context, callback) => {
+            const h = HANDLERS[event.httpMethod + ':' + event.path] || proxy;
+            return h(event, context, callback);
+          };
+
+  HandlerRole:
+    Type: "AWS::IAM::Role"
+    Properties: 
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Allow"
+            Principal:
+              Service:
+                - "lambda.amazonaws.com"
+            Action:
+              - "sts:AssumeRole"
+      ManagedPolicyArns:
+        - "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+
+  HandlerPermission:
+    Type: "AWS::Lambda::Permission"
+    Properties:
+      Action: "lambda:invokeFunction"
+      FunctionName: !GetAtt Handler.Arn
+      Principal: "apigateway.amazonaws.com"
+      SourceArn: !Sub "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${API}/*"
+
+  API:
+    Type: "AWS::ApiGateway::RestApi"
+    Properties:
+      Description: "Mock FxA OAuth API"
+      Name: !Sub "${AWS::StackName}-mock-fxa-oauth"
+      FailOnWarnings: true
+
+  APIResource:
+    Type: "AWS::ApiGateway::Resource"
+    Properties:
+      RestApiId: !Ref API
+      ParentId:  !GetAtt API.RootResourceId
+      PathPart: "{proxy+}"
+
+  APIMethod:
+    Type: "AWS::ApiGateway::Method"
+    DependsOn:
+      - HandlerPermission
+    Properties:
+      AuthorizationType: "NONE"
+      HttpMethod: "ANY"
+      ResourceId:  !Ref APIResource
+      RestApiId:  !Ref API
+      Integration:
+        Type: "AWS_PROXY"
+        IntegrationHttpMethod: "POST"
+        Uri: !Sub "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${Handler.Arn}/invocations"
+
+  APIDeployment:
+    Type: "AWS::ApiGateway::Deployment"
+    DependsOn:
+      - APIMethod
+    Properties:
+      RestApiId: !Ref API
+      StageName: "main"
+
+  APIDomainName:
+    Type: "AWS::ApiGateway::DomainName"
+    Properties:
+      DomainName: !Ref DomainName
+      CertificateArn: !Ref CertificateArn
+
+  APIDomainMapping:
+    Type: "AWS::ApiGateway::BasePathMapping"
+    Properties:
+      DomainName: !Ref APIDomainName
+      RestApiId:  !Ref API
+      Stage: "main"
+
+  APIDNSRecord:
+    Type : "AWS::Route53::RecordSet"
+    Properties :
+      HostedZoneName : !Sub "${HostedZoneName}."
+      Name : !Sub "${DomainName}."
+      Type : "A"
+      AliasTarget:
+        DNSName: !GetAtt APIDomainName.DistributionDomainName
+        HostedZoneId: "Z2FDTNDATAQYW2" # Published ZoneId for CloudFront

--- a/tools/tokenserver/loadtests/populate_db.py
+++ b/tools/tokenserver/loadtests/populate_db.py
@@ -36,14 +36,14 @@ _SERVICE_NAME = 'sync-1.5'
 
 
 # This class creates a bunch of users associated with the sync-1.5 service.
-
+#
 # The resulting users will have an address in the form of <uid>@<host> where
 # uid is an int from 0 to :param user_range:.
-
+#
 # This class is useful to populate the database during the load tests. It
 # allows us to test a specific behaviour: making sure that we are not reading
 # the values from memory when retrieving the node information.
-
+#
 # :param sqluri: the sqluri string used to connect to the database
 # :param nodes: the list of available nodes for this service
 # :param user_range: the number of users to create
@@ -94,14 +94,13 @@ class PopulateDatabase:
 
 
 def main():
-    """Read the arguments from the command line and pass them to the
-    PopulateDb class.
-
-    Example use:
-
-        python3 populate-db.py sqlite:////tmp/tokenserver\
-        node1,node2,node3,node4,node5,node6 100
-    """
+    # Read the arguments from the command line and pass them to the
+    # PopulateDb class.
+    #
+    # Example use:
+    #
+    #     python3 populate-db.py sqlite:////tmp/tokenserver\
+    #     node1,node2,node3,node4,node5,node6 100
     import sys
     if len(sys.argv) < 4:
         raise ValueError('You need to specify (in this order) sqluri, '

--- a/tools/tokenserver/loadtests/populate_db.py
+++ b/tools/tokenserver/loadtests/populate_db.py
@@ -35,20 +35,19 @@ where
 _SERVICE_NAME = 'sync-1.5'
 
 
-"""This class creates a bunch of users associated with the sync-1.5 service.
+# This class creates a bunch of users associated with the sync-1.5 service.
 
-The resulting users will have an address in the form of <uid>@<host> where
-uid is an int from 0 to :param user_range:.
+# The resulting users will have an address in the form of <uid>@<host> where
+# uid is an int from 0 to :param user_range:.
 
-This function is useful to populate the database during the load tests. It
-allows us to test a specific behaviour: making sure that we are not reading
-the values from memory when retrieving the node information.
+# This class is useful to populate the database during the load tests. It
+# allows us to test a specific behaviour: making sure that we are not reading
+# the values from memory when retrieving the node information.
 
-:param sqluri: the sqluri string used to connect to the database
-:param nodes: the list of available nodes for this service
-:param user_range: the number of users to create
-:param host: the hostname to use when generating users
-"""
+# :param sqluri: the sqluri string used to connect to the database
+# :param nodes: the list of available nodes for this service
+# :param user_range: the number of users to create
+# :param host: the hostname to use when generating users
 class PopulateDatabase:
     def __init__(self, sqluri, nodes, user_range, host="loadtest.local"):
         engine = create_engine(sqluri)
@@ -63,7 +62,9 @@ class PopulateDatabase:
 
     def _get_node_id(self, node_name):
         """Get numeric id for a node."""
-        res = self.database.execute(_GET_NODE_ID, service=self.service_id, node=node_name)
+        res = self.database.execute(_GET_NODE_ID,
+                                    service=self.service_id,
+                                    node=node_name)
         row = res.fetchone()
         res.close()
         if row is None:
@@ -82,19 +83,23 @@ class PopulateDatabase:
             'timestamp': int(time.time() * 1000),
         }
 
-        # for each user in the range, assign him to a node
+        # for each user in the range, assign them to a node
         for idx in range(0, self.user_range):
             email = "%s@%s" % (idx, self.host)
             nodeid = random.choice(self.node_ids)
-            self.database.execute(_CREATE_USER_RECORD, email=email, nodeid=nodeid, **params)
+            self.database.execute(_CREATE_USER_RECORD,
+                                  email=email,
+                                  nodeid=nodeid,
+                                  **params)
+
 
 def main():
     """Read the arguments from the command line and pass them to the
-    populate_db function.
+    PopulateDb class.
 
     Example use:
 
-        python populate-db.py sqlite:////tmp/tokenserver\
+        python3 populate-db.py sqlite:////tmp/tokenserver\
         node1,node2,node3,node4,node5,node6 100
     """
     import sys

--- a/tools/tokenserver/loadtests/populate_db.py
+++ b/tools/tokenserver/loadtests/populate_db.py
@@ -1,0 +1,113 @@
+#! /usr/bin/env python
+# script to populate the database with records
+import time
+import random
+from sqlalchemy import create_engine
+from sqlalchemy.sql import text as sqltext
+
+_CREATE_USER_RECORD = sqltext("""\
+insert into
+    users
+    (service, email, nodeid, generation, client_state,
+     created_at, replaced_at)
+values
+    (:service, :email, :nodeid, 0, "", :timestamp, NULL)
+""")
+
+_GET_SERVICE_ID = sqltext("""\
+select
+    id
+from
+    services
+where
+    service = :service
+""")
+
+_GET_NODE_ID = sqltext("""\
+select
+    id
+from
+    nodes
+where
+    service=:service and node=:node
+""")
+
+_SERVICE_NAME = 'sync-1.5'
+
+
+"""This class creates a bunch of users associated with the sync-1.5 service.
+
+The resulting users will have an address in the form of <uid>@<host> where
+uid is an int from 0 to :param user_range:.
+
+This function is useful to populate the database during the load tests. It
+allows us to test a specific behaviour: making sure that we are not reading
+the values from memory when retrieving the node information.
+
+:param sqluri: the sqluri string used to connect to the database
+:param nodes: the list of available nodes for this service
+:param user_range: the number of users to create
+:param host: the hostname to use when generating users
+"""
+class PopulateDatabase:
+    def __init__(self, sqluri, nodes, user_range, host="loadtest.local"):
+        engine = create_engine(sqluri)
+        self.database = engine. \
+            execution_options(isolation_level="AUTOCOMMIT"). \
+            connect()
+
+        self.service_id = self._get_service_id()
+        self.node_ids = [self._get_node_id(node) for node in nodes]
+        self.user_range = user_range
+        self.host = host
+
+    def _get_node_id(self, node_name):
+        """Get numeric id for a node."""
+        res = self.database.execute(_GET_NODE_ID, service=self.service_id, node=node_name)
+        row = res.fetchone()
+        res.close()
+        if row is None:
+            raise ValueError("unknown node: " + node_name)
+        return row[0]
+
+    def _get_service_id(self):
+        res = self.database.execute(_GET_SERVICE_ID, service=_SERVICE_NAME)
+        row = res.fetchone()
+        res.close()
+        return row.id
+
+    def run(self):
+        params = {
+            'service': self.service_id,
+            'timestamp': int(time.time() * 1000),
+        }
+
+        # for each user in the range, assign him to a node
+        for idx in range(0, self.user_range):
+            email = "%s@%s" % (idx, self.host)
+            nodeid = random.choice(self.node_ids)
+            self.database.execute(_CREATE_USER_RECORD, email=email, nodeid=nodeid, **params)
+
+def main():
+    """Read the arguments from the command line and pass them to the
+    populate_db function.
+
+    Example use:
+
+        python populate-db.py sqlite:////tmp/tokenserver\
+        node1,node2,node3,node4,node5,node6 100
+    """
+    import sys
+    if len(sys.argv) < 4:
+        raise ValueError('You need to specify (in this order) sqluri, '
+                         'nodes (comma separated), and user_range')
+    # transform the values from the cli to python objects
+    sys.argv[2] = sys.argv[2].split(',')  # comma separated => list
+    sys.argv[3] = int(sys.argv[3])
+
+    PopulateDatabase(*sys.argv[1:]).run()
+    print("created {nb_users} users".format(nb_users=sys.argv[3]))
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/tokenserver/loadtests/requirements.txt
+++ b/tools/tokenserver/loadtests/requirements.txt
@@ -1,0 +1,2 @@
+locust
+sqlalchemy


### PR DESCRIPTION
## Description

Adds a suite of locust load tests for Tokenserver.

## Testing

The load test suite currently doesn't run well against the new Tokenserver (I think there is an issue without how I configured the database; I'll look into this separately). Running it against the old Tokenserver should work without issue (you'll need to configure the old Tokenserver to verify OAuth tokens through the mock service at https://mock-oauth-stage.dev.lcip.org).

## Issue(s)

Closes #1107