### PR TITLE
refactor: remove static service IDs

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,10 @@
+[advisories]
+ignore = [
+    "RUSTSEC-2020-0041", # https://github.com/bodil/sized-chunks/issues/11
+    "RUSTSEC-2021-0078",
+    "RUSTSEC-2021-0079",
+    "RUSTSEC-2020-0159",
+    "RUSTSEC-2020-0071",
+    "RUSTSEC-2021-0124",
+    "RUSTSEC-2021-0131",
+]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ commands:
           command: |
             cargo fmt -- --check
             # https://github.com/bodil/sized-chunks/issues/11
-            cargo audit --ignore RUSTSEC-2020-0041 --ignore RUSTSEC-2021-0078 --ignore RUSTSEC-2021-0079 --ignore RUSTSEC-2020-0159 --ignore RUSTSEC-2020-0071 --ignore RUSTSEC-2021-0124
+            cargo audit --ignore RUSTSEC-2020-0041 --ignore RUSTSEC-2021-0078 --ignore RUSTSEC-2021-0079 --ignore RUSTSEC-2020-0159 --ignore RUSTSEC-2020-0071 --ignore RUSTSEC-2021-0124 --ignore RUSTSEC-2021-0131
   python-check:
     steps:
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,8 +37,7 @@ commands:
           name: Core Rust Checks
           command: |
             cargo fmt -- --check
-            # https://github.com/bodil/sized-chunks/issues/11
-            cargo audit --ignore RUSTSEC-2020-0041 --ignore RUSTSEC-2021-0078 --ignore RUSTSEC-2021-0079 --ignore RUSTSEC-2020-0159 --ignore RUSTSEC-2020-0071 --ignore RUSTSEC-2021-0124 --ignore RUSTSEC-2021-0131
+            cargo audit
   python-check:
     steps:
       - run:

--- a/src/tokenserver/db/mock.rs
+++ b/src/tokenserver/db/mock.rs
@@ -85,6 +85,10 @@ impl Db for MockDb {
         Box::pin(future::ok(results::GetOrCreateUser::default()))
     }
 
+    fn get_service_id(&self, _params: params::GetServiceId) -> DbFuture<'_, results::GetServiceId> {
+        Box::pin(future::ok(results::GetServiceId::default()))
+    }
+
     #[cfg(test)]
     fn set_user_created_at(
         &self,

--- a/src/tokenserver/db/mod.rs
+++ b/src/tokenserver/db/mod.rs
@@ -3,6 +3,3 @@ pub mod models;
 pub mod params;
 pub mod pool;
 pub mod results;
-
-pub const SYNC_1_1_SERVICE_ID: i32 = 1;
-pub const SYNC_1_5_SERVICE_ID: i32 = 2;

--- a/src/tokenserver/db/params.rs
+++ b/src/tokenserver/db/params.rs
@@ -92,6 +92,11 @@ pub struct AddUserToNode {
     pub node: String,
 }
 
+// #[derive(Default)]
+pub struct GetServiceId {
+    pub service: String,
+}
+
 #[cfg(test)]
 pub struct SetUserCreatedAt {
     pub uid: i64,

--- a/src/tokenserver/db/params.rs
+++ b/src/tokenserver/db/params.rs
@@ -92,7 +92,6 @@ pub struct AddUserToNode {
     pub node: String,
 }
 
-// #[derive(Default)]
 pub struct GetServiceId {
     pub service: String,
 }

--- a/src/tokenserver/db/pool.rs
+++ b/src/tokenserver/db/pool.rs
@@ -63,12 +63,18 @@ impl TokenserverPool {
         })
     }
 
+    pub fn get_sync(&self) -> Result<TokenserverDb, DbError> {
+        let conn = self.inner.get().map_err(DbError::from)?;
+
+        Ok(TokenserverDb::new(conn))
+    }
+
     #[cfg(test)]
-    pub async fn get_tokenserver_db(&self) -> Result<Box<TokenserverDb>, DbError> {
+    pub async fn get_tokenserver_db(&self) -> Result<TokenserverDb, DbError> {
         let pool = self.clone();
         let conn = block(move || pool.inner.get().map_err(DbError::from)).await?;
 
-        Ok(Box::new(TokenserverDb::new(conn)))
+        Ok(TokenserverDb::new(conn))
     }
 }
 

--- a/src/tokenserver/db/results.rs
+++ b/src/tokenserver/db/results.rs
@@ -1,11 +1,8 @@
 use diesel::{
-    sql_types::{Bigint, Nullable, Text},
+    sql_types::{Bigint, Integer, Nullable, Text},
     QueryableByName,
 };
 use serde::{Deserialize, Serialize};
-
-#[cfg(test)]
-use diesel::sql_types::Integer;
 
 /// Represents a user record as it is stored in the database.
 #[derive(Clone, Debug, Default, Deserialize, QueryableByName, Serialize)]
@@ -52,11 +49,12 @@ pub struct GetOrCreateUser {
 }
 
 #[derive(Default, QueryableByName)]
-pub struct PostUser {
+pub struct LastInsertId {
     #[sql_type = "Bigint"]
     pub id: i64,
 }
 
+pub type PostUser = LastInsertId;
 pub type ReplaceUsers = ();
 pub type ReplaceUser = ();
 pub type PutUser = ();
@@ -76,6 +74,12 @@ pub struct GetBestNode {
 }
 
 pub type AddUserToNode = ();
+
+#[derive(Default, QueryableByName)]
+pub struct GetServiceId {
+    #[sql_type = "Integer"]
+    pub id: i32,
+}
 
 #[cfg(test)]
 #[derive(Debug, Default, PartialEq, QueryableByName)]
@@ -99,11 +103,7 @@ pub struct GetUser {
 }
 
 #[cfg(test)]
-#[derive(Default, QueryableByName)]
-pub struct PostNode {
-    #[sql_type = "Bigint"]
-    pub id: i64,
-}
+pub type PostNode = LastInsertId;
 
 #[cfg(test)]
 #[derive(Default, QueryableByName)]

--- a/src/tokenserver/extractors.rs
+++ b/src/tokenserver/extractors.rs
@@ -1027,7 +1027,7 @@ mod tests {
             db_pool: Box::new(MockTokenserverPool::new()),
             node_capacity_release_rate: None,
             node_type: NodeType::default(),
-            service_id: i32::default(),
+            service_id: None,
         }
     }
 }

--- a/src/tokenserver/migrations/2021-12-22-160451_remove_services/down.sql
+++ b/src/tokenserver/migrations/2021-12-22-160451_remove_services/down.sql
@@ -1,0 +1,3 @@
+INSERT INTO services (id, service, pattern) VALUES
+    (1, "sync-1.1", "{node}/1.1/{uid}"),
+    (2, "sync-1.5", "{node}/1.5/{uid}");

--- a/src/tokenserver/migrations/2021-12-22-160451_remove_services/up.sql
+++ b/src/tokenserver/migrations/2021-12-22-160451_remove_services/up.sql
@@ -1,0 +1,3 @@
+DELETE FROM services
+      WHERE id=1 
+         OR id=2;

--- a/src/tokenserver/mod.rs
+++ b/src/tokenserver/mod.rs
@@ -47,7 +47,7 @@ impl ServerState {
         let use_test_transactions = false;
 
         TokenserverPool::new(settings, use_test_transactions)
-            .and_then(|db_pool| {
+            .map(|db_pool| {
                 let service_id = db_pool
                     .get_sync()
                     .and_then(|db| {
@@ -58,7 +58,7 @@ impl ServerState {
                     .ok()
                     .map(|result| result.id);
 
-                Ok(ServerState {
+                ServerState {
                     fxa_email_domain: settings.fxa_email_domain.clone(),
                     fxa_metrics_hash_secret: settings.fxa_metrics_hash_secret.clone(),
                     oauth_verifier,
@@ -66,7 +66,7 @@ impl ServerState {
                     node_capacity_release_rate: settings.node_capacity_release_rate,
                     node_type: settings.node_type,
                     service_id,
-                })
+                }
             })
             .map_err(Into::into)
     }

--- a/src/tokenserver/mod.rs
+++ b/src/tokenserver/mod.rs
@@ -7,7 +7,10 @@ pub mod support;
 
 pub use self::support::{MockOAuthVerifier, OAuthVerifier, TestModeOAuthVerifier, VerifyToken};
 
-use db::pool::{DbPool, TokenserverPool};
+use db::{
+    params,
+    pool::{DbPool, TokenserverPool},
+};
 use serde::{Deserialize, Serialize};
 use settings::Settings;
 
@@ -21,6 +24,7 @@ pub struct ServerState {
     pub oauth_verifier: Box<dyn VerifyToken>,
     pub node_capacity_release_rate: Option<f32>,
     pub node_type: NodeType,
+    pub service_id: Option<i32>,
 }
 
 impl ServerState {
@@ -43,13 +47,26 @@ impl ServerState {
         let use_test_transactions = false;
 
         TokenserverPool::new(settings, use_test_transactions)
-            .map(|db_pool| ServerState {
-                fxa_email_domain: settings.fxa_email_domain.clone(),
-                fxa_metrics_hash_secret: settings.fxa_metrics_hash_secret.clone(),
-                oauth_verifier,
-                db_pool: Box::new(db_pool),
-                node_capacity_release_rate: settings.node_capacity_release_rate,
-                node_type: settings.node_type,
+            .and_then(|db_pool| {
+                let service_id = db_pool
+                    .get_sync()
+                    .and_then(|db| {
+                        db.get_service_id_sync(params::GetServiceId {
+                            service: "sync-1.5".to_owned(),
+                        })
+                    })
+                    .ok()
+                    .map(|result| result.id);
+
+                Ok(ServerState {
+                    fxa_email_domain: settings.fxa_email_domain.clone(),
+                    fxa_metrics_hash_secret: settings.fxa_metrics_hash_secret.clone(),
+                    oauth_verifier,
+                    db_pool: Box::new(db_pool),
+                    node_capacity_release_rate: settings.node_capacity_release_rate,
+                    node_type: settings.node_type,
+                    service_id,
+                })
             })
             .map_err(Into::into)
     }

--- a/tools/integration_tests/tokenserver/test_misc.py
+++ b/tools/integration_tests/tokenserver/test_misc.py
@@ -144,7 +144,7 @@ class TestMisc(TestCase, unittest.TestCase):
         self.assertEqual(user['client_state'], '616161')
         # Get all the replaced users
         email = 'test@%s' % self.FXA_EMAIL_DOMAIN
-        replaced_users = self._get_replaced_users(self.SYNC_1_5_SERVICE_ID,
+        replaced_users = self._get_replaced_users(self.service_id,
                                                   email)
         # Only one user should be replaced
         self.assertEqual(len(replaced_users), 1)

--- a/tools/integration_tests/tokenserver/test_node_assignment.py
+++ b/tools/integration_tests/tokenserver/test_node_assignment.py
@@ -33,7 +33,7 @@ class TestNodeAssignment(TestCase, unittest.TestCase):
         self.assertEqual(user1['keys_changed_at'], 1234)
         self.assertEqual(user1['client_state'], '616161')
         self.assertEqual(user1['nodeid'], self.NODE_ID)
-        self.assertEqual(user1['service'], self.SYNC_1_5_SERVICE_ID)
+        self.assertEqual(user1['service'], self.service_id)
         # Ensure the 'available' and 'current_load' counts on the node
         # assigned to the user have been decremented appropriately
         node = self._get_node(self.NODE_ID)

--- a/tools/tokenserver/database.py
+++ b/tools/tokenserver/database.py
@@ -480,7 +480,7 @@ class Database:
     #
 
     def _get_service_id(self, service):
-        if self.service_id:
+        if hasattr(self, 'service_id'):
             return self.service_id
         else:
             res = self._execute_sql(_GET_SERVICE_ID, service=service)

--- a/tools/tokenserver/database.py
+++ b/tools/tokenserver/database.py
@@ -239,7 +239,8 @@ class Database:
         self.database.close()
 
     def get_user(self, email):
-        params = {'service': self._get_service_id(SERVICE_NAME), 'email': email}
+        params = {'service': self._get_service_id(SERVICE_NAME),
+                  'email': email}
         res = self._execute_sql(_GET_USER_RECORDS, **params)
         try:
             # The query fetches rows ordered by created_at, but we want
@@ -374,9 +375,9 @@ class Database:
                 keys_changed_at = user['keys_changed_at']
             now = get_timestamp()
             params = {
-                'service': self._get_service_id(SERVICE_NAME), 'email': user['email'],
-                'nodeid': nodeid, 'generation': generation,
-                'keys_changed_at': keys_changed_at,
+                'service': self._get_service_id(SERVICE_NAME),
+                'email': user['email'], 'nodeid': nodeid,
+                'generation': generation, 'keys_changed_at': keys_changed_at,
                 'client_state': client_state, 'timestamp': now,
             }
             res = self._execute_sql(_CREATE_USER_RECORD, **params)
@@ -416,7 +417,8 @@ class Database:
 
     def get_user_records(self, email):
         """Get all the user's records, including the old ones."""
-        params = {'service': self._get_service_id(SERVICE_NAME), 'email': email}
+        params = {'service': self._get_service_id(SERVICE_NAME),
+                  'email': email}
         res = self._execute_sql(_GET_ALL_USER_RECORDS_FOR_SERVICE, **params)
         try:
             for row in res:
@@ -448,7 +450,8 @@ class Database:
         if timestamp is None:
             timestamp = get_timestamp()
         params = {
-            'service': self._get_service_id(SERVICE_NAME), 'email': email, 'timestamp': timestamp
+            'service': self._get_service_id(SERVICE_NAME), 'email': email,
+            'timestamp': timestamp
         }
         res = self._execute_sql(_REPLACE_USER_RECORDS, **params)
         res.close()
@@ -458,7 +461,8 @@ class Database:
         if timestamp is None:
             timestamp = get_timestamp()
         params = {
-            'service': self._get_service_id(SERVICE_NAME), 'uid': uid, 'timestamp': timestamp
+            'service': self._get_service_id(SERVICE_NAME), 'uid': uid,
+            'timestamp': timestamp
         }
         res = self._execute_sql(_REPLACE_USER_RECORD, **params)
         res.close()
@@ -602,7 +606,8 @@ class Database:
         # We may have to re-try the query if we need to release more capacity.
         # This loop allows a maximum of five retries before bailing out.
         for _ in range(5):
-            res = self._execute_sql(_GET_BEST_NODE, service=self._get_service_id(SERVICE_NAME))
+            res = self._execute_sql(_GET_BEST_NODE,
+                                    service=self._get_service_id(SERVICE_NAME))
             row = res.fetchone()
             res.close()
             if row is None:
@@ -637,7 +642,9 @@ class Database:
         return nodeid, node
 
     def get_node(self, node):
-        res = self._execute_sql(_GET_NODE, service=self._get_service_id(SERVICE_NAME), node=node)
+        res = self._execute_sql(_GET_NODE,
+                                service=self._get_service_id(SERVICE_NAME),
+                                node=node)
         row = res.fetchone()
         res.close()
         if row is None:

--- a/tools/tokenserver/test_database.py
+++ b/tools/tokenserver/test_database.py
@@ -21,6 +21,10 @@ class TestDatabase(unittest.TestCase):
         cursor = self.database._execute_sql(('DELETE FROM nodes'), ())
         cursor.close()
 
+        cursor = self.database._execute_sql(('DELETE FROM services'), ())
+        cursor.close()
+
+        self.database.add_service('sync-1.5', r'{node}/1.5/{uid}')
         self.database.add_node('https://phx12', 100)
 
     def tearDown(self):
@@ -30,6 +34,9 @@ class TestDatabase(unittest.TestCase):
         cursor.close()
 
         cursor = self.database._execute_sql(('DELETE FROM nodes'), ())
+        cursor.close()
+
+        cursor = self.database._execute_sql(('DELETE FROM services'), ())
         cursor.close()
 
         self.database.close()

--- a/tools/tokenserver/test_process_account_events.py
+++ b/tools/tokenserver/test_process_account_events.py
@@ -33,6 +33,7 @@ class TestProcessAccountEvents(unittest.TestCase):
 
     def setUp(self):
         self.database = Database()
+        self.database.add_service('sync-1.5', r'{node}/1.5/{uid}')
         self.database.add_node("https://phx12", 100)
         self.logs = LogCapture()
 
@@ -40,11 +41,14 @@ class TestProcessAccountEvents(unittest.TestCase):
         self.logs.uninstall()
         testing.tearDown()
 
+        cursor = self.database._execute_sql('DELETE FROM users')
+        cursor.close
+
         cursor = self.database._execute_sql('DELETE FROM nodes')
         cursor.close()
 
-        cursor = self.database._execute_sql('DELETE FROM users')
-        cursor.close
+        cursor = self.database._execute_sql('DELETE FROM services')
+        cursor.close()
 
     def assertMessageWasLogged(self, msg):
         """Check that a metric was logged during the request."""

--- a/tools/tokenserver/test_purge_old_records.py
+++ b/tools/tokenserver/test_purge_old_records.py
@@ -41,13 +41,17 @@ class TestPurgeOldRecords(unittest.TestCase):
 
         # Configure the node-assignment backend to talk to our test service.
         self.database = Database()
+        self.database.add_service('sync-1.5', r'{node}/1.5/{uid}')
         self.database.add_node(self.service_node, 100)
 
     def tearDown(self):
+        cursor = self.database._execute_sql('DELETE FROM users')
+        cursor.close()
+
         cursor = self.database._execute_sql('DELETE FROM nodes')
         cursor.close()
 
-        cursor = self.database._execute_sql('DELETE FROM users')
+        cursor = self.database._execute_sql('DELETE FROM services')
         cursor.close()
 
         del self.service_requests[:]

--- a/tools/tokenserver/test_scripts.py
+++ b/tools/tokenserver/test_scripts.py
@@ -31,6 +31,12 @@ class TestScripts(unittest.TestCase):
         cursor = self.database._execute_sql('DELETE FROM nodes')
         cursor.close()
 
+        cursor = self.database._execute_sql('DELETE FROM services')
+        cursor.close()
+
+        # Add a service
+        self.database.add_service('sync-1.5', r'{node}/1.5/{uid}')
+
         # Ensure we have a node with enough capacity to run the tests.
         self.database.add_node(self.NODE_URL, 100, id=self.NODE_ID)
 
@@ -40,6 +46,9 @@ class TestScripts(unittest.TestCase):
         cursor.close()
 
         cursor = self.database._execute_sql('DELETE FROM nodes')
+        cursor.close()
+
+        cursor = self.database._execute_sql('DELETE FROM services')
         cursor.close()
 
         self.database.close()

--- a/tools/tokenserver/test_scripts.py
+++ b/tools/tokenserver/test_scripts.py
@@ -35,7 +35,8 @@ class TestScripts(unittest.TestCase):
         cursor.close()
 
         # Add a service
-        self.database.add_service('sync-1.5', r'{node}/1.5/{uid}')
+        self.service_id = self.database.add_service('sync-1.5',
+                                                    r'{node}/1.5/{uid}')
 
         # Ensure we have a node with enough capacity to run the tests.
         self.database.add_node(self.NODE_URL, 100, id=self.NODE_ID)

--- a/tools/tokenserver/test_scripts.py
+++ b/tools/tokenserver/test_scripts.py
@@ -35,8 +35,7 @@ class TestScripts(unittest.TestCase):
         cursor.close()
 
         # Add a service
-        self.service_id = self.database.add_service('sync-1.5',
-                                                    r'{node}/1.5/{uid}')
+        self.database.add_service('sync-1.5', r'{node}/1.5/{uid}')
 
         # Ensure we have a node with enough capacity to run the tests.
         self.database.add_node(self.NODE_URL, 100, id=self.NODE_ID)


### PR DESCRIPTION
## Description

Removes the two statically-defined services from the database via a new migration. Makes updates to the application code and integration tests to reflect the change in schema.

## Testing

Passing unit and integration tests should sufficiently show that the change was successful.

## Issue(s)

Closes #1144