### PR TITLE
bug: fix Tokenserver metrics

### DIFF
--- a/src/server/metrics.rs
+++ b/src/server/metrics.rs
@@ -23,9 +23,9 @@ pub struct MetricTimer {
 
 #[derive(Debug, Clone)]
 pub struct Metrics {
-    client: Option<StatsdClient>,
-    tags: Option<Tags>,
-    timer: Option<MetricTimer>,
+    pub client: Option<StatsdClient>,
+    pub tags: Option<Tags>,
+    pub timer: Option<MetricTimer>,
 }
 
 impl Drop for Metrics {

--- a/src/server/metrics.rs
+++ b/src/server/metrics.rs
@@ -63,21 +63,27 @@ impl FromRequest for Metrics {
     type Future = Ready<Result<Self, Self::Error>>;
 
     fn from_request(req: &HttpRequest, _: &mut Payload) -> Self::Future {
-        let exts = req.extensions();
-        let def_tags = Tags::from(req.head());
-        let tags = exts.get::<Tags>().unwrap_or(&def_tags);
+        future::ok(metrics_from_request(
+            req,
+            req.app_data::<Data<ServerState>>()
+                .map(|state| state.metrics.clone()),
+        ))
+    }
+}
 
-        future::ok(Metrics {
-            client: match req.app_data::<Data<ServerState>>() {
-                Some(v) => Some(*v.metrics.clone()),
-                None => {
-                    warn!("⚠️ metric error: No App State");
-                    None
-                }
-            },
-            tags: Some(tags.clone()),
-            timer: None,
-        })
+pub fn metrics_from_request(req: &HttpRequest, client: Option<Box<StatsdClient>>) -> Metrics {
+    let exts = req.extensions();
+    let def_tags = Tags::from(req.head());
+    let tags = exts.get::<Tags>().unwrap_or(&def_tags);
+
+    if client.is_none() {
+        warn!("⚠️ metric error: No App State");
+    }
+
+    Metrics {
+        client: client.as_deref().cloned(),
+        tags: Some(tags.clone()),
+        timer: None,
     }
 }
 

--- a/src/tokenserver/extractors.rs
+++ b/src/tokenserver/extractors.rs
@@ -12,7 +12,7 @@ use actix_web::{
     Error, FromRequest, HttpRequest,
 };
 use actix_web_httpauth::extractors::bearer::BearerAuth;
-use futures::future::LocalBoxFuture;
+use futures::future::{self, LocalBoxFuture, Ready};
 use hmac::{Hmac, Mac, NewMac};
 use lazy_static::lazy_static;
 use regex::Regex;
@@ -22,9 +22,10 @@ use sha2::Sha256;
 use super::db::{models::Db, params, pool::DbPool, results};
 use super::error::{ErrorLocation, TokenserverError};
 use super::support::TokenData;
-use super::{LogItemsMutator, NodeType, ServerState};
+use super::{LogItemsMutator, NodeType, ServerState, TokenserverMetrics};
 use crate::server::metrics::Metrics;
 use crate::settings::Secrets;
+use crate::web::tags::Tags;
 
 lazy_static! {
     static ref CLIENT_STATE_REGEX: Regex = Regex::new("^[a-zA-Z0-9._-]{1,32}$").unwrap();
@@ -329,7 +330,7 @@ impl FromRequest for TokenData {
             let state = get_server_state(&req)?.as_ref().as_ref().unwrap();
             let oauth_verifier = state.oauth_verifier.clone();
 
-            let mut metrics = Metrics::extract(&req).await?;
+            let TokenserverMetrics(mut metrics) = TokenserverMetrics::extract(&req).await?;
             metrics.start_timer("tokenserver.oauth_token_verification", None);
 
             web::block(move || oauth_verifier.verify_token(auth.token()))
@@ -414,6 +415,32 @@ impl FromRequest for KeyId {
             Ok(KeyId {
                 client_state,
                 keys_changed_at,
+            })
+        })
+    }
+}
+
+impl FromRequest for TokenserverMetrics {
+    type Config = ();
+    type Error = Error;
+    type Future = Ready<Result<Self, Self::Error>>;
+
+    fn from_request(req: &HttpRequest, _payload: &mut Payload) -> Self::Future {
+        let exts = req.extensions();
+        let def_tags = Tags::from(req.head());
+        let tags = exts.get::<Tags>().unwrap_or(&def_tags);
+        let state = match get_server_state(req) {
+            // XXX: Tokenserver state will no longer be an Option once the Tokenserver
+            // code is rolled out, so we will eventually be able to remove this unwrap().
+            Ok(state) => state.as_ref().as_ref().unwrap(),
+            Err(e) => return future::err(e),
+        };
+
+        future::ok({
+            TokenserverMetrics(Metrics {
+                client: Some(*state.metrics.clone()),
+                tags: Some(tags.clone()),
+                timer: None,
             })
         })
     }

--- a/src/tokenserver/extractors.rs
+++ b/src/tokenserver/extractors.rs
@@ -23,9 +23,8 @@ use super::db::{models::Db, params, pool::DbPool, results};
 use super::error::{ErrorLocation, TokenserverError};
 use super::support::TokenData;
 use super::{LogItemsMutator, NodeType, ServerState, TokenserverMetrics};
-use crate::server::metrics::Metrics;
+use crate::server::metrics;
 use crate::settings::Secrets;
-use crate::web::tags::Tags;
 
 lazy_static! {
     static ref CLIENT_STATE_REGEX: Regex = Regex::new("^[a-zA-Z0-9._-]{1,32}$").unwrap();
@@ -426,9 +425,6 @@ impl FromRequest for TokenserverMetrics {
     type Future = Ready<Result<Self, Self::Error>>;
 
     fn from_request(req: &HttpRequest, _payload: &mut Payload) -> Self::Future {
-        let exts = req.extensions();
-        let def_tags = Tags::from(req.head());
-        let tags = exts.get::<Tags>().unwrap_or(&def_tags);
         let state = match get_server_state(req) {
             // XXX: Tokenserver state will no longer be an Option once the Tokenserver
             // code is rolled out, so we will eventually be able to remove this unwrap().
@@ -436,13 +432,10 @@ impl FromRequest for TokenserverMetrics {
             Err(e) => return future::err(e),
         };
 
-        future::ok({
-            TokenserverMetrics(Metrics {
-                client: Some(*state.metrics.clone()),
-                tags: Some(tags.clone()),
-                timer: None,
-            })
-        })
+        future::ok(TokenserverMetrics(metrics::metrics_from_request(
+            req,
+            Some(state.metrics.clone()),
+        )))
     }
 }
 

--- a/src/tokenserver/mod.rs
+++ b/src/tokenserver/mod.rs
@@ -85,6 +85,8 @@ impl ServerState {
     }
 }
 
+pub struct TokenserverMetrics(Metrics);
+
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub enum NodeType {
     #[serde(rename = "mysql")]


### PR DESCRIPTION
## Description

Adds a `TokenserverMetrics` wrapper type to allow for a Tokenserver-specific `FromRequest` impl for `Metrics` (the existing impl doesn't work because it looks for the `Metrics` object in the syncstorage `ServerState` instead of the Tokenserver `ServerState`

## Testing

I tested this by running Tokenserver, sending a request, and ensuring that the "metric error: No App State" error message was no longer being logged.

## Issue(s)

Closes #1214
