### PR TITLE
refactor: use the builder pattern for `TokenserverError`s

### DIFF
--- a/src/tokenserver/auth/browserid.rs
+++ b/src/tokenserver/auth/browserid.rs
@@ -77,7 +77,7 @@ impl VerifyToken for RemoteVerifier {
             })?;
 
         if response.status() != StatusCode::OK {
-            return Err(TokenserverError::resource_unavailable());
+            return Err(ErrorBuilder::resource_unavailable().build());
         }
 
         // If FxA responds with an invalid response body, report a 503 to the client

--- a/src/tokenserver/auth/mod.rs
+++ b/src/tokenserver/auth/mod.rs
@@ -9,7 +9,7 @@ use pyo3::{
     types::IntoPyDict,
 };
 
-use super::error::TokenserverError;
+use super::error::{TokenserverError, TokenserverErrorBuilder as ErrorBuilder};
 use crate::error::{ApiError, ApiErrorKind};
 
 /// The plaintext needed to build a token.
@@ -112,7 +112,7 @@ impl<T: Clone + Send + Sync> VerifyToken for MockVerifier<T> {
     async fn verify(&self, _token: String) -> Result<T, TokenserverError> {
         self.valid
             .then(|| self.verify_output.clone())
-            .ok_or_else(|| TokenserverError::invalid_credentials("Unauthorized"))
+            .ok_or_else(|| ErrorBuilder::invalid_credentials("Unauthorized").build())
     }
 }
 

--- a/src/tokenserver/extractors.rs
+++ b/src/tokenserver/extractors.rs
@@ -535,6 +535,7 @@ impl FromRequest for KeyId {
                     if x_client_state != client_state_hex {
                         return Err(ErrorBuilder::invalid_client_state()
                             .in_body()
+                            .name("".to_owned())
                             .build()
                             .into());
                     }
@@ -930,7 +931,7 @@ mod tests {
             let response: HttpResponse = KeyId::extract(&request).await.unwrap_err().into();
             assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
 
-            let expected_error = ErrorBuilder::invalid_client_state().in_body().build();
+            let expected_error = ErrorBuilder::invalid_client_state().in_body().name("".to_owned()).build();
             let body = extract_body_as_str(ServiceResponse::new(request, response));
             assert_eq!(body, serde_json::to_string(&expected_error).unwrap());
         }

--- a/src/tokenserver/extractors.rs
+++ b/src/tokenserver/extractors.rs
@@ -931,7 +931,10 @@ mod tests {
             let response: HttpResponse = KeyId::extract(&request).await.unwrap_err().into();
             assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
 
-            let expected_error = ErrorBuilder::invalid_client_state().in_body().name("".to_owned()).build();
+            let expected_error = ErrorBuilder::invalid_client_state()
+                .in_body()
+                .name("".to_owned())
+                .build();
             let body = extract_body_as_str(ServiceResponse::new(request, response));
             assert_eq!(body, serde_json::to_string(&expected_error).unwrap());
         }

--- a/src/tokenserver/handlers.rs
+++ b/src/tokenserver/handlers.rs
@@ -14,7 +14,7 @@ use super::{
         models::Db,
         params::{GetNodeId, PostUser, PutUser, ReplaceUsers},
     },
-    error::TokenserverError,
+    error::{TokenserverError, TokenserverErrorBuilder as ErrorBuilder},
     extractors::TokenserverRequest,
     NodeType,
 };
@@ -71,7 +71,7 @@ fn get_token_plaintext(
         let client_state = hex::decode(req.auth_data.client_state.clone()).map_err(|_| {
             error!("⚠️ Failed to decode client state hex");
 
-            TokenserverError::internal_error()
+            ErrorBuilder::internal().build()
         })?;
         let client_state_b64 = base64::encode_config(&client_state, base64::URL_SAFE_NO_PAD);
 


### PR DESCRIPTION
## Description

* Add a `TokenserverErrorBuilder` type to improve the construction of `TokenserverError`s
* Make `ErrorLocation` private to the `tokenserver::error` module
* Make the fields of `TokenserverError` private

## Testing

N/A

## Issue(s)

Closes #1220 
