### PR TITLE
shell.nix: fix for recent grpc

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -6,6 +6,7 @@
 with import <nixpkgs> {};
 stdenv.mkDerivation {
   name = "syncstorage-rs";
+
   buildInputs = [
     rustc
     cargo
@@ -15,6 +16,13 @@ stdenv.mkDerivation {
     cmake
     protobuf
     go
+    grpc
   ];
+
+  # grpc otherwise fails since it's build with `-Wall`
+  hardeningDisable = [ "all" ];
+
+  GRPCIO_SYS_USE_PKG_CONFIG = 1;
+
   NIX_LDFLAGS = "-L${libmysqlclient}/lib/mysql";
 }


### PR DESCRIPTION
## Description

see title

## Testing

If you use nix, you can run `nix-shell` and `cargo build`

## Issue(s)

-
