### PR TITLE
bug: add missing Tokenserver headers

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -312,7 +312,6 @@ impl Server {
         });
 
         let server = server
-            .keep_alive(None)
             .bind(format!("{}:{}", host, port))
             .expect("Could not get Server in Server::with_settings")
             .run();

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -312,6 +312,7 @@ impl Server {
         });
 
         let server = server
+            .keep_alive(None)
             .bind(format!("{}:{}", host, port))
             .expect("Could not get Server in Server::with_settings")
             .run();

--- a/src/tokenserver/handlers.rs
+++ b/src/tokenserver/handlers.rs
@@ -50,7 +50,13 @@ pub async fn get_tokenserver_result(
         node_type: req.node_type,
     };
 
-    Ok(HttpResponse::build(StatusCode::OK).json(result))
+    let timestamp = {
+        let start = SystemTime::now();
+        start.duration_since(UNIX_EPOCH).unwrap().as_secs()
+    };
+    Ok(HttpResponse::build(StatusCode::OK)
+        .header("X-Timestamp", timestamp.to_string())
+        .json(result))
 }
 
 fn get_token_plaintext(

--- a/src/tokenserver/handlers.rs
+++ b/src/tokenserver/handlers.rs
@@ -54,6 +54,10 @@ pub async fn get_tokenserver_result(
         let start = SystemTime::now();
         start.duration_since(UNIX_EPOCH).unwrap().as_secs()
     };
+
+    // `X-Content-Type-Options: nosniff` was set automatically by the Pyramid cornice library
+    // on the Python Tokenserver. For the Rust Tokenserver, we set it in nginx instead of in the
+    // application code here.
     Ok(HttpResponse::build(StatusCode::OK)
         .header("X-Timestamp", timestamp.to_string())
         .json(result))

--- a/src/tokenserver/handlers.rs
+++ b/src/tokenserver/handlers.rs
@@ -55,9 +55,7 @@ pub async fn get_tokenserver_result(
         start.duration_since(UNIX_EPOCH).unwrap().as_secs()
     };
     Ok(HttpResponse::build(StatusCode::OK)
-        .header("X-Content-Type-Options", "nosniff")
         .header("X-Timestamp", timestamp.to_string())
-        .force_close()
         .json(result))
 }
 

--- a/src/tokenserver/handlers.rs
+++ b/src/tokenserver/handlers.rs
@@ -55,7 +55,9 @@ pub async fn get_tokenserver_result(
         start.duration_since(UNIX_EPOCH).unwrap().as_secs()
     };
     Ok(HttpResponse::build(StatusCode::OK)
+        .header("X-Content-Type-Options", "nosniff")
         .header("X-Timestamp", timestamp.to_string())
+        .force_close()
         .json(result))
 }
 

--- a/tools/integration_tests/tokenserver/test_e2e.py
+++ b/tools/integration_tests/tokenserver/test_e2e.py
@@ -206,3 +206,7 @@ class TestE2e(TestCase, unittest.TestCase):
         self.assertEqual(res.json['hashed_fxa_uid'],
                          self._fxa_metrics_hash(fxa_uid)[:32])
         self.assertEqual(res.json['node_type'], 'spanner')
+        # The response should have an X-Timestamp header that contains the
+        # number of seconds since the UNIX epoch
+        self.assertIn('X-Timestamp', res.headers)
+        self.assertIsNotNone(int(res.headers['X-Timestamp']))

--- a/tools/integration_tests/tokenserver/test_e2e.py
+++ b/tools/integration_tests/tokenserver/test_e2e.py
@@ -210,3 +210,7 @@ class TestE2e(TestCase, unittest.TestCase):
         # number of seconds since the UNIX epoch
         self.assertIn('X-Timestamp', res.headers)
         self.assertIsNotNone(int(res.headers['X-Timestamp']))
+        # Tokenserver does not support keepalive
+        self.assertEqual(res.headers['Connection'], 'close')
+        # The client should not try to sniff the MIME type
+        self.assertEqual(res.headers['X-Content-Type-Options'], 'nosniff')

--- a/tools/integration_tests/tokenserver/test_e2e.py
+++ b/tools/integration_tests/tokenserver/test_e2e.py
@@ -210,7 +210,3 @@ class TestE2e(TestCase, unittest.TestCase):
         # number of seconds since the UNIX epoch
         self.assertIn('X-Timestamp', res.headers)
         self.assertIsNotNone(int(res.headers['X-Timestamp']))
-        # Tokenserver does not support keepalive
-        self.assertEqual(res.headers['Connection'], 'close')
-        # The client should not try to sniff the MIME type
-        self.assertEqual(res.headers['X-Content-Type-Options'], 'nosniff')


### PR DESCRIPTION
## Description

Adds the missing `X-Timestamp` to responses from Tokenserver. The python equivalent can be found [here](https://github.com/mozilla-services/tokenserver/blob/master/tokenserver%2Ftweens.py#L13). I also double-checked the response from the Python Tokenserver to ensure there weren't any other missing headers that should be added here.

## Testing
I added new integration tests to check for the new headers.

## Issue(s)
Closes #1242
