### PR TITLE
feat: pass Tokenserver origin field through token payload

### DIFF
--- a/src/server/metrics.rs
+++ b/src/server/metrics.rs
@@ -143,6 +143,10 @@ impl Metrics {
         self.count_with_tags(label, 1, tags)
     }
 
+    pub fn incr_with_tag(&self, label: &str, key: &str, value: &str) {
+        self.incr_with_tags(label, Some(Tags::with_tag(key, value)))
+    }
+
     pub fn count(&self, label: &str, count: i64) {
         self.count_with_tags(label, count, None)
     }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -77,6 +77,7 @@ macro_rules! build_app {
             .wrap(middleware::sentry::SentryWrapper::default())
             .wrap(middleware::rejectua::RejectUA::default())
             .wrap($cors)
+            .wrap_fn(middleware::emit_http_status_with_tokenserver_origin)
             .service(
                 web::resource(&cfg_path("/info/collections"))
                     .route(web::get().to(handlers::get_collections)),

--- a/src/server/test.rs
+++ b/src/server/test.rs
@@ -147,6 +147,7 @@ fn create_hawk_header(method: &str, port: u16, path: &str) -> String {
         fxa_uid: format!("xxx_test_uid_{}", *RAND_UID),
         fxa_kid: format!("xxx_test_kid_{}", *RAND_UID),
         device_id: "xxx_test".to_owned(),
+        tokenserver_origin: Default::default(),
     };
     let payload =
         serde_json::to_string(&payload).expect("Could not get payload in create_hawk_header");

--- a/src/tokenserver/handlers.rs
+++ b/src/tokenserver/handlers.rs
@@ -9,7 +9,7 @@ use serde::Serialize;
 use serde_json::Value;
 
 use super::{
-    auth::{MakeTokenPlaintext, Tokenlib},
+    auth::{MakeTokenPlaintext, Tokenlib, TokenserverOrigin},
     db::{
         models::Db,
         params::{GetNodeId, PostUser, PutUser, ReplaceUsers},
@@ -104,6 +104,7 @@ fn get_token_plaintext(
         hashed_fxa_uid: req.hashed_fxa_uid.clone(),
         expires,
         uid: updates.uid.to_owned(),
+        tokenserver_origin: TokenserverOrigin::Rust,
     })
 }
 

--- a/src/web/auth.rs
+++ b/src/web/auth.rs
@@ -25,13 +25,11 @@ use super::{
 };
 use crate::error::{ApiErrorKind, ApiResult};
 use crate::settings::Secrets;
+use crate::tokenserver::auth::TokenserverOrigin;
 
 /// A parsed and authenticated JSON payload
 /// extracted from the signed `id` property
 /// of a Hawk `Authorization` header.
-///
-/// Not included here are the `fxa_uid` and `device_id` properties,
-/// which may also be present in the JSON payload.
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub struct HawkPayload {
     /// Expiry time for the payload, in seconds.
@@ -55,6 +53,10 @@ pub struct HawkPayload {
 
     #[serde(default, rename = "hashed_device_id")]
     pub device_id: String,
+
+    /// The Tokenserver that created this token.
+    #[serde(default)]
+    pub tokenserver_origin: TokenserverOrigin,
 }
 
 impl HawkPayload {
@@ -152,6 +154,7 @@ impl HawkPayload {
             fxa_uid: "xxx_test".to_owned(),
             fxa_kid: "xxx_test".to_owned(),
             device_id: "xxx_test".to_owned(),
+            tokenserver_origin: Default::default(),
         }
     }
 }
@@ -522,6 +525,7 @@ mod tests {
                     fxa_uid: "319b98f9961ff1dbdd07313cd6ba925a".to_owned(),
                     fxa_kid: "de697ad66d845b2873c9d7e13b8971af".to_owned(),
                     device_id: "2bcb92f4d4698c3d7b083a3c698a16ccd78bc2a8d20a96e4bb128ddceaf4e0b6".to_owned(),
+                    tokenserver_origin: Default::default(),
                 },
             }
         }

--- a/src/web/middleware/mod.rs
+++ b/src/web/middleware/mod.rs
@@ -6,14 +6,19 @@ pub mod weave;
 //
 // Matches the [Sync Storage middleware](https://github.com/mozilla-services/server-syncstorage/blob/master/syncstorage/tweens.py) (tweens).
 
-use std::sync::Arc;
+use std::{future::Future, sync::Arc};
 
-use actix_web::{dev::ServiceRequest, Error, HttpRequest};
+use actix_web::{
+    dev::{Service, ServiceRequest, ServiceResponse},
+    Error, HttpRequest,
+};
 
 use crate::db::util::SyncTimestamp;
 use crate::error::{ApiError, ApiErrorKind};
+use crate::server::{metrics::Metrics, ServerState};
 use crate::settings::Secrets;
-use crate::web::{extractors::HawkIdentifier, DOCKER_FLOW_ENDPOINTS};
+use crate::tokenserver::auth::TokenserverOrigin;
+use crate::web::{extractors::HawkIdentifier, tags::Tags, DOCKER_FLOW_ENDPOINTS};
 use actix_web::web::Data;
 
 /// The resource in question's Timestamp
@@ -56,5 +61,55 @@ impl SyncServerRequest for HttpRequest {
                 ApiErrorKind::Internal("No app_data Secrets".to_owned()).into()
             })?;
         HawkIdentifier::extrude(self, method.as_str(), self.uri(), ci, secrets)
+    }
+}
+
+pub fn emit_http_status_with_tokenserver_origin(
+    req: ServiceRequest,
+    srv: &mut impl Service<
+        Request = ServiceRequest,
+        Response = ServiceResponse,
+        Error = actix_web::Error,
+    >,
+) -> impl Future<Output = Result<ServiceResponse, actix_web::Error>> {
+    let fut = srv.call(req);
+
+    async move {
+        let res = fut.await?;
+        let req = res.request();
+        let metrics = {
+            let statsd_client = req
+                .app_data::<Data<ServerState>>()
+                .map(|state| state.metrics.clone())
+                .ok_or_else(|| ApiError::from(ApiErrorKind::NoServerState))?;
+
+            Metrics::from(&*statsd_client)
+        };
+        let tags = req
+            .extensions()
+            .get::<TokenserverOrigin>()
+            .copied()
+            .map(|origin| {
+                let mut tags = Tags::default();
+
+                tags.tags
+                    .insert("tokenserver_origin".to_string(), origin.to_string());
+
+                tags
+            });
+
+        if res.status().is_informational() {
+            metrics.incr_with_tags("http_1XX", tags);
+        } else if res.status().is_success() {
+            metrics.incr_with_tags("http_2XX", tags);
+        } else if res.status().is_redirection() {
+            metrics.incr_with_tags("http_3XX", tags);
+        } else if res.status().is_client_error() {
+            metrics.incr_with_tags("http_4XX", tags);
+        } else if res.status().is_server_error() {
+            metrics.incr_with_tags("http_5XX", tags);
+        }
+
+        Ok(res)
     }
 }

--- a/src/web/tags.rs
+++ b/src/web/tags.rs
@@ -70,6 +70,14 @@ impl Tags {
         }
     }
 
+    pub fn with_tag(key: &str, value: &str) -> Self {
+        let mut tags = Tags::default();
+
+        tags.tags.insert(key.to_owned(), value.to_owned());
+
+        tags
+    }
+
     pub fn add_extra(&mut self, key: &str, value: &str) {
         if !value.is_empty() {
             self.extra.insert(key.to_owned(), value.to_owned());

--- a/tools/integration_tests/tokenserver/test_e2e.py
+++ b/tools/integration_tests/tokenserver/test_e2e.py
@@ -216,6 +216,9 @@ class TestE2e(TestCase, unittest.TestCase):
         payload = raw[:-32]
         signature = raw[-32:]
         payload_dict = json.loads(payload.decode('utf-8'))
+        # The `id` payload should include a field indicating the origin of the
+        # token
+        self.assertEqual(payload_dict['tokenserver_origin'], 'rust')
         signing_secret = self.TOKEN_SIGNING_SECRET
         expected_token = tokenlib.make_token(payload_dict,
                                              secret=signing_secret)


### PR DESCRIPTION
## Description

* Add a new `tokenserver_origin` field to the `HawkPayload` so syncstorage can determine which tokens originated from
* Parse the field on the syncstorage side and add it as a tag to some key metrics
* Add the Tokenserver origin as a tag on the HTTP status and API metrics

## Testing

I wasn't sure how to test that the metrics were being emitted properly, but I added an integration test to ensure that the field is present in the token created by Tokenserver.

## Issue(s)

Closes #1245
