### PR TITLE
bug: fix Tokenserver migrations

### DIFF
--- a/src/tokenserver/migrations/2021-07-16-001122_init/up.sql
+++ b/src/tokenserver/migrations/2021-07-16-001122_init/up.sql
@@ -1,4 +1,4 @@
-CREATE TABLE `services` (
+CREATE TABLE IF NOT EXISTS `services` (
   `id` int NOT NULL AUTO_INCREMENT,
   `service` varchar(30) DEFAULT NULL,
   `pattern` varchar(128) DEFAULT NULL,
@@ -6,7 +6,7 @@ CREATE TABLE `services` (
   UNIQUE KEY `service` (`service`)
 );
 
-CREATE TABLE `nodes` (
+CREATE TABLE IF NOT EXISTS `nodes` (
   `id` bigint NOT NULL AUTO_INCREMENT,
   `service` int NOT NULL,
   `node` varchar(64) NOT NULL,
@@ -20,7 +20,7 @@ CREATE TABLE `nodes` (
   CONSTRAINT `nodes_ibfk_1` FOREIGN KEY (`service`) REFERENCES `services` (`id`)
 );
 
-CREATE TABLE `users` (
+CREATE TABLE IF NOT EXISTS `users` (
   `uid` bigint NOT NULL AUTO_INCREMENT,
   `service` int NOT NULL,
   `email` varchar(255) NOT NULL,

--- a/src/tokenserver/migrations/2021-08-03-234845_populate_services/up.sql
+++ b/src/tokenserver/migrations/2021-08-03-234845_populate_services/up.sql
@@ -1,3 +1,3 @@
-INSERT INTO services (id, service, pattern) VALUES
+INSERT IGNORE INTO services (id, service, pattern) VALUES
     (1, "sync-1.1", "{node}/1.1/{uid}"),
     (2, "sync-1.5", "{node}/1.5/{uid}");

--- a/src/tokenserver/migrations/2021-12-22-160451_remove_services/down.sql
+++ b/src/tokenserver/migrations/2021-12-22-160451_remove_services/down.sql
@@ -1,3 +1,3 @@
-INSERT INTO services (id, service, pattern) VALUES
+INSERT IGNORE INTO services (id, service, pattern) VALUES
     (1, "sync-1.1", "{node}/1.1/{uid}"),
     (2, "sync-1.5", "{node}/1.5/{uid}");


### PR DESCRIPTION
## Description

Migrations were previously failing in GCP because the `services` table
already exists in the database. To rectify this, we needed to change the
`CREATE TABLE` statements to `CREATE TABLE IF NOT EXISTS`. We also had
to change any `INSERT` statements to `INSERT IGNORE` statements.

## Testing

I tested this by reverting all the migrations, manually adding the tables and `sync-1.1` and `sync-1.5` services, and running the migrations. The migrations should complete with no errors.
