### PR TITLE
feat: don't run Tokenserver migrations on startup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,3 @@ run_spanner:
 
 test:
 	SYNC_DATABASE_URL=$(SYNC_DATABASE_URL) SYNC_TOKENSERVER__DATABASE_URL=$(SYNC_TOKENSERVER__DATABASE_URL) RUST_TEST_THREADS=1 cargo test
-
-tokenserver_migrate:
-	diesel --database-url $(SYNC_TOKENSERVER__DATABASE_URL) migration --migration-dir src/tokenserver/migrations run

--- a/Makefile
+++ b/Makefile
@@ -44,13 +44,10 @@ python:
 	venv/bin/python -m pip install -r requirements.txt
 
 run: python
-	PATH="./venv/bin:$(PATH)" RUST_LOG=debug RUST_BACKTRACE=full cargo run -- --config config/local.toml
+	PATH=./venv/bin:$(PATH) RUST_LOG=debug RUST_BACKTRACE=full cargo run -- --config config/local.toml
 
 run_spanner:
 	GOOGLE_APPLICATION_CREDENTIALS=$(PATH_TO_SYNC_SPANNER_KEYS) GRPC_DEFAULT_SSL_ROOTS_FILE_PATH=$(PATH_TO_GRPC_CERT) make run
 
 test:
 	SYNC_DATABASE_URL=$(SYNC_DATABASE_URL) SYNC_TOKENSERVER__DATABASE_URL=$(SYNC_TOKENSERVER__DATABASE_URL) RUST_TEST_THREADS=1 cargo test
-
-tokenserver_migrate:
-	diesel --database-url $(SYNC_TOKENSERVER__DATABASE_URL) migration --migration-dir src/tokenserver/migrations run

--- a/Makefile
+++ b/Makefile
@@ -44,10 +44,13 @@ python:
 	venv/bin/python -m pip install -r requirements.txt
 
 run: python
-	PATH=./venv/bin:$(PATH) RUST_LOG=debug RUST_BACKTRACE=full cargo run -- --config config/local.toml
+	PATH="./venv/bin:$(PATH)" RUST_LOG=debug RUST_BACKTRACE=full cargo run -- --config config/local.toml
 
 run_spanner:
 	GOOGLE_APPLICATION_CREDENTIALS=$(PATH_TO_SYNC_SPANNER_KEYS) GRPC_DEFAULT_SSL_ROOTS_FILE_PATH=$(PATH_TO_GRPC_CERT) make run
 
 test:
 	SYNC_DATABASE_URL=$(SYNC_DATABASE_URL) SYNC_TOKENSERVER__DATABASE_URL=$(SYNC_TOKENSERVER__DATABASE_URL) RUST_TEST_THREADS=1 cargo test
+
+tokenserver_migrate:
+	diesel --database-url $(SYNC_TOKENSERVER__DATABASE_URL) migration --migration-dir src/tokenserver/migrations run

--- a/docker-compose.e2e.mysql.yaml
+++ b/docker-compose.e2e.mysql.yaml
@@ -33,6 +33,7 @@ services:
           SYNC_TOKENSERVER__FXA_BROWSERID_ISSUER: "api-accounts.stage.mozaws.net"
           SYNC_TOKENSERVER__FXA_EMAIL_DOMAIN: api-accounts.stage.mozaws.net
           SYNC_TOKENSERVER__FXA_METRICS_HASH_SECRET: secret0
+          SYNC_TOKENSERVER__RUN_MIGRATIONS: true
           TOKENSERVER_HOST: http://localhost:8000
         entrypoint: >
           /bin/sh -c "

--- a/docker-compose.e2e.mysql.yaml
+++ b/docker-compose.e2e.mysql.yaml
@@ -33,7 +33,7 @@ services:
           SYNC_TOKENSERVER__FXA_BROWSERID_ISSUER: "api-accounts.stage.mozaws.net"
           SYNC_TOKENSERVER__FXA_EMAIL_DOMAIN: api-accounts.stage.mozaws.net
           SYNC_TOKENSERVER__FXA_METRICS_HASH_SECRET: secret0
-          SYNC_TOKENSERVER__RUN_MIGRATIONS: true
+          SYNC_TOKENSERVER__RUN_MIGRATIONS: "true"
           TOKENSERVER_HOST: http://localhost:8000
         entrypoint: >
           /bin/sh -c "

--- a/docker-compose.e2e.spanner.yaml
+++ b/docker-compose.e2e.spanner.yaml
@@ -34,6 +34,7 @@ services:
           SYNC_TOKENSERVER__FXA_BROWSERID_ISSUER: "api-accounts.stage.mozaws.net"
           SYNC_TOKENSERVER__FXA_EMAIL_DOMAIN: api-accounts.stage.mozaws.net
           SYNC_TOKENSERVER__FXA_METRICS_HASH_SECRET: secret0
+          SYNC_TOKENSERVER__RUN_MIGRATIONS: true
           TOKENSERVER_HOST: http://localhost:8000
         entrypoint: >
           /bin/sh -c "

--- a/docker-compose.e2e.spanner.yaml
+++ b/docker-compose.e2e.spanner.yaml
@@ -34,7 +34,7 @@ services:
           SYNC_TOKENSERVER__FXA_BROWSERID_ISSUER: "api-accounts.stage.mozaws.net"
           SYNC_TOKENSERVER__FXA_EMAIL_DOMAIN: api-accounts.stage.mozaws.net
           SYNC_TOKENSERVER__FXA_METRICS_HASH_SECRET: secret0
-          SYNC_TOKENSERVER__RUN_MIGRATIONS: true
+          SYNC_TOKENSERVER__RUN_MIGRATIONS: "true"
           TOKENSERVER_HOST: http://localhost:8000
         entrypoint: >
           /bin/sh -c "

--- a/docker-compose.mysql.yaml
+++ b/docker-compose.mysql.yaml
@@ -49,7 +49,7 @@ services:
           SYNC_MASTER_SECRET: secret0
           SYNC_DATABASE_URL: mysql://test:test@sync-db:3306/syncstorage
           SYNC_TOKENSERVER__DATABASE_URL: mysql://test:test@tokenserver-db:3306/tokenserver
-          SYNC_TOKENSERVER__RUN_MIGRATIONS: true
+          SYNC_TOKENSERVER__RUN_MIGRATIONS: "true"
 
 volumes:
     sync_db_data:

--- a/docker-compose.mysql.yaml
+++ b/docker-compose.mysql.yaml
@@ -49,6 +49,7 @@ services:
           SYNC_MASTER_SECRET: secret0
           SYNC_DATABASE_URL: mysql://test:test@sync-db:3306/syncstorage
           SYNC_TOKENSERVER__DATABASE_URL: mysql://test:test@tokenserver-db:3306/tokenserver
+          SYNC_TOKENSERVER__RUN_MIGRATIONS: true
 
 volumes:
     sync_db_data:

--- a/docker-compose.spanner.yaml
+++ b/docker-compose.spanner.yaml
@@ -10,7 +10,7 @@ services:
     sync-db-setup:
         image: app:build
         depends_on:
-          - sync-db
+            - sync-db
         restart: "no"
         entrypoint: "/app/scripts/prepare-spanner.sh"
         environment:
@@ -39,19 +39,20 @@ services:
         image: ${SYNCSTORAGE_RS_IMAGE:-syncstorage-rs:latest}
         restart: always
         ports:
-          - "8000:8000"
+            - "8000:8000"
         depends_on:
-          - sync-db-setup
+            - sync-db-setup
         environment:
-          SYNC_HOST: 0.0.0.0
-          SYNC_MASTER_SECRET: secret0
-          SYNC_DATABASE_URL: spanner://projects/test-project/instances/test-instance/databases/test-database
-          SYNC_SPANNER_EMULATOR_HOST: sync-db:9010
-          SYNC_TOKENSERVER__DATABASE_URL: mysql://test:test@tokenserver-db:3306/tokenserver
+            SYNC_HOST: 0.0.0.0
+            SYNC_MASTER_SECRET: secret0
+            SYNC_DATABASE_URL: spanner://projects/test-project/instances/test-instance/databases/test-database
+            SYNC_SPANNER_EMULATOR_HOST: sync-db:9010
+            SYNC_TOKENSERVER__DATABASE_URL: mysql://test:test@tokenserver-db:3306/tokenserver
+            SYNC_TOKENSERVER__RUN_MIGRATIONS: true
 
 volumes:
     tokenserver_db_data:
 
-# Application runs off of port 8000.
-# you can test if it's available with
-# curl "http://localhost:8000/__heartbeat__"
+        # Application runs off of port 8000.
+        # you can test if it's available with
+        # curl "http://localhost:8000/__heartbeat__"

--- a/docker-compose.spanner.yaml
+++ b/docker-compose.spanner.yaml
@@ -48,7 +48,7 @@ services:
             SYNC_DATABASE_URL: spanner://projects/test-project/instances/test-instance/databases/test-database
             SYNC_SPANNER_EMULATOR_HOST: sync-db:9010
             SYNC_TOKENSERVER__DATABASE_URL: mysql://test:test@tokenserver-db:3306/tokenserver
-            SYNC_TOKENSERVER__RUN_MIGRATIONS: true
+            SYNC_TOKENSERVER__RUN_MIGRATIONS: "true"
 
 volumes:
     tokenserver_db_data:

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -215,7 +215,7 @@ impl Settings {
         s.set_default("tokenserver.fxa_oauth_request_timeout", 10)?;
         s.set_default("tokenserver.node_type", "spanner")?;
         s.set_default("tokenserver.statsd_label", "syncstorage.tokenserver")?;
-        s.set_default("tokenserver.run_migrations", false)?;
+        s.set_default("tokenserver.run_migrations", cfg!(test))?;
 
         // Set Cors defaults
         s.set_default(

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -215,6 +215,7 @@ impl Settings {
         s.set_default("tokenserver.fxa_oauth_request_timeout", 10)?;
         s.set_default("tokenserver.node_type", "spanner")?;
         s.set_default("tokenserver.statsd_label", "syncstorage.tokenserver")?;
+        s.set_default("tokenserver.run_migrations", false)?;
 
         // Set Cors defaults
         s.set_default(

--- a/src/tokenserver/README.md
+++ b/src/tokenserver/README.md
@@ -45,7 +45,7 @@ cargo install diesel_cli
 ```
 Then, run the migrations:
 ```
-make tokenserver_migrate
+diesel --database-url mysql://sample_user:sample_password@localhost/tokenserver_rs migration --migration-dir src/tokenserver/migrations run
 ```
 You should replace the above database Data Source Name (DSN) with the DSN of the database you are using.
 

--- a/src/tokenserver/README.md
+++ b/src/tokenserver/README.md
@@ -45,7 +45,7 @@ cargo install diesel_cli
 ```
 Then, run the migrations:
 ```
-diesel --database-url mysql://sample_user:sample_password@localhost/tokenserver_rs migration --migration-dir src/tokenserver/migrations run
+make tokenserver_migrate
 ```
 You should replace the above database Data Source Name (DSN) with the DSN of the database you are using.
 

--- a/src/tokenserver/db/pool.rs
+++ b/src/tokenserver/db/pool.rs
@@ -48,7 +48,7 @@ impl TokenserverPool {
         metrics: &Metrics,
         _use_test_transactions: bool,
     ) -> DbResult<Self> {
-        #[cfg(test)]
+        #[cfg(debug_assertions)]
         run_embedded_migrations(&settings.database_url)?;
 
         let manager = ConnectionManager::<MysqlConnection>::new(settings.database_url.clone());

--- a/src/tokenserver/db/pool.rs
+++ b/src/tokenserver/db/pool.rs
@@ -4,13 +4,13 @@ use diesel::{
     mysql::MysqlConnection,
     r2d2::{ConnectionManager, Pool},
 };
-#[cfg(test)]
+#[cfg(debug_assertions)]
 use diesel_logger::LoggingConnection;
 use std::time::Duration;
 
 use super::models::{Db, DbResult, TokenserverDb};
 use crate::db::{error::DbError, DbErrorKind};
-#[cfg(test)]
+#[cfg(debug_assertions)]
 use crate::diesel::Connection;
 use crate::server::metrics::Metrics;
 use crate::tokenserver::settings::Settings;
@@ -18,14 +18,15 @@ use crate::tokenserver::settings::Settings;
 #[cfg(test)]
 use crate::db::mysql::TestTransactionCustomizer;
 
-#[cfg(test)]
+// We only want to embed and run the migrations in non-release builds
+#[cfg(debug_assertions)]
 embed_migrations!("src/tokenserver/migrations");
 
 /// Run the diesel embedded migrations
 ///
 /// Mysql DDL statements implicitly commit which could disrupt MysqlPool's
 /// begin_test_transaction during tests. So this runs on its own separate conn.
-#[cfg(test)]
+#[cfg(debug_assertions)]
 pub fn run_embedded_migrations(database_url: &str) -> DbResult<()> {
     let conn = MysqlConnection::establish(database_url)?;
 

--- a/src/tokenserver/db/pool.rs
+++ b/src/tokenserver/db/pool.rs
@@ -3,10 +3,7 @@ use async_trait::async_trait;
 use diesel::{
     mysql::MysqlConnection,
     r2d2::{ConnectionManager, Pool},
-    Connection,
 };
-#[cfg(test)]
-use diesel_logger::LoggingConnection;
 use std::time::Duration;
 
 use super::models::{Db, DbResult, TokenserverDb};
@@ -16,23 +13,6 @@ use crate::tokenserver::settings::Settings;
 
 #[cfg(test)]
 use crate::db::mysql::TestTransactionCustomizer;
-
-embed_migrations!("src/tokenserver/migrations");
-
-/// Run the diesel embedded migrations
-///
-/// Mysql DDL statements implicitly commit which could disrupt MysqlPool's
-/// begin_test_transaction during tests. So this runs on its own separate conn.
-pub fn run_embedded_migrations(database_url: &str) -> DbResult<()> {
-    let conn = MysqlConnection::establish(database_url)?;
-
-    #[cfg(test)]
-    embedded_migrations::run(&LoggingConnection::new(conn))?;
-    #[cfg(not(test))]
-    embedded_migrations::run(&conn)?;
-
-    Ok(())
-}
 
 #[derive(Clone)]
 pub struct TokenserverPool {
@@ -47,8 +27,6 @@ impl TokenserverPool {
         metrics: &Metrics,
         _use_test_transactions: bool,
     ) -> DbResult<Self> {
-        run_embedded_migrations(&settings.database_url)?;
-
         let manager = ConnectionManager::<MysqlConnection>::new(settings.database_url.clone());
         let builder = Pool::builder()
             .max_size(settings.database_pool_max_size.unwrap_or(10))

--- a/src/tokenserver/settings.rs
+++ b/src/tokenserver/settings.rs
@@ -70,7 +70,7 @@ impl Default for Settings {
             node_capacity_release_rate: None,
             node_type: NodeType::Spanner,
             statsd_label: "syncstorage.tokenserver".to_owned(),
-            run_migrations: false,
+            run_migrations: cfg!(test),
         }
     }
 }

--- a/src/tokenserver/settings.rs
+++ b/src/tokenserver/settings.rs
@@ -46,6 +46,8 @@ pub struct Settings {
     pub node_type: NodeType,
     /// The label to be used when reporting Metrics.
     pub statsd_label: String,
+    /// Whether or not to run the Tokenserver migrations upon startup.
+    pub run_migrations: bool,
 }
 
 impl Default for Settings {
@@ -68,6 +70,7 @@ impl Default for Settings {
             node_capacity_release_rate: None,
             node_type: NodeType::Spanner,
             statsd_label: "syncstorage.tokenserver".to_owned(),
+            run_migrations: false,
         }
     }
 }


### PR DESCRIPTION
## Description

Since we're connecting to the pre-existing Tokenserver database, we should not be running the migrations on server startup.