### PR TITLE
bug: fix metrics and BrowserID error context

### DIFF
--- a/src/tokenserver/auth/browserid.rs
+++ b/src/tokenserver/auth/browserid.rs
@@ -122,6 +122,12 @@ impl VerifyToken for RemoteVerifier {
                     ..Default::default()
                 })
             }
+            VerifyResponse::Failure {
+                reason: Some(reason),
+            } => Err(TokenserverError {
+                context: format!("BrowserID verification error: {}", reason),
+                ..TokenserverError::invalid_credentials("Unauthorized")
+            }),
             VerifyResponse::Failure { .. } => Err(TokenserverError {
                 context: "Unknown BrowserID verification error".to_owned(),
                 ..TokenserverError::invalid_credentials("Unauthorized")

--- a/src/tokenserver/auth/browserid.rs
+++ b/src/tokenserver/auth/browserid.rs
@@ -397,11 +397,27 @@ mod tests {
             assert_eq!(expected_error, error);
         }
 
-        // {"status": "error"} in body with random reason
+        // {"status": "failure"} in body with random reason
         {
             let mock = mockito::mock("POST", "/v2")
                 .with_header("content-type", "application/json")
                 .with_body("{\"status\": \"failure\", \"reason\": \"something broke\"}")
+                .create();
+
+            let error = verifier.verify(assertion.to_owned()).await.unwrap_err();
+            mock.assert();
+
+            let expected_error = TokenserverError {
+                context: "BrowserID verification error: something broke".to_owned(),
+                ..TokenserverError::invalid_credentials("Unauthorized")
+            };
+            assert_eq!(expected_error, error);
+        }
+        // {"status": "failure"} in body with no reason
+        {
+            let mock = mockito::mock("POST", "/v2")
+                .with_header("content-type", "application/json")
+                .with_body("{\"status\": \"failure\"}")
                 .create();
 
             let error = verifier.verify(assertion.to_owned()).await.unwrap_err();

--- a/src/tokenserver/db/models.rs
+++ b/src/tokenserver/db/models.rs
@@ -215,7 +215,7 @@ impl TokenserverDb {
         const DEFAULT_CAPACITY_RELEASE_RATE: f32 = 0.1;
 
         let mut metrics = self.metrics.clone();
-        metrics.start_timer("tokenserver.storage.get_best_node", None);
+        metrics.start_timer("storage.get_best_node", None);
 
         // We may have to retry the query if we need to release more capacity. This loop allows
         // a maximum of five retries before bailing out.
@@ -407,7 +407,7 @@ impl TokenserverDb {
     /// Creates a new user and assigns them to a node.
     fn allocate_user_sync(&self, params: params::AllocateUser) -> DbResult<results::AllocateUser> {
         let mut metrics = self.metrics.clone();
-        metrics.start_timer("tokenserver.storage.allocate_user", None);
+        metrics.start_timer("storage.allocate_user", None);
 
         // Get the least-loaded node
         let node = self.get_best_node_sync(params::GetBestNode {

--- a/src/tokenserver/db/pool.rs
+++ b/src/tokenserver/db/pool.rs
@@ -98,7 +98,7 @@ impl From<actix_web::error::BlockingError<DbError>> for DbError {
 impl DbPool for TokenserverPool {
     async fn get(&self) -> Result<Box<dyn Db>, DbError> {
         let mut metrics = self.metrics.clone();
-        metrics.start_timer("tokenserver.storage.get_pool", None);
+        metrics.start_timer("storage.get_pool", None);
 
         let pool = self.clone();
         let conn = block(move || pool.inner.get().map_err(DbError::from)).await?;

--- a/src/tokenserver/extractors.rs
+++ b/src/tokenserver/extractors.rs
@@ -411,7 +411,7 @@ impl FromRequest for AuthData {
             let token = Token::extract(&req).await?;
 
             let TokenserverMetrics(mut metrics) = TokenserverMetrics::extract(&req).await?;
-            metrics.start_timer("tokenserver.token_verification", None);
+            metrics.start_timer("token_verification", None);
 
             match token {
                 Token::BrowserIdAssertion(assertion) => {

--- a/src/tokenserver/handlers.rs
+++ b/src/tokenserver/handlers.rs
@@ -41,7 +41,7 @@ pub async fn get_tokenserver_result(
     let (token, derived_secret) = {
         let token_plaintext = get_token_plaintext(&req, &updates)?;
 
-        metrics.start_timer("tokenserver.token_creation", None);
+        metrics.start_timer("token_creation", None);
         // Get the token and secret
         Tokenlib::get_token_and_derived_secret(token_plaintext, &req.shared_secret)?
     };

--- a/src/tokenserver/handlers.rs
+++ b/src/tokenserver/handlers.rs
@@ -16,9 +16,8 @@ use super::{
     },
     error::TokenserverError,
     extractors::TokenserverRequest,
-    NodeType,
+    NodeType, TokenserverMetrics,
 };
-use crate::server::metrics::Metrics;
 
 #[derive(Debug, Serialize)]
 pub struct TokenserverResult {
@@ -35,7 +34,7 @@ pub struct TokenserverResult {
 pub async fn get_tokenserver_result(
     req: TokenserverRequest,
     db: Box<dyn Db>,
-    mut metrics: Metrics,
+    TokenserverMetrics(mut metrics): TokenserverMetrics,
 ) -> Result<HttpResponse, Error> {
     let updates = update_user(&req, db).await?;
 


### PR DESCRIPTION
## Description

Three small changes:
* We were extracting the Tokenserver metrics reporter incorrectly, which I noticed when we weren't receiving one of the metrics correctly
* The Tokenserver statsd label already has `tokenserver.` in it, so remove that prefix from the places in the code where we emit metrics
* Add context to unrecognized BrowserID verification errors that have a reason message
