### PR TITLE
refactor/remove unnecessary syncserverrequest impl

### DIFF
--- a/syncstorage/src/db/transaction.rs
+++ b/syncstorage/src/db/transaction.rs
@@ -241,13 +241,10 @@ impl FromRequest for DbTransactionPool {
                 }
             };
             let method = req.method().clone();
-            let user_id = match HawkIdentifier::try_from(&req) {
-                Ok(v) => v,
-                Err(e) => {
-                    warn!("⚠️ Bad Hawk Id: {:?}", e; "user_agent"=> useragent);
-                    return Err(e);
-                }
-            };
+            let user_id = HawkIdentifier::try_from(&req).map_err(|e| {
+                warn!("⚠️ Bad Hawk Id: {:?}", e; "user_agent"=> useragent);
+                e
+            })?;
             let bso = BsoParam::extrude(req.head(), &mut req.extensions_mut()).ok();
             let bso_opt = bso.map(|b| b.bso);
 

--- a/syncstorage/src/db/transaction.rs
+++ b/syncstorage/src/db/transaction.rs
@@ -1,5 +1,4 @@
 use std::cell::RefMut;
-use std::convert::TryFrom;
 use std::future::Future;
 
 use actix_http::http::{HeaderValue, Method, StatusCode};
@@ -241,7 +240,7 @@ impl FromRequest for DbTransactionPool {
                 }
             };
             let method = req.method().clone();
-            let user_id = HawkIdentifier::try_from(&req).map_err(|e| {
+            let user_id = HawkIdentifier::extract(&req).await.map_err(|e| {
                 warn!("⚠️ Bad Hawk Id: {:?}", e; "user_agent"=> useragent);
                 e
             })?;

--- a/syncstorage/src/db/transaction.rs
+++ b/syncstorage/src/db/transaction.rs
@@ -1,4 +1,5 @@
 use std::cell::RefMut;
+use std::convert::TryFrom;
 use std::future::Future;
 
 use actix_http::http::{HeaderValue, Method, StatusCode};
@@ -16,9 +17,8 @@ use crate::error::{ApiError, ApiErrorKind};
 use crate::server::metrics::Metrics;
 use crate::server::ServerState;
 use crate::web::extractors::{
-    BsoParam, CollectionParam, PreConditionHeader, PreConditionHeaderOpt,
+    BsoParam, CollectionParam, HawkIdentifier, PreConditionHeader, PreConditionHeaderOpt,
 };
-use crate::web::middleware::SyncServerRequest;
 use crate::web::tags::Tags;
 use crate::web::X_LAST_MODIFIED;
 
@@ -241,7 +241,7 @@ impl FromRequest for DbTransactionPool {
                 }
             };
             let method = req.method().clone();
-            let user_id = match req.get_hawk_id() {
+            let user_id = match HawkIdentifier::try_from(&req) {
                 Ok(v) => v,
                 Err(e) => {
                     warn!("⚠️ Bad Hawk Id: {:?}", e; "user_agent"=> useragent);

--- a/syncstorage/src/web/extractors.rs
+++ b/syncstorage/src/web/extractors.rs
@@ -1136,8 +1136,7 @@ impl From<HawkIdentifier> for UserIdentifier {
 }
 
 impl TryFrom<&HttpRequest> for HawkIdentifier {
-    type Error = actix_web::Error;
-    // type Error = ActixError;
+    type Error = Error;
 
     fn try_from(req: &HttpRequest) -> Result<HawkIdentifier, Error> {
         if DOCKER_FLOW_ENDPOINTS.contains(&req.uri().path().to_lowercase().as_str()) {

--- a/syncstorage/src/web/extractors.rs
+++ b/syncstorage/src/web/extractors.rs
@@ -1143,9 +1143,7 @@ impl TryFrom<&HttpRequest> for HawkIdentifier {
             return Ok(HawkIdentifier::cmd_dummy());
         }
         let method = req.method().clone();
-        // NOTE: `connection_info()` gets a mutable reference lock on `extensions()`, so
-        // it must be cloned
-        let ci = req.connection_info().clone();
+        let ci = req.connection_info();
         let secrets = req
             .app_data::<Data<Arc<Secrets>>>()
             .ok_or_else(|| -> ApiError {

--- a/syncstorage/src/web/extractors.rs
+++ b/syncstorage/src/web/extractors.rs
@@ -1139,6 +1139,7 @@ impl TryFrom<&HttpRequest> for HawkIdentifier {
     type Error = Error;
 
     fn try_from(req: &HttpRequest) -> Result<HawkIdentifier, Error> {
+        // Dummy token if a Docker Flow request is detected.
         if DOCKER_FLOW_ENDPOINTS.contains(&req.uri().path().to_lowercase().as_str()) {
             return Ok(HawkIdentifier::cmd_dummy());
         }
@@ -1156,32 +1157,57 @@ impl TryFrom<&HttpRequest> for HawkIdentifier {
 impl FromRequest for HawkIdentifier {
     type Config = ();
     type Error = Error;
-    type Future = LocalBoxFuture<'static, Result<Self, Self::Error>>;
+    type Future = Ready<Result<Self, Self::Error>>;
 
     /// Use HawkPayload extraction and format as HawkIdentifier.
     fn from_request(req: &HttpRequest, _payload: &mut Payload) -> Self::Future {
+        // Dummy token if a Docker Flow request is detected.
+        if DOCKER_FLOW_ENDPOINTS.contains(&req.uri().path().to_lowercase().as_str()) {
+            return future::ready(Ok(HawkIdentifier::cmd_dummy()));
+        }
         let req = req.clone();
+        let uri = req.uri();
+        // NOTE: `connection_info()` will get a mutable reference lock on `extensions()`
+        let connection_info = req.connection_info().clone();
+        let method = req.method().clone();
+        // Tried collapsing this to a `.or_else` and hit problems with the retun resolving
+        // to an appropriate error state.
+        let secrets = match req.app_data::<Data<Arc<Secrets>>>() {
+            Some(v) => v,
+            None => {
+                let err: ApiError = ApiErrorKind::Internal("No app_data Secrets".to_owned()).into();
+                return future::ready(Err(err.into()));
+            }
+        };
 
-        Box::pin(async move {
-            let secrets = match req.app_data::<Data<Arc<Secrets>>>() {
-                Some(s) => s,
-                None => {
-                    error!("⚠️ Could not load the app secrets");
-                    return Err(ValidationErrorKind::FromDetails(
-                        "Internal error".to_owned(),
-                        RequestErrorLocation::Unknown,
-                        Some("secrets".to_owned()),
-                        None,
-                    )
-                    .into());
-                }
-            };
-            // NOTE: `connection_info()` will get a mutable reference lock on `extensions()`
-            let connection_info = req.connection_info().clone();
-            let method = req.method().as_str();
-            let uri = req.uri();
-            Self::extrude(&req, method, uri, &connection_info, secrets)
-        })
+        future::ready(Self::extrude(
+            &req,
+            method.as_str(),
+            uri,
+            &connection_info,
+            secrets,
+        ))
+
+        // Box::pin(async move {
+        //     let secrets = match req.app_data::<Data<Arc<Secrets>>>() {
+        //         Some(s) => s,
+        //         None => {
+        //             error!("⚠️ Could not load the app secrets");
+        //             return Err(ValidationErrorKind::FromDetails(
+        //                 "Internal error".to_owned(),
+        //                 RequestErrorLocation::Unknown,
+        //                 Some("secrets".to_owned()),
+        //                 None,
+        //             )
+        //             .into());
+        //         }
+        //     };
+        // NOTE: `connection_info()` will get a mutable reference lock on `extensions()`
+        // let connection_info = req.connection_info().clone();
+        // let method = req.method().as_str();
+        // let uri = req.uri();
+        // future::ready(Self::extrude(&req, method, uri, &connection_info, secrets))
+        // })
     }
 }
 


### PR DESCRIPTION
## Description

This task entailed removing unnecessary impl blocks for syncserverrequest, as they were not used. The implementation of the TryFrom trait for HawkIdentifier followed by moving it into `extractors.rs` sufficiently tidied up the code in `mod.rs` scoping the functionality to where the structure is defined and various traits implemented for `HawkIdentifier`

In the Makefile, added a quoting to avoid certain paths with space characters breaking the build. @ethowitz was able to clear this issue up and had dealt with it in the past.

## Testing

Ensuring compilation should be sufficient. Ran into some formatting deltas between CircleCI and clippy in initial tests.

## Issue(s)

Closes [link](link).
https://mozilla-hub.atlassian.net/browse/CONSVC-1693
