### PR TITLE
feat: support setting JWK for Tokenserver OAuth verification

### DIFF
--- a/docker-compose.e2e.mysql.yaml
+++ b/docker-compose.e2e.mysql.yaml
@@ -1,41 +1,48 @@
 version: '3'
 services:
-    sync-db:
-    tokenserver-db:
-    syncstorage-rs:
-        depends_on:
-          - sync-db
-          - tokenserver-db
-        # TODO: either syncstorage-rs should retry the db connection
-        # itself a few times or should include a wait-for-it.sh script
-        # inside its docker that would do this for us. Same (probably
-        # the latter solution) for server-syncstorage below
-        entrypoint: >
-          /bin/sh -c "
-            sleep 15;
-            /app/bin/syncstorage;
-          "
-    e2e-tests:
-        depends_on:
-          - mock-fxa-server
-          - syncstorage-rs
-        image: app:build
-        privileged: true
-        user: root
-        environment:
-          MOCK_FXA_SERVER_URL: http://mock-fxa-server:6000
-          SYNC_HOST: 0.0.0.0
-          SYNC_MASTER_SECRET: secret0
-          SYNC_DATABASE_URL: mysql://test:test@sync-db:3306/syncstorage
-          SYNC_TOKENSERVER__DATABASE_URL: mysql://test:test@tokenserver-db:3306/tokenserver
-          SYNC_TOKENSERVER__ENABLED: "true"
-          SYNC_TOKENSERVER__FXA_BROWSERID_AUDIENCE: "https://token.stage.mozaws.net/"
-          SYNC_TOKENSERVER__FXA_BROWSERID_ISSUER: "api-accounts.stage.mozaws.net"
-          SYNC_TOKENSERVER__FXA_EMAIL_DOMAIN: api-accounts.stage.mozaws.net
-          SYNC_TOKENSERVER__FXA_METRICS_HASH_SECRET: secret0
-          SYNC_TOKENSERVER__RUN_MIGRATIONS: "true"
-          TOKENSERVER_HOST: http://localhost:8000
-        entrypoint: >
-          /bin/sh -c "
-            sleep 28; python3 /app/tools/integration_tests/run.py 'http://localhost:8000#secret0'
-          "
+  sync-db:
+  tokenserver-db:
+  syncstorage-rs:
+    depends_on:
+      - sync-db
+      - tokenserver-db
+    # TODO: either syncstorage-rs should retry the db connection
+    # itself a few times or should include a wait-for-it.sh script
+    # inside its docker that would do this for us. Same (probably
+    # the latter solution) for server-syncstorage below
+    entrypoint: >
+      /bin/sh -c "
+        sleep 15;
+        /app/bin/syncstorage;
+      "
+  e2e-tests:
+    depends_on:
+      - mock-fxa-server
+      - syncstorage-rs
+    image: app:build
+    privileged: true
+    user: root
+    environment:
+      MOCK_FXA_SERVER_URL: http://mock-fxa-server:6000
+      SYNC_HOST: 0.0.0.0
+      SYNC_MASTER_SECRET: secret0
+      SYNC_DATABASE_URL: mysql://test:test@sync-db:3306/syncstorage
+      SYNC_TOKENSERVER__DATABASE_URL: mysql://test:test@tokenserver-db:3306/tokenserver
+      SYNC_TOKENSERVER__ENABLED: "true"
+      SYNC_TOKENSERVER__FXA_BROWSERID_AUDIENCE: "https://token.stage.mozaws.net/"
+      SYNC_TOKENSERVER__FXA_BROWSERID_ISSUER: "api-accounts.stage.mozaws.net"
+      SYNC_TOKENSERVER__FXA_EMAIL_DOMAIN: api-accounts.stage.mozaws.net
+      SYNC_TOKENSERVER__FXA_METRICS_HASH_SECRET: secret0
+      SYNC_TOKENSERVER__RUN_MIGRATIONS: "true"
+      SYNC_TOKENSERVER__FXA_OAUTH_JWK__KTY: "RSA"
+      SYNC_TOKENSERVER__FXA_OAUTH_JWK__ALG: "RS256"
+      SYNC_TOKENSERVER__FXA_OAUTH_JWK__KID: "20190730-15e473fd"
+      SYNC_TOKENSERVER__FXA_OAUTH_JWK__FXA_CREATED_AT: "1564502400"
+      SYNC_TOKENSERVER__FXA_OAUTH_JWK__USE: "sig"
+      SYNC_TOKENSERVER__FXA_OAUTH_JWK__N: "15OpVGC7ws_SlU0gRbRh1Iwo8_gR8ElX2CDnbN5blKyXLg-ll0ogktoDXc-tDvTabRTxi7AXU0wWQ247odhHT47y5uz0GASYXdfPponynQ_xR9CpNn1eEL1gvDhQN9rfPIzfncl8FUi9V4WMd5f600QC81yDw9dX-Z8gdkru0aDaoEKF9-wU2TqrCNcQdiJCX9BISotjz_9cmGwKXFEekQNJWBeRQxH2bUmgwUK0HaqwW9WbYOs-zstNXXWFsgK9fbDQqQeGehXLZM4Cy5Mgl_iuSvnT3rLzPo2BmlxMLUvRqBx3_v8BTtwmNGA0v9O0FJS_mnDq0Iue0Dz8BssQCQ"
+      SYNC_TOKENSERVER__FXA_OAUTH_JWK__E: "AQAB"
+      TOKENSERVER_HOST: http://localhost:8000
+    entrypoint: >
+      /bin/sh -c "
+        sleep 28; python3 /app/tools/integration_tests/run.py 'http://localhost:8000#secret0'
+      "

--- a/docker-compose.e2e.spanner.yaml
+++ b/docker-compose.e2e.spanner.yaml
@@ -1,42 +1,49 @@
 version: '3'
 services:
-    sync-db:
-    sync-db-setup:
-    tokenserver-db:
-    syncstorage-rs:
-        depends_on:
-          - sync-db-setup
-        # TODO: either syncstorage-rs should retry the db connection
-        # itself a few times or should include a wait-for-it.sh script
-        # inside its docker that would do this for us. Same (probably
-        # the latter solution) for server-syncstorage below
-        entrypoint: >
-          /bin/sh -c "
-            sleep 15;
-            /app/bin/syncstorage;
-          "
-    e2e-tests:
-        depends_on:
-          - mock-fxa-server
-          - syncstorage-rs
-        image: app:build
-        privileged: true
-        user: root
-        environment:
-          MOCK_FXA_SERVER_URL: http://mock-fxa-server:6000
-          SYNC_HOST: 0.0.0.0
-          SYNC_MASTER_SECRET: secret0
-          SYNC_DATABASE_URL: spanner://projects/test-project/instances/test-instance/databases/test-database
-          SYNC_SPANNER_EMULATOR_HOST: sync-db:9010
-          SYNC_TOKENSERVER__DATABASE_URL: mysql://test:test@tokenserver-db:3306/tokenserver
-          SYNC_TOKENSERVER__ENABLED: "true"
-          SYNC_TOKENSERVER__FXA_BROWSERID_AUDIENCE: "https://token.stage.mozaws.net/"
-          SYNC_TOKENSERVER__FXA_BROWSERID_ISSUER: "api-accounts.stage.mozaws.net"
-          SYNC_TOKENSERVER__FXA_EMAIL_DOMAIN: api-accounts.stage.mozaws.net
-          SYNC_TOKENSERVER__FXA_METRICS_HASH_SECRET: secret0
-          SYNC_TOKENSERVER__RUN_MIGRATIONS: "true"
-          TOKENSERVER_HOST: http://localhost:8000
-        entrypoint: >
-          /bin/sh -c "
-            sleep 28; python3 /app/tools/integration_tests/run.py 'http://localhost:8000#secret0'
-          "
+  sync-db:
+  sync-db-setup:
+  tokenserver-db:
+  syncstorage-rs:
+    depends_on:
+      - sync-db-setup
+    # TODO: either syncstorage-rs should retry the db connection
+    # itself a few times or should include a wait-for-it.sh script
+    # inside its docker that would do this for us. Same (probably
+    # the latter solution) for server-syncstorage below
+    entrypoint: >
+      /bin/sh -c "
+        sleep 15;
+        /app/bin/syncstorage;
+      "
+  e2e-tests:
+    depends_on:
+      - mock-fxa-server
+      - syncstorage-rs
+    image: app:build
+    privileged: true
+    user: root
+    environment:
+      MOCK_FXA_SERVER_URL: http://mock-fxa-server:6000
+      SYNC_HOST: 0.0.0.0
+      SYNC_MASTER_SECRET: secret0
+      SYNC_DATABASE_URL: spanner://projects/test-project/instances/test-instance/databases/test-database
+      SYNC_SPANNER_EMULATOR_HOST: sync-db:9010
+      SYNC_TOKENSERVER__DATABASE_URL: mysql://test:test@tokenserver-db:3306/tokenserver
+      SYNC_TOKENSERVER__ENABLED: "true"
+      SYNC_TOKENSERVER__FXA_BROWSERID_AUDIENCE: "https://token.stage.mozaws.net/"
+      SYNC_TOKENSERVER__FXA_BROWSERID_ISSUER: "api-accounts.stage.mozaws.net"
+      SYNC_TOKENSERVER__FXA_EMAIL_DOMAIN: api-accounts.stage.mozaws.net
+      SYNC_TOKENSERVER__FXA_METRICS_HASH_SECRET: secret0
+      SYNC_TOKENSERVER__RUN_MIGRATIONS: "true"
+      SYNC_TOKENSERVER__FXA_OAUTH_JWK__KTY: "RSA"
+      SYNC_TOKENSERVER__FXA_OAUTH_JWK__ALG: "RS256"
+      SYNC_TOKENSERVER__FXA_OAUTH_JWK__KID: "20190730-15e473fd"
+      SYNC_TOKENSERVER__FXA_OAUTH_JWK__FXA_CREATED_AT: "1564502400"
+      SYNC_TOKENSERVER__FXA_OAUTH_JWK__USE: "sig"
+      SYNC_TOKENSERVER__FXA_OAUTH_JWK__N: "15OpVGC7ws_SlU0gRbRh1Iwo8_gR8ElX2CDnbN5blKyXLg-ll0ogktoDXc-tDvTabRTxi7AXU0wWQ247odhHT47y5uz0GASYXdfPponynQ_xR9CpNn1eEL1gvDhQN9rfPIzfncl8FUi9V4WMd5f600QC81yDw9dX-Z8gdkru0aDaoEKF9-wU2TqrCNcQdiJCX9BISotjz_9cmGwKXFEekQNJWBeRQxH2bUmgwUK0HaqwW9WbYOs-zstNXXWFsgK9fbDQqQeGehXLZM4Cy5Mgl_iuSvnT3rLzPo2BmlxMLUvRqBx3_v8BTtwmNGA0v9O0FJS_mnDq0Iue0Dz8BssQCQ"
+      SYNC_TOKENSERVER__FXA_OAUTH_JWK__E: "AQAB"
+      TOKENSERVER_HOST: http://localhost:8000
+    entrypoint: >
+      /bin/sh -c "
+        sleep 28; python3 /app/tools/integration_tests/run.py 'http://localhost:8000#secret0'
+      "

--- a/syncstorage/src/tokenserver/auth/verify.py
+++ b/syncstorage/src/tokenserver/auth/verify.py
@@ -6,8 +6,8 @@ DEFAULT_OAUTH_SCOPE = 'https://identity.mozilla.com/apps/oldsync'
 
 
 class FxaOAuthClient:
-    def __init__(self, server_url=None):
-        self._client = Client(server_url=server_url)
+    def __init__(self, server_url=None, jwks=None):
+        self._client = Client(server_url=server_url, jwks=jwks)
 
     def verify_token(self, token):
         try:

--- a/syncstorage/src/tokenserver/mod.rs
+++ b/syncstorage/src/tokenserver/mod.rs
@@ -41,7 +41,7 @@ pub struct ServerState {
 impl ServerState {
     pub fn from_settings(settings: &Settings, metrics: StatsdClient) -> Result<Self, ApiError> {
         let oauth_verifier = Box::new(
-            oauth::RemoteVerifier::try_from(settings)
+            oauth::Verifier::try_from(settings)
                 .expect("failed to create Tokenserver OAuth verifier"),
         );
         let browserid_verifier = Box::new(

--- a/syncstorage/src/tokenserver/settings.rs
+++ b/syncstorage/src/tokenserver/settings.rs
@@ -28,8 +28,8 @@ pub struct Settings {
     /// The timeout to be used when making requests to the FxA OAuth verification server.
     pub fxa_oauth_request_timeout: u64,
     /// The JWK to be used to verify OAuth tokens. Passing a JWK to the PyFxA Python library
-    /// prevents it from making an external API call to FxA (instead verifying the token locally),
-    /// yielding substantial performance benefits.
+    /// prevents it from making an external API call to FxA to get the JWK, yielding substantial
+    /// performance benefits.
     pub fxa_oauth_jwk: Option<Jwk>,
     /// The issuer expected in the BrowserID verification response.
     pub fxa_browserid_issuer: String,

--- a/syncstorage/src/tokenserver/settings.rs
+++ b/syncstorage/src/tokenserver/settings.rs
@@ -27,6 +27,8 @@ pub struct Settings {
     pub fxa_oauth_server_url: String,
     /// The timeout to be used when making requests to the FxA OAuth verification server.
     pub fxa_oauth_request_timeout: u64,
+    /// The JWK to be used to verify OAuth tokens.
+    pub fxa_oauth_jwk: Option<Jwk>,
     /// The issuer expected in the BrowserID verification response.
     pub fxa_browserid_issuer: String,
     /// The audience to be sent to the FxA BrowserID verification server.
@@ -50,6 +52,18 @@ pub struct Settings {
     pub run_migrations: bool,
 }
 
+#[derive(Clone, Debug, Deserialize)]
+pub struct Jwk {
+    pub kty: String,
+    pub alg: String,
+    pub kid: String,
+    pub fxa_created_at: u64,
+    #[serde(rename = "use")]
+    pub use_of_key: String,
+    pub n: String,
+    pub e: String,
+}
+
 impl Default for Settings {
     fn default() -> Settings {
         Settings {
@@ -62,6 +76,7 @@ impl Default for Settings {
             fxa_metrics_hash_secret: "secret".to_owned(),
             fxa_oauth_server_url: "https://oauth.stage.mozaws.net".to_owned(),
             fxa_oauth_request_timeout: 10,
+            fxa_oauth_jwk: None,
             fxa_browserid_audience: "https://token.stage.mozaws.net".to_owned(),
             fxa_browserid_issuer: "api-accounts.stage.mozaws.net".to_owned(),
             fxa_browserid_server_url: "https://verifier.stage.mozaws.net/v2".to_owned(),

--- a/syncstorage/src/tokenserver/settings.rs
+++ b/syncstorage/src/tokenserver/settings.rs
@@ -27,7 +27,9 @@ pub struct Settings {
     pub fxa_oauth_server_url: String,
     /// The timeout to be used when making requests to the FxA OAuth verification server.
     pub fxa_oauth_request_timeout: u64,
-    /// The JWK to be used to verify OAuth tokens.
+    /// The JWK to be used to verify OAuth tokens. Passing a JWK to the PyFxA Python library
+    /// prevents it from making an external API call to FxA (instead verifying the token locally),
+    /// yielding substantial performance benefits.
     pub fxa_oauth_jwk: Option<Jwk>,
     /// The issuer expected in the BrowserID verification response.
     pub fxa_browserid_issuer: String,


### PR DESCRIPTION
## Description

The Python Tokenserver supports setting the JWK used to verify OAuth tokens, [which prevents the `PyFxA` library from having to make a request to FxA to verify tokens](https://github.com/mozilla/PyFxA/blob/main/fxa/oauth.py#L288). Eliminating this request will yield substantial performance benefits.

## Testing

I tested this by adding a `print` statement in `verify.py` to ensure that the JWK was properly being passed into the pyfxa OAuth `Client`.