### PR TITLE
refactor: replaced dbg! with trace macro

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@
 #
 version: 2.1
 commands:
-  setup-rust:
+  display-rust:
     steps:
       - run:
           name: Display Rust Version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ commands:
     steps:
       - run:
           name: Setup Rust
-          command: |
+          command: 
             # rustup install stable
             # rustup default stable
             # rustup update

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,9 +11,9 @@ commands:
       - run:
           name: Setup Rust
           command: |
-            rustup install stable
-            rustup default stable
-            rustup update
+            # rustup install stable
+            # rustup default stable
+            # rustup update
             rustc --version
   setup-rust-check:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ commands:
       - run:
           name: cargo build
           command: cargo build
-          timeout: 20m
+          no_output_timeout: 20m
   setup-gcp-grpc:
     steps:
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ commands:
   setup-rust:
     steps:
       - run:
-          name: Setup Rust
+          name: Display Rust Version
           command: 
             rustc --version
   setup-rust-check:
@@ -54,7 +54,6 @@ commands:
       - run:
           name: cargo build
           command: cargo build
-          no_output_timeout: 20m
   setup-gcp-grpc:
     steps:
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,6 +57,7 @@ commands:
       - run:
           name: cargo build
           command: cargo build
+          timeout: 20m
   setup-gcp-grpc:
     steps:
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,7 +166,7 @@ jobs:
           password: $DOCKER_PASS
     steps:
       - checkout
-      - setup-rust
+      - display-rust
       - setup-rust-check
       - setup-gcp-grpc
       - rust-check
@@ -207,7 +207,7 @@ jobs:
               echo "${DOCKER_PASS}" | docker login -u="${DOCKER_USER}" --password-stdin
             fi
       - checkout
-      - setup-rust
+      - display-rust
       - setup-python
       - setup-gcp-grpc
       - setup-mysql

--- a/syncstorage/src/web/handlers.rs
+++ b/syncstorage/src/web/handlers.rs
@@ -365,7 +365,7 @@ pub async fn post_collection_batch(
         if !coll.bsos.valid.is_empty() {
             // Append the data to the requested batch.
             let result = {
-                dbg!("Batch: Appending to {}", &new_batch.id);
+                trace!("Batch: Appending to {}", &new_batch.id);
                 db.append_to_batch(params::AppendToBatch {
                     user_id: coll.user_id.clone(),
                     collection: coll.collection.clone(),


### PR DESCRIPTION
## Description

Simple change to replace `dbg!` marco with the slog-rs `trace!` macro, since the `dbg!` was resulting in stderr output, not to stdout.

## Testing
Compiles and matches patterns in rest of `handlers.rs` file.
Had to make alterations within the `.circleci` yaml file. @pjenvey was essential in identifying issue where cargo build pulls in most recent rust version which is often at odds with the specified version in the Docker build, which is explicitly hard-coded. 
Commented out commands to build rust and update which would override specified version in CI/CD. In the future, these lines can be commented back in and a `|` inserted at start of command directive.
Also, it was necessary to add the `no_output_timeout` directive to `cargo build` to allow for longer compilation times.

How should reviewers test?
Ensure GCP logs show  output of trace!("Batch: Appending to {}", &new_batch.id); replacing previous `dbg!` [here](https://github.com/mozilla-services/syncstorage-rs/blob/master/syncstorage/src/web/handlers.rs#L368)

## Issue(s)

Closes [link](https://github.com/mozilla-services/syncstorage-rs/issues/1309).
