### PR TITLE
chore: pin Rust 1.60.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,8 +11,8 @@ commands:
       - run:
           name: Setup Rust
           command: |
-            rustup install stable
-            rustup default stable
+            rustup install 1.60.0
+            rustup default 1.60.0
             rustup update
             rustc --version
   setup-rust-check:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,7 +163,7 @@ commands:
 jobs:
   checks:
     docker:
-      - image: circleci/rust:latest
+      - image: cimg/rust:1.60.0
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
@@ -179,7 +179,7 @@ jobs:
 
   build-and-test:
     docker:
-      - image: circleci/rust:latest
+      - image: cimg/rust:1.60.0
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS


### PR DESCRIPTION
## Description

Rust 1.61.0 uses substantially more memory than 1.60.0 in our CI builds, preventing them from completing (and preventing us from merging anything new). This PR pins Rust 1.60.0 until the issue is resolved upstream.

Upstream issue: https://github.com/rust-lang/rust/issues/97549
