### PR TITLE
perf: remove unnecessary database calls for Tokenserver

### DIFF
--- a/syncstorage/src/tokenserver/db/params.rs
+++ b/syncstorage/src/tokenserver/db/params.rs
@@ -35,7 +35,6 @@ pub struct GetOrCreateUser {
     pub client_state: String,
     pub keys_changed_at: Option<i64>,
     pub capacity_release_rate: Option<f32>,
-    pub spanner_node_id: Option<i32>,
 }
 
 pub type AllocateUser = GetOrCreateUser;
@@ -85,7 +84,6 @@ pub struct GetNodeId {
 pub struct GetBestNode {
     pub service_id: i32,
     pub capacity_release_rate: Option<f32>,
-    pub spanner_node_id: Option<i32>,
 }
 
 #[derive(Default)]

--- a/syncstorage/src/tokenserver/db/pool.rs
+++ b/syncstorage/src/tokenserver/db/pool.rs
@@ -35,6 +35,9 @@ pub struct TokenserverPool {
     /// Pool of db connections
     inner: Pool<ConnectionManager<MysqlConnection>>,
     metrics: Metrics,
+    // This field is public so the service ID can be set after the pool is created
+    pub service_id: Option<i32>,
+    spanner_node_id: Option<i32>,
 }
 
 impl TokenserverPool {
@@ -65,13 +68,20 @@ impl TokenserverPool {
         Ok(Self {
             inner: builder.build(manager)?,
             metrics: metrics.clone(),
+            spanner_node_id: settings.spanner_node_id,
+            service_id: None,
         })
     }
 
     pub fn get_sync(&self) -> Result<TokenserverDb, DbError> {
         let conn = self.inner.get().map_err(DbError::from)?;
 
-        Ok(TokenserverDb::new(conn, &self.metrics))
+        Ok(TokenserverDb::new(
+            conn,
+            &self.metrics,
+            self.service_id,
+            self.spanner_node_id,
+        ))
     }
 
     #[cfg(test)]
@@ -80,7 +90,12 @@ impl TokenserverPool {
         let conn =
             db::run_on_blocking_threadpool(move || pool.inner.get().map_err(DbError::from)).await?;
 
-        Ok(TokenserverDb::new(conn, &self.metrics))
+        Ok(TokenserverDb::new(
+            conn,
+            &self.metrics,
+            self.service_id,
+            self.spanner_node_id,
+        ))
     }
 }
 
@@ -94,7 +109,12 @@ impl DbPool for TokenserverPool {
         let conn =
             db::run_on_blocking_threadpool(move || pool.inner.get().map_err(DbError::from)).await?;
 
-        Ok(Box::new(TokenserverDb::new(conn, &self.metrics)) as Box<dyn Db>)
+        Ok(Box::new(TokenserverDb::new(
+            conn,
+            &self.metrics,
+            self.service_id,
+            self.spanner_node_id,
+        )) as Box<dyn Db>)
     }
 
     fn box_clone(&self) -> Box<dyn DbPool> {

--- a/syncstorage/src/tokenserver/extractors.rs
+++ b/syncstorage/src/tokenserver/extractors.rs
@@ -199,13 +199,11 @@ impl FromRequest for TokenserverRequest {
 
                 if application == "sync" {
                     if version == "1.5" {
-                        state.service_id.unwrap_or(
-                            db.get_service_id(params::GetServiceId {
-                                service: SYNC_SERVICE_NAME.to_owned(),
-                            })
-                            .await?
-                            .id,
-                        )
+                        db.get_service_id(params::GetServiceId {
+                            service: SYNC_SERVICE_NAME.to_owned(),
+                        })
+                        .await?
+                        .id
                     } else {
                         return Err(TokenserverError::unsupported(
                             "Unsupported application version".to_owned(),
@@ -232,7 +230,6 @@ impl FromRequest for TokenserverRequest {
                     client_state: auth_data.client_state.clone(),
                     keys_changed_at: auth_data.keys_changed_at,
                     capacity_release_rate: state.node_capacity_release_rate,
-                    spanner_node_id: state.spanner_node_id,
                 })
                 .await?;
             log_items_mutator.insert("first_seen_at".to_owned(), user.first_seen_at.to_string());
@@ -1298,7 +1295,6 @@ mod tests {
             db_pool: Box::new(MockTokenserverPool::new()),
             node_capacity_release_rate: None,
             node_type: NodeType::default(),
-            service_id: None,
             metrics: Box::new(
                 metrics::metrics_from_opts(
                     &settings.tokenserver.statsd_label,
@@ -1307,7 +1303,6 @@ mod tests {
                 )
                 .unwrap(),
             ),
-            spanner_node_id: None,
         }
     }
 }

--- a/syncstorage/src/tokenserver/handlers.rs
+++ b/syncstorage/src/tokenserver/handlers.rs
@@ -172,14 +172,16 @@ async fn update_user(
             uid,
         })
     } else {
-        let params = PutUser {
-            email: req.auth_data.email.clone(),
-            service_id: req.service_id,
-            generation,
-            keys_changed_at: Some(keys_changed_at),
-        };
+        if generation != req.user.generation || Some(keys_changed_at) != req.user.keys_changed_at {
+            let params = PutUser {
+                email: req.auth_data.email.clone(),
+                service_id: req.service_id,
+                generation,
+                keys_changed_at: Some(keys_changed_at),
+            };
 
-        db.put_user(params).await?;
+            db.put_user(params).await?;
+        }
 
         Ok(UserUpdates {
             keys_changed_at,

--- a/syncstorage/src/tokenserver/mod.rs
+++ b/syncstorage/src/tokenserver/mod.rs
@@ -34,9 +34,7 @@ pub struct ServerState {
     pub browserid_verifier: Box<dyn VerifyToken<Output = browserid::VerifyOutput>>,
     pub node_capacity_release_rate: Option<f32>,
     pub node_type: NodeType,
-    pub service_id: Option<i32>,
     pub metrics: Box<StatsdClient>,
-    pub spanner_node_id: Option<i32>,
 }
 
 impl ServerState {
@@ -52,8 +50,8 @@ impl ServerState {
         let use_test_transactions = false;
 
         TokenserverPool::new(settings, &Metrics::from(&metrics), use_test_transactions)
-            .map(|db_pool| {
-                let service_id = db_pool
+            .map(|mut db_pool| {
+                db_pool.service_id = db_pool
                     .get_sync()
                     .and_then(|db| {
                         db.get_service_id_sync(params::GetServiceId {
@@ -72,8 +70,6 @@ impl ServerState {
                     node_capacity_release_rate: settings.node_capacity_release_rate,
                     node_type: settings.node_type,
                     metrics: Box::new(metrics),
-                    service_id,
-                    spanner_node_id: settings.spanner_node_id,
                 }
             })
             .map_err(Into::into)

--- a/syncstorage/src/tokenserver/mod.rs
+++ b/syncstorage/src/tokenserver/mod.rs
@@ -51,9 +51,8 @@ impl ServerState {
 
         TokenserverPool::new(settings, &Metrics::from(&metrics), use_test_transactions)
             .map(|mut db_pool| {
-                // NOTE: The only situation in which this query will fail is if there is no
-                // "sync-1.5" service record in the database, but for our purposes, this record
-                // should always exist
+                // NOTE: Provided there's a "sync-1.5" service record in the database, it is highly
+                // unlikely for this query to fail outside of random network failures
                 db_pool.service_id = db_pool
                     .get_sync()
                     .and_then(|db| {

--- a/syncstorage/src/tokenserver/mod.rs
+++ b/syncstorage/src/tokenserver/mod.rs
@@ -52,7 +52,8 @@ impl ServerState {
         TokenserverPool::new(settings, &Metrics::from(&metrics), use_test_transactions)
             .map(|mut db_pool| {
                 // NOTE: Provided there's a "sync-1.5" service record in the database, it is highly
-                // unlikely for this query to fail outside of random network failures
+                // unlikely for this query to fail outside of network failures or other random
+                // errors
                 db_pool.service_id = db_pool
                     .get_sync()
                     .and_then(|db| {

--- a/syncstorage/src/tokenserver/mod.rs
+++ b/syncstorage/src/tokenserver/mod.rs
@@ -51,6 +51,9 @@ impl ServerState {
 
         TokenserverPool::new(settings, &Metrics::from(&metrics), use_test_transactions)
             .map(|mut db_pool| {
+                // NOTE: The only situation in which this query will fail is if there is no
+                // "sync-1.5" service record in the database, but for our purposes, this record
+                // should always exist
                 db_pool.service_id = db_pool
                     .get_sync()
                     .and_then(|db| {


### PR DESCRIPTION
## Description

A few more changes I wanted to make before we load test:
* Only call `Db::put_user` if there are changes that need to be made to the user record
* Remove an unnecessary call to `Db::get_node_id` when the Spanner node ID is cached
* Cache `spanner_node_id` and `service_id` on `TokenserverPool` and `TokenserverDb` instead of on `ServerState` (this isn't really a performance improvement; just a refactor I thought made sense given the changes here)
* Add metrics for some of the most common database methods

## Testing

These changes should be transparent. The caching of the Spanner node ID already has test coverage, and user updates have integration test coverage.