### PR TITLE
feat: use Actix to spawn blocking threads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ target
 .#*
 service-account.json
 .sentryclirc
+.envrc
 
 config/local.toml
 tools/tokenserver/loadtests/*.pem

--- a/syncstorage/src/db/mysql/pool.rs
+++ b/syncstorage/src/db/mysql/pool.rs
@@ -64,7 +64,7 @@ impl MysqlDbPool {
     pub fn new_without_migrations(settings: &Settings, metrics: &Metrics) -> Result<Self> {
         let manager = ConnectionManager::<MysqlConnection>::new(settings.database_url.clone());
         let builder = Pool::builder()
-            .max_size(settings.database_pool_max_size.unwrap_or(10))
+            .max_size(settings.database_pool_max_size)
             .connection_timeout(Duration::from_secs(
                 settings.database_pool_connection_timeout.unwrap_or(30) as u64,
             ))

--- a/syncstorage/src/db/spanner/pool.rs
+++ b/syncstorage/src/db/spanner/pool.rs
@@ -47,7 +47,7 @@ impl SpannerDbPool {
     }
 
     pub async fn new_without_migrations(settings: &Settings, metrics: &Metrics) -> Result<Self> {
-        let max_size = settings.database_pool_max_size.unwrap_or(10) as usize;
+        let max_size = settings.database_pool_max_size as usize;
         let wait = settings
             .database_pool_connection_timeout
             .map(|seconds| Duration::from_secs(seconds as u64));

--- a/syncstorage/src/server/test.rs
+++ b/syncstorage/src/server/test.rs
@@ -59,7 +59,7 @@ fn get_test_settings() -> Settings {
     .expect("Could not get pool_size in get_test_settings");
     settings.port = port;
     settings.host = host;
-    settings.database_pool_max_size = Some(pool_size + 1);
+    settings.database_pool_max_size = pool_size + 1;
     settings
 }
 
@@ -726,7 +726,7 @@ async fn lbheartbeat_max_pool_size_check() {
     use actix_web::web::Buf;
 
     let mut settings = get_test_settings();
-    settings.database_pool_max_size = Some(10);
+    settings.database_pool_max_size = 10;
 
     let mut app = init_app!(settings).await;
 

--- a/syncstorage/src/settings.rs
+++ b/syncstorage/src/settings.rs
@@ -386,7 +386,7 @@ impl Settings {
                 };
 
                 env::set_var(
-                    "ACITX_THREADPOOL",
+                    "ACTIX_THREADPOOL",
                     ((total_db_pool_size + fxa_threads) as usize)
                         .max(num_cpus::get() * 5)
                         .to_string(),

--- a/syncstorage/src/settings.rs
+++ b/syncstorage/src/settings.rs
@@ -349,10 +349,7 @@ impl Settings {
                     s.enable_quota = true
                 }
 
-                if matches!(
-                    env::var("ACTIX_THREADPOOL").unwrap_err(),
-                    Err(VarError::NotPresent)
-                ) {
+                if matches!(env::var("ACTIX_THREADPOOL"), Err(VarError::NotPresent)) {
                     // Db backends w/ blocking calls block via
                     // actix-threadpool: grow its size to accommodate the
                     // full number of connections

--- a/syncstorage/src/settings.rs
+++ b/syncstorage/src/settings.rs
@@ -53,7 +53,7 @@ pub struct Quota {
 /// Optionally we can permanently fail the check after a set time period,
 /// indicating that this instance should be evicted and replaced.
 pub struct Deadman {
-    pub max_size: Option<u32>,
+    pub max_size: u32,
     pub previous_count: usize,
     pub clock_start: Option<time::Instant>,
     pub expiry: Option<time::Instant>,
@@ -83,7 +83,7 @@ pub struct Settings {
     pub port: u16,
     pub host: String,
     pub database_url: String,
-    pub database_pool_max_size: Option<u32>,
+    pub database_pool_max_size: u32,
     // NOTE: Not supported by deadpool!
     pub database_pool_min_idle: Option<u32>,
     /// Pool timeout when waiting for a slot to become available, in seconds
@@ -144,7 +144,7 @@ impl Default for Settings {
             port: DEFAULT_PORT,
             host: "127.0.0.1".to_string(),
             database_url: "mysql://root@127.0.0.1/syncstorage".to_string(),
-            database_pool_max_size: None,
+            database_pool_max_size: 10,
             database_pool_min_idle: None,
             database_pool_connection_lifespan: None,
             database_pool_connection_max_idle: None,
@@ -203,6 +203,7 @@ impl Settings {
         s.set_default("human_logs", false)?;
         #[cfg(test)]
         s.set_default("database_pool_connection_timeout", Some(30))?;
+        s.set_default("database_pool_max_size", 10)?;
         // Max lifespan a connection should have.
         s.set_default::<Option<String>>("database_connection_lifespan", None)?;
         // Max time a connection should be idle before dropping.
@@ -245,6 +246,7 @@ impl Settings {
             "tokenserver.database_url",
             "mysql://root@127.0.0.1/tokenserver",
         )?;
+        s.set_default("tokenserver.database_pool_max_size", 10)?;
         s.set_default("tokenserver.enabled", false)?;
         s.set_default(
             "tokenserver.fxa_browserid_audience",
@@ -331,18 +333,7 @@ impl Settings {
                     ms.limits.max_total_bytes =
                         min(ms.limits.max_total_bytes, MAX_SPANNER_LOAD_SIZE as u32);
                     return Ok(ms);
-                }
-
-                if !s.uses_spanner() {
-                    if let Some(database_pool_max_size) = s.database_pool_max_size {
-                        // Db backends w/ blocking calls block via
-                        // actix-threadpool: grow its size to accommodate the
-                        // full number of connections
-                        let default = num_cpus::get() * 5;
-                        if (database_pool_max_size as usize) > default {
-                            env::set_var("ACTIX_THREADPOOL", database_pool_max_size.to_string());
-                        }
-                    }
+                } else {
                     // No quotas for stand alone servers
                     s.limits.max_quota_limit = 0;
                     s.enable_quota = false;
@@ -354,6 +345,31 @@ impl Settings {
                 if s.enforce_quota {
                     s.enable_quota = true
                 }
+
+                // Db backends w/ blocking calls block via
+                // actix-threadpool: grow its size to accommodate the
+                // full number of connections
+                let total_db_pool_size = {
+                    let mysql_db_pool_max_size = if s.uses_spanner() {
+                        0
+                    } else {
+                        s.database_pool_max_size
+                    };
+
+                    let tokenserver_pool_max_size = if s.tokenserver.enabled {
+                        s.tokenserver.database_pool_max_size
+                    } else {
+                        0
+                    };
+
+                    mysql_db_pool_max_size + tokenserver_pool_max_size
+                };
+                env::set_var(
+                    "ACITX_THREADPOOL",
+                    (total_db_pool_size as usize)
+                        .max(num_cpus::get() * 5)
+                        .to_string(),
+                );
                 s
             }
             Err(e) => match e {
@@ -545,7 +561,7 @@ pub fn test_settings() -> Settings {
         .expect("Could not get Settings in get_test_settings");
     settings.debug = true;
     settings.port = 8000;
-    settings.database_pool_max_size = Some(1);
+    settings.database_pool_max_size = 1;
     settings.database_use_test_transactions = true;
     settings.database_pool_connection_max_idle = Some(300);
     settings.database_pool_connection_lifespan = Some(300);

--- a/syncstorage/src/settings.rs
+++ b/syncstorage/src/settings.rs
@@ -350,7 +350,7 @@ impl Settings {
                 // actix-threadpool: grow its size to accommodate the
                 // full number of connections
                 let total_db_pool_size = {
-                    let mysql_db_pool_max_size = if s.uses_spanner() {
+                    let syncstorage_pool_max_size = if s.uses_spanner() || s.disable_syncstorage {
                         0
                     } else {
                         s.database_pool_max_size
@@ -362,7 +362,7 @@ impl Settings {
                         0
                     };
 
-                    mysql_db_pool_max_size + tokenserver_pool_max_size
+                    syncstorage_pool_max_size + tokenserver_pool_max_size
                 };
 
                 let fxa_threads = if s.tokenserver.enabled

--- a/syncstorage/src/tokenserver/auth/oauth.rs
+++ b/syncstorage/src/tokenserver/auth/oauth.rs
@@ -1,5 +1,5 @@
+use actix_web::{error::BlockingError, web};
 use async_trait::async_trait;
-use futures::TryFutureExt;
 use pyo3::{
     prelude::{Py, PyAny, PyErr, PyModule, Python},
     types::{IntoPyDict, PyString},
@@ -7,7 +7,7 @@ use pyo3::{
 use serde::{Deserialize, Serialize};
 use serde_json;
 use tokenserver_common::error::TokenserverError;
-use tokio::{task, time};
+use tokio::time;
 
 use super::VerifyToken;
 use crate::tokenserver::settings::{Jwk, Settings};
@@ -155,20 +155,7 @@ impl VerifyToken for Verifier {
             // If the JWK is not cached, PyFxA will make a request to FxA to retrieve it, blocking
             // this thread. To improve performance, we make the request on a thread in a threadpool
             // specifically used for blocking operations.
-            let fut = task::spawn_blocking(move || verify_inner(&verifier)).map_err(|err| {
-                let context = if err.is_cancelled() {
-                    "Tokenserver threadpool operation cancelled"
-                } else if err.is_panic() {
-                    "Tokenserver threadpool operation panicked"
-                } else {
-                    "Tokenserver threadpool operation failed for unknown reason"
-                };
-
-                TokenserverError {
-                    context: context.to_owned(),
-                    ..TokenserverError::internal_error()
-                }
-            });
+            let fut = web::block(move || verify_inner(&verifier)); //.map_err(|err| {
 
             // The PyFxA OAuth client does not offer a way to set a request timeout, so we set one here
             // by timing out the future if the verification process blocks this thread for longer
@@ -179,7 +166,13 @@ impl VerifyToken for Verifier {
                     context: "OAuth verification timeout".to_owned(),
                     ..TokenserverError::resource_unavailable()
                 })?
-                .map_err(|_| TokenserverError::resource_unavailable())?
+                .map_err(|e| match e {
+                    BlockingError::Error(_) => TokenserverError::resource_unavailable(),
+                    BlockingError::Canceled => TokenserverError {
+                        context: "Tokenserver threadpool operation failed".to_owned(),
+                        ..TokenserverError::internal_error()
+                    },
+                })
         }
     }
 }

--- a/syncstorage/src/tokenserver/auth/oauth.rs
+++ b/syncstorage/src/tokenserver/auth/oauth.rs
@@ -154,7 +154,8 @@ impl VerifyToken for Verifier {
 
             // If the JWK is not cached, PyFxA will make a request to FxA to retrieve it, blocking
             // this thread. To improve performance, we make the request on a thread in a threadpool
-            // specifically used for blocking operations.
+            // specifically used for blocking operations. The JWK should _always_ be cached in
+            // production to maximize performance.
             let fut = web::block(move || verify_inner(&verifier)); //.map_err(|err| {
 
             // The PyFxA OAuth client does not offer a way to set a request timeout, so we set one here

--- a/syncstorage/src/tokenserver/db/pool.rs
+++ b/syncstorage/src/tokenserver/db/pool.rs
@@ -52,7 +52,7 @@ impl TokenserverPool {
 
         let manager = ConnectionManager::<MysqlConnection>::new(settings.database_url.clone());
         let builder = Pool::builder()
-            .max_size(settings.database_pool_max_size.unwrap_or(10))
+            .max_size(settings.database_pool_max_size)
             .connection_timeout(Duration::from_secs(
                 settings.database_pool_connection_timeout.unwrap_or(30) as u64,
             ))

--- a/syncstorage/src/tokenserver/settings.rs
+++ b/syncstorage/src/tokenserver/settings.rs
@@ -57,6 +57,12 @@ pub struct Settings {
     pub run_migrations: bool,
     /// The database ID of the Spanner node.
     pub spanner_node_id: Option<i32>,
+    /// The number of additional blocking threads to add to the blocking threadpool to handle
+    /// OAuth verification requests to FxA. This value is added to the `ACTIX_THREADPOOL` env var.
+    /// Note that this setting only applies if the OAuth public JWK is not cached, since OAuth
+    /// verifications do not require requests to FXA if the JWK is set on Tokenserver. The server
+    /// will return an error at startup if the JWK is not cached and this setting is `None`.
+    pub additional_blocking_threads_for_fxa_requests: Option<u32>,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -95,6 +101,7 @@ impl Default for Settings {
             statsd_label: "syncstorage.tokenserver".to_owned(),
             run_migrations: cfg!(test),
             spanner_node_id: None,
+            additional_blocking_threads_for_fxa_requests: None,
         }
     }
 }

--- a/syncstorage/src/tokenserver/settings.rs
+++ b/syncstorage/src/tokenserver/settings.rs
@@ -7,7 +7,7 @@ pub struct Settings {
     /// The URL of the Tokenserver MySQL database.
     pub database_url: String,
     /// The max size of the database connection pool.
-    pub database_pool_max_size: Option<u32>,
+    pub database_pool_max_size: u32,
     // NOTE: Not supported by deadpool!
     /// The minimum number of database connections to be maintained at any given time.
     pub database_pool_min_idle: Option<u32>,
@@ -75,7 +75,7 @@ impl Default for Settings {
     fn default() -> Settings {
         Settings {
             database_url: "mysql://root@127.0.0.1/tokenserver_rs".to_owned(),
-            database_pool_max_size: None,
+            database_pool_max_size: 10,
             database_pool_min_idle: None,
             database_pool_connection_timeout: Some(30),
             enabled: false,

--- a/syncstorage/src/web/auth.rs
+++ b/syncstorage/src/web/auth.rs
@@ -512,7 +512,6 @@ mod tests {
                     port: 0,
                     host: "127.0.0.1".to_string(),
                     database_url: "".to_string(),
-                    database_pool_max_size: None,
                     database_use_test_transactions: false,
                     limits: Default::default(),
                     master_secret: Secrets::new("Ted Koppel is a robot").unwrap(),


### PR DESCRIPTION
## Description

In a previous commit, I refactored syncstorage-rs to use tokio's `task::spawn_blocking` to add blocking tasks to tokio's blocking threadpool. Since the tokio runtime is started up by Actix, we don't have easy control over the number of threads in the blocking threadpool. We should stick with using Actix's [`web::block`](https://docs.rs/actix-web/3.3.3/actix_web/web/fn.block.html) to spawn blocking tasks, since we can control the size of the blocking threadpool using `ACTIX_THREADPOOL`.

This PR switches back to using `web::block`. It also:
* Adds the ability for the server to correctly set `ACTIX_THREADPOOL` based on the sizes of the Syncstorage and Tokenserver database connection pools
* Adds an `additional_blocking_threads_for_fxa_requests` setting to add more blocking threads when the OAuth JWK is not cached on the server. The server will throw an error at startup if this setting is unset when the JWK is not cached to ensure that there are always enough blocking threads in the threadpool to allow for the max number of database connections and requests to FxA
* Refactors `Settings` to set the defaults for `database_pool_max_size` and `tokenserver.database_pool_max_size` in a single place

## Testing

N/A