### PR TITLE
bug: fix JWT library for Tokenserver load tests

### DIFF
--- a/tools/tokenserver/loadtests/requirements.txt
+++ b/tools/tokenserver/loadtests/requirements.txt
@@ -1,6 +1,6 @@
 authlib
 cryptography
-jwt
 locust
 pybrowserid
+pyjwt
 sqlalchemy


### PR DESCRIPTION
`jwt` was specified as the JWT library to be used for the Tokenserver load tests, but `pyjwt` should have been used instead.

Closes #1372 
