### PR TITLE
feat: add `__error__` endpoint to Tokenserver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3273,6 +3273,7 @@ dependencies = [
  "backtrace",
  "serde 1.0.135",
  "serde_json",
+ "syncstorage-common",
  "syncstorage-db-common",
  "thiserror",
 ]

--- a/syncstorage-common/src/lib.rs
+++ b/syncstorage-common/src/lib.rs
@@ -19,3 +19,7 @@ macro_rules! impl_fmt_display {
         }
     };
 }
+
+pub trait ErrorBacktrace {
+    fn error_backtrace(&self) -> String;
+}

--- a/syncstorage-common/src/lib.rs
+++ b/syncstorage-common/src/lib.rs
@@ -20,6 +20,8 @@ macro_rules! impl_fmt_display {
     };
 }
 
-pub trait ErrorBacktrace {
+pub trait ReportableError {
     fn error_backtrace(&self) -> String;
+    fn is_reportable(&self) -> bool;
+    fn metric_label(&self) -> Option<String>;
 }

--- a/syncstorage-common/src/lib.rs
+++ b/syncstorage-common/src/lib.rs
@@ -22,6 +22,6 @@ macro_rules! impl_fmt_display {
 
 pub trait ReportableError {
     fn error_backtrace(&self) -> String;
-    fn is_reportable(&self) -> bool;
+    fn is_sentry_event(&self) -> bool;
     fn metric_label(&self) -> Option<String>;
 }

--- a/syncstorage-db-common/src/error.rs
+++ b/syncstorage-db-common/src/error.rs
@@ -65,7 +65,7 @@ impl DbError {
         DbErrorKind::Internal(msg.to_owned()).into()
     }
 
-    pub fn is_reportable(&self) -> bool {
+    pub fn is_sentry_event(&self) -> bool {
         !matches!(&self.kind, DbErrorKind::Conflict)
     }
 

--- a/syncstorage/src/error.rs
+++ b/syncstorage/src/error.rs
@@ -267,11 +267,11 @@ impl ReportableError for ApiError {
         format!("{:#?}", self.backtrace)
     }
 
-    fn is_reportable(&self) -> bool {
+    fn is_sentry_event(&self) -> bool {
         // Should we report this error to sentry?
         self.status.is_server_error()
             && match &self.kind {
-                ApiErrorKind::Db(dbe) => dbe.is_reportable(),
+                ApiErrorKind::Db(dbe) => dbe.is_sentry_event(),
                 _ => self.kind.metric_label().is_none(),
             }
     }

--- a/syncstorage/src/error.rs
+++ b/syncstorage/src/error.rs
@@ -21,7 +21,7 @@ use serde::{
     Serialize,
 };
 
-use syncstorage_common::{from_error, impl_fmt_display, ErrorBacktrace};
+use syncstorage_common::{from_error, impl_fmt_display, ReportableError};
 use syncstorage_db_common::error::DbError;
 use thiserror::Error;
 
@@ -96,15 +96,6 @@ impl ApiErrorKind {
 }
 
 impl ApiError {
-    pub fn is_reportable(&self) -> bool {
-        // Should we report this error to sentry?
-        self.status.is_server_error()
-            && match &self.kind {
-                ApiErrorKind::Db(dbe) => dbe.is_reportable(),
-                _ => self.kind.metric_label().is_none(),
-            }
-    }
-
     fn weave_error_code(&self) -> WeaveError {
         match &self.kind {
             ApiErrorKind::Validation(ver) => ver.weave_error_code(),
@@ -142,10 +133,6 @@ impl ApiError {
 
     pub fn is_bso_not_found(&self) -> bool {
         matches!(&self.kind, ApiErrorKind::Db(dbe) if dbe.is_bso_not_found())
-    }
-
-    pub fn metric_label(&self) -> Option<String> {
-        self.kind.metric_label()
     }
 }
 
@@ -275,8 +262,21 @@ impl From<DbError> for ApiError {
 from_error!(HawkError, ApiError, ApiErrorKind::Hawk);
 from_error!(ValidationError, ApiError, ApiErrorKind::Validation);
 
-impl ErrorBacktrace for ApiError {
+impl ReportableError for ApiError {
     fn error_backtrace(&self) -> String {
         format!("{:#?}", self.backtrace)
+    }
+
+    fn is_reportable(&self) -> bool {
+        // Should we report this error to sentry?
+        self.status.is_server_error()
+            && match &self.kind {
+                ApiErrorKind::Db(dbe) => dbe.is_reportable(),
+                _ => self.kind.metric_label().is_none(),
+            }
+    }
+
+    fn metric_label(&self) -> Option<String> {
+        self.kind.metric_label()
     }
 }

--- a/syncstorage/src/error.rs
+++ b/syncstorage/src/error.rs
@@ -21,7 +21,7 @@ use serde::{
     Serialize,
 };
 
-use syncstorage_common::{from_error, impl_fmt_display};
+use syncstorage_common::{from_error, impl_fmt_display, ErrorBacktrace};
 use syncstorage_db_common::error::DbError;
 use thiserror::Error;
 
@@ -274,3 +274,9 @@ impl From<DbError> for ApiError {
 
 from_error!(HawkError, ApiError, ApiErrorKind::Hawk);
 from_error!(ValidationError, ApiError, ApiErrorKind::Validation);
+
+impl ErrorBacktrace for ApiError {
+    fn error_backtrace(&self) -> String {
+        format!("{:#?}", self.backtrace)
+    }
+}

--- a/syncstorage/src/server/mod.rs
+++ b/syncstorage/src/server/mod.rs
@@ -215,6 +215,9 @@ macro_rules! build_app_without_syncstorage {
                         .body(include_str!("../../version.json"))
                 })),
             )
+            .service(
+                web::resource("/__error__").route(web::get().to(tokenserver::handlers::test_error)),
+            )
             .service(web::resource("/").route(web::get().to(|_: HttpRequest| {
                 HttpResponse::Found()
                     .header(LOCATION, SYNC_DOCS_URL)

--- a/syncstorage/src/tokenserver/handlers.rs
+++ b/syncstorage/src/tokenserver/handlers.rs
@@ -220,3 +220,13 @@ pub async fn heartbeat(db: Box<dyn Db>) -> Result<HttpResponse, Error> {
         }
     }
 }
+
+/// Generates an error to test the Sentry integration
+pub async fn test_error() -> Result<HttpResponse, TokenserverError> {
+    error!("Test Error");
+    Err(TokenserverError {
+        context: "Test error for Sentry".to_owned(),
+        description: "Test error for Sentry".to_owned(),
+        ..TokenserverError::internal_error()
+    })
+}

--- a/syncstorage/src/web/middleware/sentry.rs
+++ b/syncstorage/src/web/middleware/sentry.rs
@@ -144,17 +144,23 @@ where
                                 metrics.incr(&label);
                             }
                         }
-                        if !apie.is_reportable() {
+
+                        if apie.is_reportable() {
+                            report(&tags, event_from_error(apie));
+                        } else {
                             trace!("Sentry: Not reporting error: {:?}", apie);
-                            return Ok(sresp);
                         }
-                        report(&tags, event_from_error(apie));
                     } else if let Some(tokenserver_error) = e.as_error::<TokenserverError>() {
-                        if tokenserver_error.http_status.is_server_error() {
+                        if let Some(metrics) = metrics {
+                            if let Some(label) = tokenserver_error.metric_label() {
+                                metrics.incr(&label);
+                            }
+                        }
+
+                        if tokenserver_error.is_reportable() {
                             report(&tags, event_from_error(tokenserver_error));
                         } else {
                             trace!("Sentry: Not reporting error: {:?}", tokenserver_error);
-                            return Ok(sresp);
                         }
                     }
                 }

--- a/syncstorage/src/web/middleware/sentry.rs
+++ b/syncstorage/src/web/middleware/sentry.rs
@@ -160,7 +160,7 @@ where
         }
     }
 
-    if err.is_reportable() {
+    if err.is_sentry_event() {
         report(tags, event_from_error(err));
     } else {
         trace!("Sentry: Not reporting error: {:?}", err);
@@ -171,7 +171,7 @@ where
 ///
 /// `sentry::event_from_error` can't access `std::Error` backtraces as its
 /// `backtrace()` method is currently Rust nightly only. This function works
-/// against `HandlerError` instead to access its backtrace.
+/// against `ReportableError` instead to access its backtrace.
 pub fn event_from_error<E>(err: &E) -> Event<'static>
 where
     E: ReportableError + StdError + 'static,
@@ -197,12 +197,12 @@ where
     }
 }
 
-/// Custom `exception_from_error` support function for `ApiError`
+/// Custom `exception_from_error` support function for `ReportableError`
 ///
 /// Based moreso on sentry_failure's `exception_from_single_fail`.
 fn exception_from_error_with_backtrace<E>(err: &E) -> sentry::protocol::Exception
 where
-    E: ReportableError + StdError + ?Sized,
+    E: ReportableError + StdError,
 {
     let mut exception = exception_from_error(err);
     exception.stacktrace = parse_stacktrace(&err.error_backtrace());

--- a/syncstorage/src/web/middleware/sentry.rs
+++ b/syncstorage/src/web/middleware/sentry.rs
@@ -167,7 +167,7 @@ where
     }
 }
 
-/// Custom `sentry::event_from_error` for `ApiError`
+/// Custom `sentry::event_from_error` for `ReportableError`
 ///
 /// `sentry::event_from_error` can't access `std::Error` backtraces as its
 /// `backtrace()` method is currently Rust nightly only. This function works

--- a/tokenserver-common/Cargo.toml
+++ b/tokenserver-common/Cargo.toml
@@ -8,5 +8,6 @@ actix-web = "3"
 backtrace = "0.3.61"
 serde = "1.0"
 serde_json = { version = "1.0", features = ["arbitrary_precision"] }
+syncstorage-common = { path = "../syncstorage-common" }
 syncstorage-db-common = { path = "../syncstorage-db-common" }
 thiserror = "1.0.26"

--- a/tokenserver-common/src/error.rs
+++ b/tokenserver-common/src/error.rs
@@ -279,7 +279,7 @@ impl ReportableError for TokenserverError {
         format!("{:#?}", self.backtrace)
     }
 
-    fn is_reportable(&self) -> bool {
+    fn is_sentry_event(&self) -> bool {
         self.http_status.is_server_error() && self.metric_label().is_none()
     }
 

--- a/tokenserver-common/src/error.rs
+++ b/tokenserver-common/src/error.rs
@@ -1,4 +1,4 @@
-use std::{cmp::PartialEq, fmt};
+use std::{cmp::PartialEq, error::Error, fmt};
 
 use actix_web::{http::StatusCode, HttpResponse, ResponseError};
 use backtrace::Backtrace;
@@ -6,6 +6,7 @@ use serde::{
     ser::{SerializeMap, Serializer},
     Serialize,
 };
+use syncstorage_common::ErrorBacktrace;
 use syncstorage_db_common::error::DbError;
 
 #[derive(Clone, Debug)]
@@ -20,6 +21,8 @@ pub struct TokenserverError {
     pub context: String,
     pub backtrace: Backtrace,
 }
+
+impl Error for TokenserverError {}
 
 // We implement `PartialEq` manually here because `Backtrace` doesn't implement `PartialEq`, so we
 // can't derive it
@@ -260,5 +263,11 @@ impl From<DbError> for TokenserverError {
 impl From<TokenserverError> for HttpResponse {
     fn from(inner: TokenserverError) -> Self {
         ResponseError::error_response(&inner)
+    }
+}
+
+impl ErrorBacktrace for TokenserverError {
+    fn error_backtrace(&self) -> String {
+        format!("{:#?}", self.backtrace)
     }
 }


### PR DESCRIPTION
## Description

* Add the `/__error__` Dockerflow endpoint to Tokenserver
* Report `TokenserverError`s to Sentry

## Testing

The endpoint itself can be tested by running the server and sending `GET /__error__` to ensure that an error is correctly generated. I wasn't sure how to test integration with Sentry.

## Issue(s)

Closes #1364 
