### PR TITLE
feat: update Tokenserver load tests to test user allocation

### DIFF
--- a/tools/tokenserver/loadtests/locustfile.py
+++ b/tools/tokenserver/loadtests/locustfile.py
@@ -1,5 +1,6 @@
 from base64 import urlsafe_b64encode as b64encode
 import binascii
+import hashlib
 import jwt
 import os
 import time
@@ -77,6 +78,11 @@ class TokenserverTestUser(HttpUser):
         token = self._make_oauth_token(self.email)
 
         self._do_token_exchange_via_oauth(token)
+
+    @task(200)
+    def change_user_id(self):
+        self.fxa_uid = hashlib.sha256(self.fxa_uid.encode('utf-8')).hexdigest()
+        self.email = "loadtest-%s@%s" % (self.fxa_uid, MOCKMYID_DOMAIN)
 
     @task(100)
     def test_invalid_oauth(self):

--- a/tools/tokenserver/loadtests/locustfile.py
+++ b/tools/tokenserver/loadtests/locustfile.py
@@ -10,7 +10,7 @@ import browserid.jwt
 from browserid.tests.support import make_assertion
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
-from locust import HttpUser, task, between
+from locust import HttpUser, task, constant_throughput
 
 BROWSERID_AUDIENCE = os.environ['BROWSERID_AUDIENCE']
 DEFAULT_OAUTH_SCOPE = 'https://identity.mozilla.com/apps/oldsync'
@@ -60,7 +60,7 @@ class TokenserverTestUser(HttpUser):
     # `wait_time` class variable and the `@task` decorators, each user will
     # make sporadic requests to the server under test.
 
-    wait_time = between(1, 5)
+    wait_time = constant_throughput(1)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -70,7 +70,7 @@ class TokenserverTestUser(HttpUser):
             self.generation_counter.to_bytes(16, 'big')).decode('utf8')
         # Locust spawns a new instance of this class for each user. Using the
         # object ID as the FxA UID guarantees uniqueness.
-        self.fxa_uid = id(self)
+        self.fxa_uid = str(id(self))
         self.email = "loadtest-%s@%s" % (self.fxa_uid, MOCKMYID_DOMAIN)
 
     @task(3000)


### PR DESCRIPTION
## Description
Locust works by creating an instance of the `TokenserverTestUser` class for each user you specify when you run the load tests. For example, if you wanted to generate 4000 requests/second, you could instantiate 4000 users, where each user sends ~1 request/second. The problem with this approach is that there is a significant difference in the cost of handling a request from a previously-seen UID and a newly-seen UID (namely, Tokenserver needs to allocate a new user when a UID has not been seen before).

Previously, I was using the object ID of each instance of the `TokenserverTestUser` as the FxA UID, but this meant that, once we reached the peak number of Locust "users," no new users were being allocated. This doesn't accurately represent production load, since real load will include new user allocation. To address this, I've added a test case that periodically rotates the `fxa_uid` for each instance of the `TokenserverTestUser` class.

## Testing
This can be tested by commenting out all the load tests except for the `change_user_id` test case, and ensuring that the `fxa_uid` is rotated with each run of the test case by adding `print(self.fxa_uid, self.email)` to the end of the `change_user_id` function.
