### PR TITLE
bug: fix Tokenserver node assignment query

### DIFF
--- a/syncstorage/src/tokenserver/db/models.rs
+++ b/syncstorage/src/tokenserver/db/models.rs
@@ -304,8 +304,20 @@ impl TokenserverDb {
              WHERE service = ?
                AND node = ?
         "#;
+        const SPANNER_QUERY: &str = r#"
+            UPDATE nodes
+               SET current_load = current_load + 1,
+             WHERE service = ?
+               AND node = ?
+        "#;
 
-        diesel::sql_query(QUERY)
+        let query = if self.spanner_node_id.is_some() {
+            SPANNER_QUERY
+        } else {
+            QUERY
+        };
+
+        diesel::sql_query(query)
             .bind::<Integer, _>(params.service_id)
             .bind::<Text, _>(&params.node)
             .execute(&self.inner.conn)


### PR DESCRIPTION
## Description

A quick fix to the query that assigns a user to a node to match [the logic on the Python Tokenserver](https://github.com/mozilla-services/tokenserver/blob/master/tokenserver/assignment/sqlnode/sql.py#L748)