### PR TITLE
bug: fix Tokenserver Spanner node query

### DIFF
--- a/syncstorage/src/tokenserver/db/models.rs
+++ b/syncstorage/src/tokenserver/db/models.rs
@@ -306,7 +306,7 @@ impl TokenserverDb {
         "#;
         const SPANNER_QUERY: &str = r#"
             UPDATE nodes
-               SET current_load = current_load + 1,
+               SET current_load = current_load + 1
              WHERE service = ?
                AND node = ?
         "#;


### PR DESCRIPTION
## Description

Fixes a query syntax error involving a stray comma at the end of a line.

## Testing

I tested this by sending a request to my local Tokenserver and ensuring that the query ran without issue.
