### PR TITLE
feat: add Tokenserver origin Sentry tag

### DIFF
--- a/syncstorage/src/tokenserver/db/models.rs
+++ b/syncstorage/src/tokenserver/db/models.rs
@@ -297,6 +297,9 @@ impl TokenserverDb {
         &self,
         params: params::AddUserToNode,
     ) -> DbResult<results::AddUserToNode> {
+        let mut metrics = self.metrics.clone();
+        metrics.start_timer("storage.add_user_to_node", None);
+
         const QUERY: &str = r#"
             UPDATE nodes
                SET current_load = current_load + 1,


### PR DESCRIPTION
## Description

* Add the Tokenserver origin as a Syncstorage extra to report along with Sentry errors
* Add a timer metric for the `add_users_to_node` query (every request to Tokenserver that results in a user allocation will result in a write to the Spanner node in the database, which has the potential to be a major bottleneck if we see a lot of new users concurrently)

## Testing

I tested this by ensuring that new user allocations succeed without issue. I will test the new Sentry error tag on dev when this PR is merged.
