### PR TITLE
don't convert all oauth token verification errors to resource_unavailable

### DIFF
--- a/syncstorage/src/tokenserver/auth/oauth.rs
+++ b/syncstorage/src/tokenserver/auth/oauth.rs
@@ -168,7 +168,7 @@ impl VerifyToken for Verifier {
                     ..TokenserverError::resource_unavailable()
                 })?
                 .map_err(|e| match e {
-                    BlockingError::Error(_) => TokenserverError::resource_unavailable(),
+                    BlockingError::Error(inner) => inner,
                     BlockingError::Canceled => TokenserverError {
                         context: "Tokenserver threadpool operation failed".to_owned(),
                         ..TokenserverError::internal_error()


### PR DESCRIPTION
## Description

we have a `Result<VerifyOutput, BlockingError<TokenserverError>>` here. mapping all BlockingError::Error values to resource_unavailable causes 503 response for expired oauth tokens, which breaks sync from firefox. we previously returned the wrapped error unaltered (only turning a JoinError into resource_unavailable), so go back to that.

## Testing

reliably: use 0.12.1 with an expired or revoked oauth token and observe that sync does not work and does not recover. apply patch and see it recover.

## Issue(s)

none.