### PR TITLE
test: run the Tokenserver E2E tests without a cached JWK

### DIFF
--- a/tokenserver-settings/src/lib.rs
+++ b/tokenserver-settings/src/lib.rs
@@ -29,7 +29,8 @@ pub struct Settings {
     pub fxa_oauth_request_timeout: u64,
     /// The JWK to be used to verify OAuth tokens. Passing a JWK to the PyFxA Python library
     /// prevents it from making an external API call to FxA to get the JWK, yielding substantial
-    /// performance benefits.
+    /// performance benefits. This value should match that on the `/v1/jwks` on the FxA Auth
+    /// Server.
     pub fxa_oauth_primary_jwk: Option<Jwk>,
     /// A secondary JWK to be used to verify OAuth tokens. This is intended to be used to enable
     /// seamless key rotations on FxA.

--- a/tokenserver-settings/src/lib.rs
+++ b/tokenserver-settings/src/lib.rs
@@ -29,8 +29,8 @@ pub struct Settings {
     pub fxa_oauth_request_timeout: u64,
     /// The JWK to be used to verify OAuth tokens. Passing a JWK to the PyFxA Python library
     /// prevents it from making an external API call to FxA to get the JWK, yielding substantial
-    /// performance benefits. This value should match that on the `/v1/jwks` on the FxA Auth
-    /// Server.
+    /// performance benefits. This value should match that on the `/v1/jwks` endpoint on the FxA
+    /// Auth Server.
     pub fxa_oauth_primary_jwk: Option<Jwk>,
     /// A secondary JWK to be used to verify OAuth tokens. This is intended to be used to enable
     /// seamless key rotations on FxA.

--- a/tools/integration_tests/run.py
+++ b/tools/integration_tests/run.py
@@ -75,4 +75,19 @@ if __name__ == "__main__":
     finally:
         terminate_process(the_server_subprocess)
 
+    # Run the Tokenserver end-to-end tests without the JWK cached
+    del os.environ["SYNC_TOKENSERVER__FXA_OAUTH_PRIMARY_JWK__KTY"]
+    del os.environ["SYNC_TOKENSERVER__FXA_OAUTH_PRIMARY_JWK__ALG"]
+    del os.environ["SYNC_TOKENSERVER__FXA_OAUTH_PRIMARY_JWK__KID"]
+    del os.environ["SYNC_TOKENSERVER__FXA_OAUTH_PRIMARY_JWK__FXA_CREATED_AT"]
+    del os.environ["SYNC_TOKENSERVER__FXA_OAUTH_PRIMARY_JWK__USE"]
+    del os.environ["SYNC_TOKENSERVER__FXA_OAUTH_PRIMARY_JWK__N"]
+    del os.environ["SYNC_TOKENSERVER__FXA_OAUTH_PRIMARY_JWK__E"]
+
+    the_server_subprocess = start_server()
+    try:
+        res |= run_end_to_end_tests()
+    finally:
+        terminate_process(the_server_subprocess)
+
     sys.exit(res)


### PR DESCRIPTION
## Description

Runs the Tokenserver E2E integration tests against a Tokenserver without a cached FxA public JWK. This was done to ensure that we have test coverage for the OAuth verification code paths that involve making a request to FxA to verify tokens. We didn't have coverage before and it hid [a bug](https://github.com/mozilla-services/syncstorage-rs/pull/1389) where we were incorrectly handling `BlockingError`s returned by Actix's `web::block`.

## Testing

I made sure that the `test_unauthorized_oauth_error_status` test failed without ebdd609 and passed with it

