### PR TITLE
bug: fix Tokenserver generation and keys_changed_at handling

### DIFF
--- a/syncstorage/src/settings.rs
+++ b/syncstorage/src/settings.rs
@@ -289,6 +289,7 @@ impl Settings {
         s.set_default("tokenserver.node_type", "spanner")?;
         s.set_default("tokenserver.statsd_label", "syncstorage.tokenserver")?;
         s.set_default("tokenserver.run_migrations", cfg!(test))?;
+        s.set_default("tokenserver.token_duration", 3600)?;
 
         // Set Cors defaults
         s.set_default(

--- a/syncstorage/src/tokenserver/db/models.rs
+++ b/syncstorage/src/tokenserver/db/models.rs
@@ -164,7 +164,7 @@ impl TokenserverDb {
              WHERE service = ?
                AND email = ?
                AND generation <= ?
-               AND COALESCE(keys_changed_at, 0) <= COALESCE(?, 0)
+               AND COALESCE(keys_changed_at, 0) <= COALESCE(?, keys_changed_at, 0)
                AND replaced_at IS NULL
         "#;
 

--- a/syncstorage/src/tokenserver/extractors.rs
+++ b/syncstorage/src/tokenserver/extractors.rs
@@ -97,6 +97,14 @@ impl TokenserverRequest {
             });
         }
 
+        // If the client previously reported a client state, every subsequent request must include
+        // one. Note that this is only relevant for BrowserID requests, since OAuth requests must
+        // always include a client state.
+        if !self.user.client_state.is_empty() && self.auth_data.client_state.is_empty() {
+            let error_message = "Unacceptable client-state value empty string".to_owned();
+            return Err(TokenserverError::invalid_client_state(error_message));
+        }
+
         // The client state on the request must not have been used in the past.
         if self
             .user
@@ -104,14 +112,6 @@ impl TokenserverRequest {
             .contains(&self.auth_data.client_state)
         {
             let error_message = "Unacceptable client-state value stale value".to_owned();
-            return Err(TokenserverError::invalid_client_state(error_message));
-        }
-
-        // If the client previously reported a client state, every subsequent request must include
-        // one. Note that this is only relevant for BrowserID requests, since OAuth requests must
-        // always include a client state.
-        if !self.user.client_state.is_empty() && self.auth_data.client_state.is_empty() {
-            let error_message = "Unacceptable client-state value empty string".to_owned();
             return Err(TokenserverError::invalid_client_state(error_message));
         }
 

--- a/syncstorage/src/tokenserver/handlers.rs
+++ b/syncstorage/src/tokenserver/handlers.rs
@@ -1,5 +1,4 @@
 use std::{
-    cmp,
     collections::HashMap,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
@@ -84,7 +83,12 @@ fn get_token_plaintext(
             })?;
         let client_state_b64 = base64::encode_config(&client_state, base64::URL_SAFE_NO_PAD);
 
-        format!("{:013}-{:}", updates.keys_changed_at, client_state_b64)
+        format!(
+            "{:013}-{:}",
+            // We fall back to using the user's generation here, which matches FxA's behavior
+            updates.keys_changed_at.unwrap_or(updates.generation),
+            client_state_b64
+        )
     };
 
     let expires = {
@@ -108,7 +112,8 @@ fn get_token_plaintext(
 }
 
 struct UserUpdates {
-    keys_changed_at: i64,
+    keys_changed_at: Option<i64>,
+    generation: i64,
     uid: i64,
 }
 
@@ -116,20 +121,51 @@ async fn update_user(
     req: &TokenserverRequest,
     db: Box<dyn Db>,
 ) -> Result<UserUpdates, TokenserverError> {
-    // If the keys_changed_at in the request is larger than that stored on the user record,
-    // update to the value in the request.
-    let keys_changed_at =
-        cmp::max(req.auth_data.keys_changed_at, req.user.keys_changed_at).unwrap_or(0);
+    let keys_changed_at = match (req.auth_data.keys_changed_at, req.user.keys_changed_at) {
+        // If the keys_changed_at in the request is larger than that stored on the user record,
+        // update to the value in the request.
+        (Some(request_keys_changed_at), Some(user_keys_changed_at))
+            if request_keys_changed_at >= user_keys_changed_at =>
+        {
+            Some(request_keys_changed_at)
+        }
+        // If there is a keys_changed_at in the request and it's smaller than that stored on the
+        // user record, we've already returned an error at this point.
+        (Some(_request_keys_changed_at), Some(_user_keys_changed_at)) => unreachable!(),
+        // If there is a keys_changed_at on the request but not one on the user record, this is the
+        // first time the client reported it, so we assign the new value.
+        (Some(request_keys_changed_at), None) => Some(request_keys_changed_at),
+        // At this point, we've already validated that, if there is a keys_changed_at already
+        // stored on the user record, there must be one in the request. If that isn't the case,
+        // we've already returned an error.
+        (None, Some(user_keys_changed_at)) if user_keys_changed_at != 0 => unreachable!(),
+        // If there's no keys_changed_at in the request and the keys_changed_at on the user record
+        // is 0, keep the value as 0.
+        (None, Some(_user_keys_changed_at)) => Some(0),
+        // If there is no keys_changed_at on the user record or in the request, we want to leave
+        // the value unset.
+        (None, None) => None,
+    };
 
-    let generation = if let Some(generation) = req.auth_data.generation {
-        // If there's a generation on the request, choose the larger of that and the generation
-        // already stored on the user record.
-        cmp::max(generation, req.user.generation)
-    } else {
-        // If there's not a generation on the request and the keys_changed_at on the request is
-        // larger than the generation stored on the user record, set the user's generation to be
-        // the keys_changed_at on the request.
-        cmp::max(req.auth_data.keys_changed_at, Some(req.user.generation)).unwrap_or(0)
+    let generation = match req.auth_data.generation {
+        // If there's a generation in the request and it's greater than or equal to that stored on
+        // the user record, update to the value in the request.
+        Some(request_generation) if request_generation >= req.user.generation => request_generation,
+        // If there's a generation in the request and it's smaller than that stored on the user
+        // record, we've already returned an error.
+        Some(_request_generation) => unreachable!(),
+        None => match req.auth_data.keys_changed_at {
+            // If there's not a generation on the request and the keys_changed_at on the request is
+            // larger than the generation stored on the user record, set the user's generation to be
+            // the keys_changed_at on the request.
+            Some(request_keys_changed_at) if request_keys_changed_at > req.user.generation => {
+                request_keys_changed_at
+            }
+            // If there's not a generation on the request and the keys_changed_at on the request is
+            // less than or equal to the generation stored on the user record, just use the user's
+            // current generation.
+            _ => req.user.generation,
+        },
     };
 
     // If the client state changed, we need to mark the current user as "replaced" and create a
@@ -153,7 +189,7 @@ async fn update_user(
                 })
                 .await?
                 .id,
-            keys_changed_at: Some(keys_changed_at),
+            keys_changed_at,
             created_at: timestamp,
         };
         let uid = db.post_user(post_user_params).await?.id;
@@ -169,15 +205,16 @@ async fn update_user(
 
         Ok(UserUpdates {
             keys_changed_at,
+            generation,
             uid,
         })
     } else {
-        if generation != req.user.generation || Some(keys_changed_at) != req.user.keys_changed_at {
+        if generation != req.user.generation || keys_changed_at != req.user.keys_changed_at {
             let params = PutUser {
                 email: req.auth_data.email.clone(),
                 service_id: req.service_id,
                 generation,
-                keys_changed_at: Some(keys_changed_at),
+                keys_changed_at,
             };
 
             db.put_user(params).await?;
@@ -185,6 +222,7 @@ async fn update_user(
 
         Ok(UserUpdates {
             keys_changed_at,
+            generation,
             uid: req.user.uid,
         })
     }

--- a/syncstorage/src/tokenserver/mod.rs
+++ b/syncstorage/src/tokenserver/mod.rs
@@ -35,6 +35,7 @@ pub struct ServerState {
     pub node_capacity_release_rate: Option<f32>,
     pub node_type: NodeType,
     pub metrics: Box<StatsdClient>,
+    pub token_duration: u64,
 }
 
 impl ServerState {
@@ -73,6 +74,7 @@ impl ServerState {
                     node_capacity_release_rate: settings.node_capacity_release_rate,
                     node_type: settings.node_type,
                     metrics: Box::new(metrics),
+                    token_duration: settings.token_duration,
                 }
             })
             .map_err(Into::into)

--- a/syncstorage/src/tokenserver/settings.rs
+++ b/syncstorage/src/tokenserver/settings.rs
@@ -63,6 +63,8 @@ pub struct Settings {
     /// verifications do not require requests to FXA if the JWK is set on Tokenserver. The server
     /// will return an error at startup if the JWK is not cached and this setting is `None`.
     pub additional_blocking_threads_for_fxa_requests: Option<u32>,
+    /// The amount of time in seconds before a token provided by Tokenserver expires.
+    pub token_duration: u64,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -102,6 +104,7 @@ impl Default for Settings {
             run_migrations: cfg!(test),
             spanner_node_id: None,
             additional_blocking_threads_for_fxa_requests: None,
+            token_duration: 3600,
         }
     }
 }

--- a/tools/integration_tests/tokenserver/test_authorization.py
+++ b/tools/integration_tests/tokenserver/test_authorization.py
@@ -573,8 +573,8 @@ class TestAuthorization(TestCase, unittest.TestCase):
         self.assertEqual(user['generation'], 1234)
 
     def test_zero_keys_changed_at_treated_as_null(self):
-        # Add a user that has a keys_changed_at set
-        uid = self._add_user(generation=1234, keys_changed_at=1234,
+        # Add a user that has no keys_changed_at set
+        uid = self._add_user(generation=1234, keys_changed_at=None,
                              client_state='aaaa')
         headers = self._build_auth_headers(generation=1234,
                                            keys_changed_at=0,
@@ -584,4 +584,4 @@ class TestAuthorization(TestCase, unittest.TestCase):
         # Ensure that the request succeeded and that the user's
         # keys_changed_at was not updated
         user = self._get_user(uid)
-        self.assertEqual(user['keys_changed_at'], 1234)
+        self.assertEqual(user['keys_changed_at'], None)

--- a/tools/integration_tests/tokenserver/test_authorization.py
+++ b/tools/integration_tests/tokenserver/test_authorization.py
@@ -277,6 +277,27 @@ class TestAuthorization(TestCase, unittest.TestCase):
         # This should not result in the creation of a new user
         self.assertEqual(res.json['uid'], uid)
 
+    def test_set_generation_to_keys_changed_at(self):
+        # Add a user who has never sent us a generation
+        uid = self._add_user(generation=0, keys_changed_at=1234,
+                             client_state='aaaa')
+        # Send a request without a generation that doesn't update
+        # keys_changed_at
+        headers = self._build_auth_headers(generation=0,
+                                           keys_changed_at=1234,
+                                           client_state='aaaa')
+        self.app.get('/1.0/sync/1.5', headers=headers)
+        user = self._get_user(uid)
+        # This should not have set the user's generation
+        self.assertEqual(user['generation'], 0)
+        # Send a request without a generation that updates keys_changed_at
+        headers = self._build_auth_headers(generation=None,
+                                           keys_changed_at=1235,
+                                           client_state='aaaa')
+        user = self._get_user(uid)
+        # This should have set the user's generation
+        self.assertEqual(user['generation'], 1235)
+
     def test_fxa_kid_change(self):
         self._add_user(generation=1234, keys_changed_at=None,
                        client_state='aaaa')

--- a/tools/integration_tests/tokenserver/test_authorization.py
+++ b/tools/integration_tests/tokenserver/test_authorization.py
@@ -302,15 +302,15 @@ class TestAuthorization(TestCase, unittest.TestCase):
     def test_set_generation_with_keys_changed_at_initialization(self):
         # Add a user who has never sent us a generation or a keys_changed_at
         uid = self._add_user(generation=0, keys_changed_at=None,
-                            client_state='aaaa')
+                             client_state='aaaa')
 
         # Only BrowserID requests can omit keys_changed_at
         if self.auth_method == 'browserid':
             # Send a request without a generation that doesn't update
             # keys_changed_at
             headers = self._build_auth_headers(generation=None,
-                                            keys_changed_at=None,
-                                            client_state='aaaa')
+                                               keys_changed_at=None,
+                                               client_state='aaaa')
             self.app.get('/1.0/sync/1.5', headers=headers)
             user = self._get_user(uid)
             # This should not have set the user's generation

--- a/tools/integration_tests/tokenserver/test_authorization.py
+++ b/tools/integration_tests/tokenserver/test_authorization.py
@@ -557,3 +557,31 @@ class TestAuthorization(TestCase, unittest.TestCase):
             self.assertEqual(res.json, expected_error_response)
             headers['X-Client-State'] = 'aaaa'
             res = self.app.get('/1.0/sync/1.5', headers=headers)
+
+    def test_zero_generation_treated_as_null(self):
+        # Add a user that has a generation set
+        uid = self._add_user(generation=1234, keys_changed_at=1234,
+                             client_state='aaaa')
+        headers = self._build_auth_headers(generation=0,
+                                           keys_changed_at=1234,
+                                           client_state='aaaa')
+        # Send a request with a generation of 0
+        self.app.get('/1.0/sync/1.5', headers=headers)
+        # Ensure that the request succeeded and that the user's generation
+        # was not updated
+        user = self._get_user(uid)
+        self.assertEqual(user['generation'], 1234)
+
+    def test_zero_keys_changed_at_treated_as_null(self):
+        # Add a user that has a keys_changed_at set
+        uid = self._add_user(generation=1234, keys_changed_at=1234,
+                             client_state='aaaa')
+        headers = self._build_auth_headers(generation=1234,
+                                           keys_changed_at=0,
+                                           client_state='aaaa')
+        # Send a request with a keys_changed_at of 0
+        self.app.get('/1.0/sync/1.5', headers=headers)
+        # Ensure that the request succeeded and that the user's
+        # keys_changed_at was not updated
+        user = self._get_user(uid)
+        self.assertEqual(user['keys_changed_at'], 1234)

--- a/tools/integration_tests/tokenserver/test_authorization.py
+++ b/tools/integration_tests/tokenserver/test_authorization.py
@@ -277,7 +277,7 @@ class TestAuthorization(TestCase, unittest.TestCase):
         # This should not result in the creation of a new user
         self.assertEqual(res.json['uid'], uid)
 
-    def test_set_generation_to_keys_changed_at(self):
+    def test_set_generation_unchanged_without_keys_changed_at_update(self):
         # Add a user who has never sent us a generation
         uid = self._add_user(generation=0, keys_changed_at=1234,
                              client_state='aaaa')
@@ -298,18 +298,24 @@ class TestAuthorization(TestCase, unittest.TestCase):
         user = self._get_user(uid)
         # This should have set the user's generation
         self.assertEqual(user['generation'], 1235)
+
+    def test_set_generation_with_keys_changed_at_initialization(self):
         # Add a user who has never sent us a generation or a keys_changed_at
         uid = self._add_user(generation=0, keys_changed_at=None,
-                             client_state='aaaa')
-        # Send a request without a generation that doesn't update
-        # keys_changed_at
-        headers = self._build_auth_headers(generation=None,
-                                           keys_changed_at=None,
-                                           client_state='aaaa')
-        self.app.get('/1.0/sync/1.5', headers=headers)
-        user = self._get_user(uid)
-        # This should not have set the user's generation
-        self.assertEqual(user['generation'], 0)
+                            client_state='aaaa')
+
+        # Only BrowserID requests can omit keys_changed_at
+        if self.auth_method == 'browserid':
+            # Send a request without a generation that doesn't update
+            # keys_changed_at
+            headers = self._build_auth_headers(generation=None,
+                                            keys_changed_at=None,
+                                            client_state='aaaa')
+            self.app.get('/1.0/sync/1.5', headers=headers)
+            user = self._get_user(uid)
+            # This should not have set the user's generation
+            self.assertEqual(user['generation'], 0)
+
         # Send a request without a generation that updates keys_changed_at
         headers = self._build_auth_headers(generation=None,
                                            keys_changed_at=1234,

--- a/tools/integration_tests/tokenserver/test_authorization.py
+++ b/tools/integration_tests/tokenserver/test_authorization.py
@@ -358,12 +358,12 @@ class TestAuthorization(TestCase, unittest.TestCase):
         self.assertEquals(res.json['duration'], 12)
         # But you can't exceed the server's default value.
         res = self.app.get('/1.0/sync/1.5?duration=4000', headers=headers)
-        self.assertEquals(res.json['duration'], 300)
+        self.assertEquals(res.json['duration'], 3600)
         # And nonsense values are ignored.
         res = self.app.get('/1.0/sync/1.5?duration=lolwut', headers=headers)
-        self.assertEquals(res.json['duration'], 300)
+        self.assertEquals(res.json['duration'], 3600)
         res = self.app.get('/1.0/sync/1.5?duration=-1', headers=headers)
-        self.assertEquals(res.json['duration'], 300)
+        self.assertEquals(res.json['duration'], 3600)
 
     # Although all servers are now writing keys_changed_at, we still need this
     # case to be handled. See this PR for more information:

--- a/tools/integration_tests/tokenserver/test_browserid.py
+++ b/tools/integration_tests/tokenserver/test_browserid.py
@@ -474,3 +474,87 @@ class TestBrowserId(TestCase, unittest.TestCase):
                                                 client_state="aaaa")
         res = self.app.get("/1.0/sync/1.5", headers=headers, status=401)
         self.assertEqual(res.json["status"], "invalid-generation")
+
+    def test_reverting_to_no_keys_changed_at(self):
+        # Add a user that has no keys_changed_at set
+        uid = self._add_user(generation=0, keys_changed_at=None,
+                             client_state='aaaa')
+        # Send a request with keys_changed_at
+        headers = self._build_browserid_headers(generation=None,
+                                           keys_changed_at=1234,
+                                           client_state='aaaa')
+        self.app.get('/1.0/sync/1.5', headers=headers)
+        user = self._get_user(uid)
+        # Confirm that keys_changed_at was set
+        self.assertEqual(user['keys_changed_at'], 1234)
+        # Send a request with no keys_changed_at
+        headers = self._build_browserid_headers(generation=None,
+                                           keys_changed_at=None,
+                                           client_state='aaaa')
+        # Once a keys_changed_at has been set, the server expects to receive
+        # it from that point onwards
+        res = self.app.get('/1.0/sync/1.5', headers=headers, status=401)
+        expected_error_response = {
+            'status': 'invalid-keysChangedAt',
+            'errors': [
+                {
+                    'location': 'body',
+                    'name': '',
+                    'description': 'Unauthorized',
+                }
+            ]
+        }
+        self.assertEqual(res.json, expected_error_response)
+
+    def test_zero_keys_changed_at_treated_as_null(self):
+        # Add a user that has a zero keys_changed_at
+        uid = self._add_user(generation=0, keys_changed_at=0,
+                             client_state='aaaa')
+        # Send a request with no keys_changed_at
+        headers = self._build_browserid_headers(generation=None,
+                                           keys_changed_at=None,
+                                           client_state='aaaa')
+        self.app.get('/1.0/sync/1.5', headers=headers)
+        # The request should succeed and the keys_changed_at should be
+        # unchanged
+        user = self._get_user(uid)
+        self.assertEqual(user['keys_changed_at'], 0)
+
+    def test_reverting_to_no_client_state(self):
+        # Add a user that has no client_state
+        uid = self._add_user(generation=0, keys_changed_at=None,
+                             client_state=None)
+        # Send a request with no client state
+        headers = self._build_browserid_headers(generation=None,
+                                           keys_changed_at=None,
+                                           client_state=None)
+        # The request should succeed
+        self.app.get('/1.0/sync/1.5', headers=headers)
+        # Send a request that updates the client state
+        headers = self._build_browserid_headers(generation=None,
+                                           keys_changed_at=None,
+                                           client_state='aaaa')
+        # The request should succeed
+        self.app.get('/1.0/sync/1.5', headers=headers)
+        user = self._get_user(uid)
+        # The client state should have been updated
+        self.assertEqual(user['client_state'], 'aaaa')
+        # Send another request with no client state
+        headers = self._build_browserid_headers(generation=None,
+                                           keys_changed_at=None,
+                                           client_state=None)
+        # The request should fail, since we are trying to revert to using no
+        # client state after setting one
+        res = self.app.get('/1.0/sync/1.5', headers=headers, status=401)
+        expected_error_response = {
+            'status': 'invalid-client-state',
+            'errors': [
+                {
+                    'location': 'header',
+                    'name': 'X-Client-State',
+                    'description': 'Unacceptable client-state value empty '
+                                   'string',
+                }
+            ]
+        }
+        self.assertEqual(res.json, expected_error_response)

--- a/tools/integration_tests/tokenserver/test_browserid.py
+++ b/tools/integration_tests/tokenserver/test_browserid.py
@@ -481,16 +481,16 @@ class TestBrowserId(TestCase, unittest.TestCase):
                              client_state='aaaa')
         # Send a request with keys_changed_at
         headers = self._build_browserid_headers(generation=None,
-                                           keys_changed_at=1234,
-                                           client_state='aaaa')
+                                                keys_changed_at=1234,
+                                                client_state='aaaa')
         self.app.get('/1.0/sync/1.5', headers=headers)
         user = self._get_user(uid)
         # Confirm that keys_changed_at was set
         self.assertEqual(user['keys_changed_at'], 1234)
         # Send a request with no keys_changed_at
         headers = self._build_browserid_headers(generation=None,
-                                           keys_changed_at=None,
-                                           client_state='aaaa')
+                                                keys_changed_at=None,
+                                                client_state='aaaa')
         # Once a keys_changed_at has been set, the server expects to receive
         # it from that point onwards
         res = self.app.get('/1.0/sync/1.5', headers=headers, status=401)
@@ -512,8 +512,8 @@ class TestBrowserId(TestCase, unittest.TestCase):
                              client_state='aaaa')
         # Send a request with no keys_changed_at
         headers = self._build_browserid_headers(generation=None,
-                                           keys_changed_at=None,
-                                           client_state='aaaa')
+                                                keys_changed_at=None,
+                                                client_state='aaaa')
         self.app.get('/1.0/sync/1.5', headers=headers)
         # The request should succeed and the keys_changed_at should be
         # unchanged
@@ -526,14 +526,14 @@ class TestBrowserId(TestCase, unittest.TestCase):
                              client_state=None)
         # Send a request with no client state
         headers = self._build_browserid_headers(generation=None,
-                                           keys_changed_at=None,
-                                           client_state=None)
+                                                keys_changed_at=None,
+                                                client_state=None)
         # The request should succeed
         self.app.get('/1.0/sync/1.5', headers=headers)
         # Send a request that updates the client state
         headers = self._build_browserid_headers(generation=None,
-                                           keys_changed_at=None,
-                                           client_state='aaaa')
+                                                keys_changed_at=None,
+                                                client_state='aaaa')
         # The request should succeed
         self.app.get('/1.0/sync/1.5', headers=headers)
         user = self._get_user(uid)
@@ -541,8 +541,8 @@ class TestBrowserId(TestCase, unittest.TestCase):
         self.assertEqual(user['client_state'], 'aaaa')
         # Send another request with no client state
         headers = self._build_browserid_headers(generation=None,
-                                           keys_changed_at=None,
-                                           client_state=None)
+                                                keys_changed_at=None,
+                                                client_state=None)
         # The request should fail, since we are trying to revert to using no
         # client state after setting one
         res = self.app.get('/1.0/sync/1.5', headers=headers, status=401)

--- a/tools/integration_tests/tokenserver/test_browserid.py
+++ b/tools/integration_tests/tokenserver/test_browserid.py
@@ -523,7 +523,7 @@ class TestBrowserId(TestCase, unittest.TestCase):
     def test_reverting_to_no_client_state(self):
         # Add a user that has no client_state
         uid = self._add_user(generation=0, keys_changed_at=None,
-                             client_state=None)
+                             client_state="")
         # Send a request with no client state
         headers = self._build_browserid_headers(generation=None,
                                                 keys_changed_at=None,

--- a/tools/integration_tests/tokenserver/test_browserid.py
+++ b/tools/integration_tests/tokenserver/test_browserid.py
@@ -535,8 +535,10 @@ class TestBrowserId(TestCase, unittest.TestCase):
                                                 keys_changed_at=None,
                                                 client_state='aaaa')
         # The request should succeed
-        self.app.get('/1.0/sync/1.5', headers=headers)
-        user = self._get_user(uid)
+        res = self.app.get('/1.0/sync/1.5', headers=headers)
+        user = self._get_user(res.json['uid'])
+        # A new user should have been created
+        self.assertNotEqual(uid, res.json['uid'])
         # The client state should have been updated
         self.assertEqual(user['client_state'], 'aaaa')
         # Send another request with no client state

--- a/tools/integration_tests/tokenserver/test_e2e.py
+++ b/tools/integration_tests/tokenserver/test_e2e.py
@@ -25,7 +25,7 @@ from tokenserver.test_support import TestCase
 # this is the proper client ID to be using for these integration tests.
 BROWSERID_AUDIENCE = "https://token.stage.mozaws.net"
 CLIENT_ID = '5882386c6d801776'
-DEFAULT_TOKEN_DURATION = 300
+DEFAULT_TOKEN_DURATION = 3600
 FXA_ACCOUNT_STAGE_HOST = 'https://api-accounts.stage.mozaws.net'
 FXA_OAUTH_STAGE_HOST = 'https://oauth.stage.mozaws.net'
 PASSWORD_CHARACTERS = string.ascii_letters + string.punctuation + string.digits

--- a/tools/integration_tests/tokenserver/test_misc.py
+++ b/tools/integration_tests/tokenserver/test_misc.py
@@ -57,7 +57,7 @@ class TestMisc(TestCase, unittest.TestCase):
         res = self.app.get('/1.0/sync/1.5', headers=headers)
         self.assertIn('https://example.com/1.5', res.json['api_endpoint'])
         self.assertIn('duration', res.json)
-        self.assertEquals(res.json['duration'], 300)
+        self.assertEquals(res.json['duration'], 3600)
 
     def test_current_user_is_the_most_up_to_date(self):
         # Add some users

--- a/tools/integration_tests/tokenserver/test_support.py
+++ b/tools/integration_tests/tokenserver/test_support.py
@@ -17,7 +17,6 @@ DEFAULT_OAUTH_SCOPE = 'https://identity.mozilla.com/apps/oldsync'
 
 
 class TestCase:
-    AUTH_METHOD = os.environ.get('TOKENSERVER_AUTH_METHOD', 'oauth')
     BROWSERID_ISSUER = os.environ['SYNC_TOKENSERVER__FXA_BROWSERID_ISSUER']
     FXA_EMAIL_DOMAIN = 'api-accounts.stage.mozaws.net'
     FXA_METRICS_HASH_SECRET = 'secret0'
@@ -25,6 +24,15 @@ class TestCase:
     NODE_URL = 'https://example.com'
     TOKEN_SIGNING_SECRET = 'secret0'
     TOKENSERVER_HOST = os.environ['TOKENSERVER_HOST']
+
+    @classmethod
+    def setUpClass(cls):
+        cls.auth_method = os.environ['TOKENSERVER_AUTH_METHOD']
+
+        if cls.auth_method == 'browserid':
+            cls._build_auth_headers = cls._build_browserid_headers
+        else:
+            cls._build_auth_headers = cls._build_oauth_headers
 
     def setUp(self):
         engine = create_engine(os.environ['SYNC_TOKENSERVER__DATABASE_URL'])
@@ -40,11 +48,6 @@ class TestCase:
             'REMOTE_ADDR': '127.0.0.1',
             'SCRIPT_NAME': host_url.path,
         })
-
-        if self.AUTH_METHOD == 'browserid':
-            self._build_auth_headers = self._build_browserid_headers
-        else:
-            self._build_auth_headers = self._build_oauth_headers
 
         # Start each test with a blank slate.
         cursor = self._execute_sql(('DELETE FROM users'), ())

--- a/tools/integration_tests/tokenserver/test_support.py
+++ b/tools/integration_tests/tokenserver/test_support.py
@@ -108,8 +108,8 @@ class TestCase:
             'issuer': issuer
         }
 
-        if device_id or generation or keys_changed_at or \
-                token_verified is not None:
+        if device_id or generation is not None or \
+                keys_changed_at is not None or token_verified is not None:
             idp_claims = {}
 
             if device_id:

--- a/tools/integration_tests/tokenserver/test_support.py
+++ b/tools/integration_tests/tokenserver/test_support.py
@@ -83,6 +83,10 @@ class TestCase:
             'client_id': 'fake client id',
             'scope': [DEFAULT_OAUTH_SCOPE],
         }
+
+        if generation is not None:
+            claims['generation'] = generation
+
         body = {
             'body': claims,
             'status': status

--- a/tools/integration_tests/tokenserver/test_support.py
+++ b/tools/integration_tests/tokenserver/test_support.py
@@ -130,8 +130,10 @@ class TestCase:
 
         headers = {
             'Authorization': 'BrowserID %s' % json.dumps(body),
-            'X-Client-State': client_state
         }
+
+        if client_state:
+            headers['X-Client-State'] = client_state
 
         headers.update(additional_headers)
 


### PR DESCRIPTION
## Description

There were a few missing cases relating to how we handle generation and keys_changed_at:
* When Tokenserver gets an updated keys_changed_at in a request but that request has no generation and the generation on the user record is less than the new keys_changed_at, it should set the generation equal to the updated keys_changed_at
  * Rust Tokenserver was setting the generation to be the keys_changed_at in the request even when the request didn't contain an updated keys_changed_at
* Once Tokenserver sees a client state and keys_changed_at for a user, it requires both of them in every request going forward (this is only relevant for BrowserID requests, since all OAuth requests must contain both keys_changed_at and client state in the form of an `X-KeyID` header
  * Rust Tokenserver was allowing clients to revert to omitting these fields even after it had already seen them. Prior to adding support for BrowserID, this case didn't need to be handled since every request included both keys_changed_at and client state (and the server errored out if they weren't included). When we introduced BrowserID support, we allowed BrowserID clients to omit `X-Client-State` and `keys_changed_at` but didn't make sure we were enforcing that requests contain them if we had already seen these values for a given user.
* This is minor and may not be something we need to handle, but: The database schema allows users.keys_changed_at to be null. When the Python Tokenserver loads the value into memory, it converts null values to 0, which means that null and 0 values from the database are both treated as 0 when running the consistency checks. This has the implication that clients can `technically` have a keys_changed_at of 0 in the database and then revert to not sending a keys_changed_at. In reality, I'm sure why any user would have a keys_changed_at of 0 in the database, but for completeness's sake, I added support to handle this the same way in the Rust Tokenserver

## Testing

I added integration tests to handle the missing cases.
