### PR TITLE
feat: emit metrics about the number of blocking tasks

### DIFF
--- a/syncstorage/src/db/mod.rs
+++ b/syncstorage/src/db/mod.rs
@@ -69,6 +69,11 @@ pub fn spawn_pool_periodic_reporter<T: GetPoolState + Send + 'static>(
     Ok(())
 }
 
+/// Runs a function as a task on Actix's blocking threadpool.
+///
+/// WARNING: Calling `web::block` anywhere else will result in inaccurate threadpool metrics being
+/// reported. If you want to spawn a task on Actix's blocking threadpool, you **must** use this
+/// function.
 pub async fn run_on_blocking_threadpool<F, T>(metrics: Metrics, f: F) -> Result<T, DbError>
 where
     F: FnOnce() -> Result<T, DbError> + Send + 'static,

--- a/syncstorage/src/db/mysql/pool.rs
+++ b/syncstorage/src/db/mysql/pool.rs
@@ -103,7 +103,8 @@ impl MysqlDbPool {
 impl DbPool for MysqlDbPool {
     async fn get<'a>(&'a self) -> Result<Box<dyn Db<'a>>> {
         let pool = self.clone();
-        let db = db::run_on_blocking_threadpool(move || pool.get_sync()).await?;
+        let db =
+            db::run_on_blocking_threadpool(pool.metrics.clone(), move || pool.get_sync()).await?;
 
         Ok(Box::new(db) as Box<dyn Db<'a>>)
     }

--- a/syncstorage/src/db/spanner/manager/session.rs
+++ b/syncstorage/src/db/spanner/manager/session.rs
@@ -39,26 +39,29 @@ pub async fn create_spanner_session(
     emulator_host: Option<String>,
 ) -> Result<SpannerSession, DbError> {
     let using_spanner_emulator = emulator_host.is_some();
-    let chan = db::run_on_blocking_threadpool(move || -> Result<grpcio::Channel, DbError> {
-        if let Some(spanner_emulator_address) = emulator_host {
-            Ok(ChannelBuilder::new(env)
-                .max_send_message_len(100 << 20)
-                .max_receive_message_len(100 << 20)
-                .connect(&spanner_emulator_address))
-        } else {
-            // Requires
-            // GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
-            metrics.start_timer("storage.pool.grpc_auth", None);
+    let chan = db::run_on_blocking_threadpool(
+        metrics.clone(),
+        move || -> Result<grpcio::Channel, DbError> {
+            if let Some(spanner_emulator_address) = emulator_host {
+                Ok(ChannelBuilder::new(env)
+                    .max_send_message_len(100 << 20)
+                    .max_receive_message_len(100 << 20)
+                    .connect(&spanner_emulator_address))
+            } else {
+                // Requires
+                // GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
+                metrics.start_timer("storage.pool.grpc_auth", None);
 
-            // XXX: issue732: Could google_default_credentials (or
-            // ChannelBuilder::secure_connect) block?!
-            let creds = ChannelCredentials::google_default_credentials()?;
-            Ok(ChannelBuilder::new(env)
-                .max_send_message_len(100 << 20)
-                .max_receive_message_len(100 << 20)
-                .secure_connect(SPANNER_ADDRESS, creds))
-        }
-    })
+                // XXX: issue732: Could google_default_credentials (or
+                // ChannelBuilder::secure_connect) block?!
+                let creds = ChannelCredentials::google_default_credentials()?;
+                Ok(ChannelBuilder::new(env)
+                    .max_send_message_len(100 << 20)
+                    .max_receive_message_len(100 << 20)
+                    .secure_connect(SPANNER_ADDRESS, creds))
+            }
+        },
+    )
     .await?;
     let client = SpannerClient::new(chan);
 

--- a/syncstorage/src/server/metrics.rs
+++ b/syncstorage/src/server/metrics.rs
@@ -139,6 +139,11 @@ impl Metrics {
         self.incr_with_tags(label, None)
     }
 
+    // decrement a counter with no tags data.
+    pub fn decr(&self, label: &str) {
+        self.count_with_tags(label, -1, None)
+    }
+
     pub fn incr_with_tags(&self, label: &str, tags: Option<Tags>) {
         self.count_with_tags(label, 1, tags)
     }

--- a/syncstorage/src/tokenserver/db/models.rs
+++ b/syncstorage/src/tokenserver/db/models.rs
@@ -682,7 +682,10 @@ impl Db for TokenserverDb {
 
     fn check(&self) -> DbFuture<'_, results::Check> {
         let db = self.clone();
-        Box::pin(db::run_on_blocking_threadpool(move || db.check_sync()))
+        Box::pin(db::run_on_blocking_threadpool(
+            db.metrics.clone(),
+            move || db.check_sync(),
+        ))
     }
 
     #[cfg(test)]

--- a/syncstorage/src/tokenserver/db/pool.rs
+++ b/syncstorage/src/tokenserver/db/pool.rs
@@ -87,8 +87,10 @@ impl TokenserverPool {
     #[cfg(test)]
     pub async fn get_tokenserver_db(&self) -> Result<TokenserverDb, DbError> {
         let pool = self.clone();
-        let conn =
-            db::run_on_blocking_threadpool(move || pool.inner.get().map_err(DbError::from)).await?;
+        let conn = db::run_on_blocking_threadpool(pool.metrics.clone(), move || {
+            pool.inner.get().map_err(DbError::from)
+        })
+        .await?;
 
         Ok(TokenserverDb::new(
             conn,
@@ -106,8 +108,10 @@ impl DbPool for TokenserverPool {
         metrics.start_timer("storage.get_pool", None);
 
         let pool = self.clone();
-        let conn =
-            db::run_on_blocking_threadpool(move || pool.inner.get().map_err(DbError::from)).await?;
+        let conn = db::run_on_blocking_threadpool(pool.metrics.clone(), move || {
+            pool.inner.get().map_err(DbError::from)
+        })
+        .await?;
 
         Ok(Box::new(TokenserverDb::new(
             conn,


### PR DESCRIPTION
## Description

Increment the counter when the blocking task is spawned, and decrement the counter when the future returns. This would be visualized on a per-pod basis in grafana. My (possibly incorrect) assumption here is that each pod would have its own counter, and when a pod starts up, its counter is 0.
## Issue(s)

Closes #1416
