### PR TITLE
fix syncstorage DB cfg key in default config

### DIFF
--- a/config/local.example.toml
+++ b/config/local.example.toml
@@ -1,5 +1,5 @@
 # Example MySQL DSN:
-database_url = "mysql://sample_user:sample_password@localhost/syncstorage_rs"
+syncstorage.database_url = "mysql://sample_user:sample_password@localhost/syncstorage_rs"
 
 # Example Spanner DSN:
 # database_url="spanner://projects/SAMPLE_GCP_PROJECT/instances/SAMPLE_SPANNER_INSTANCE/databases/SAMPLE_SPANNER_DB"


### PR DESCRIPTION
## Description

This patch fixes the path for syncstorage database key. In my setup (Debian, self compiled, NO docker) I wasn't able to connect to my database with another user/password than root/nopwd via config file. I figured out that the key's parent was missing.

## Testing

Run `make run` with and without default values (e.g. some user db user than root)
