### PR TITLE
chore: make docker files more podman friendly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.64-buster as builder
+FROM docker.io/library/rust:1.64-buster as builder
 WORKDIR /app
 ADD . /app
 ENV PATH=$PATH:/root/.cargo/bin
@@ -21,7 +21,7 @@ RUN \
     cargo install --path ./syncserver --locked --root /app && \
     cargo install --path ./syncserver --locked --root /app --bin purge_ttl
 
-FROM debian:buster-slim
+FROM docker.io/library/debian:buster-slim
 WORKDIR /app
 COPY --from=builder /app/requirements.txt /app
 COPY --from=builder /app/mysql_pubkey.asc /app

--- a/docker-compose.mysql.yaml
+++ b/docker-compose.mysql.yaml
@@ -5,7 +5,7 @@
 version: '3'
 services:
     sync-db:
-        image: mysql:5.7
+        image: docker.io/library/mysql:5.7
         volumes:
             - sync_db_data:/var/lib/mysql
         restart: always
@@ -19,7 +19,7 @@ services:
             MYSQL_PASSWORD: test
 
     tokenserver-db:
-        image: mysql:5.7
+        image: docker.io/library/mysql:5.7
         volumes:
             - tokenserver_db_data:/var/lib/mysql
         restart: always

--- a/docker-compose.spanner.yaml
+++ b/docker-compose.spanner.yaml
@@ -16,7 +16,7 @@ services:
         environment:
             SYNC_SYNCSTORAGE__SPANNER_EMULATOR_HOST: sync-db:9020
     tokenserver-db:
-        image: mysql:5.7
+        image: docker.io/library/mysql:5.7
         volumes:
             - tokenserver_db_data:/var/lib/mysql
         restart: always


### PR DESCRIPTION
Make docker files more podman friendly by specifying that images come from docker.io. It would be possible to specify the dependency as `docker.io/mysql` instead of `docker.io/library/mysql`. The doc seems to prefer the longer version, so I used it in this PR as well.

## Description

Specify registry from which podman should pull the images. From the doc:

> **Note**: Podman searches in different registries. Therefore it is recommend to use the full image name (`docker.io/library/httpd` instead of `httpd`) to ensure, that you are using the correct image. [[1]](https://podman.io/getting-started/#searching-pulling--listing-images)

On Arch Linux it doesn't seem to find the image without the `docker.io`-prefix, hence I created this PR.

## Testing - How should reviewers test?
Test by verifying that the images still build and start with docker/docker-compose. And maybe by running them with podman/podman-compose
