### PR TITLE
chore: temporarily disable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
   schedule:
     interval: monthly
     timezone: UCT
-  open-pull-requests-limit: 99
+  open-pull-requests-limit: 0
   labels:
   - dependencies
   ignore:


### PR DESCRIPTION
## Description

Let's plan to switch this back on when we're done with the crate reorg (and updating the deps afterwards)