### PR TITLE
Fix high cardinality metrics tags

### DIFF
--- a/syncserver/src/db/mysql/models.rs
+++ b/syncserver/src/db/mysql/models.rs
@@ -31,7 +31,6 @@ use super::{
 };
 use crate::db;
 use crate::server::metrics::Metrics;
-use crate::web::tags::Tags;
 
 pub type Result<T> = std::result::Result<T, DbError>;
 type Conn = PooledConnection<ConnectionManager<MysqlConnection>>;
@@ -402,11 +401,9 @@ impl MysqlDb {
                 collection_id,
             })?;
             if usage.total_bytes >= self.quota.size as usize {
-                let mut tags = Tags::default();
-                tags.tags
-                    .insert("collection".to_owned(), bso.collection.clone());
-                self.metrics
-                    .incr_with_tags("storage.quota.at_limit", Some(tags));
+                let mut tags = HashMap::default();
+                tags.insert("collection".to_owned(), bso.collection.clone());
+                self.metrics.incr_with_tags("storage.quota.at_limit", tags);
                 if self.quota.enforced {
                     return Err(DbErrorKind::Quota.into());
                 } else {

--- a/syncserver/src/db/spanner/batch.rs
+++ b/syncserver/src/db/spanner/batch.rs
@@ -18,7 +18,6 @@ use uuid::Uuid;
 
 use super::models::{Result, SpannerDb, PRETOUCH_TS};
 use super::support::{as_type, null_value, struct_type_field, IntoSpannerValue};
-use crate::web::tags::Tags;
 
 pub async fn create_async(
     db: &SpannerDb,
@@ -286,8 +285,8 @@ pub async fn do_append_async(
     let mut existing = HashSet::new();
     let mut collisions = HashSet::new();
     let mut count_collisions = 0;
-    let mut tags = Tags::default();
-    tags.tags.insert(
+    let mut tags = HashMap::new();
+    tags.insert(
         "collection".to_owned(),
         db.get_collection_name(collection_id)
             .await
@@ -330,7 +329,7 @@ pub async fn do_append_async(
     db.metrics.count_with_tags(
         "storage.spanner.batch.pre-existing",
         existing.len() as i64,
-        Some(tags.clone()),
+        tags.clone(),
     );
 
     // Approach 1:
@@ -398,7 +397,7 @@ pub async fn do_append_async(
         db.metrics.count_with_tags(
             "storage.spanner.batch.collisions",
             count_collisions,
-            Some(tags.clone()),
+            tags.clone(),
         );
     }
 
@@ -463,7 +462,7 @@ pub async fn do_append_async(
         db.metrics.count_with_tags(
             "storage.spanner.batch.insert",
             count_inserts as i64,
-            Some(tags.clone()),
+            tags.clone(),
         );
     }
 

--- a/syncserver/src/server/metrics.rs
+++ b/syncserver/src/server/metrics.rs
@@ -1,44 +1,45 @@
+use std::collections::HashMap;
 use std::net::UdpSocket;
 use std::time::Instant;
 
-use actix_web::{
-    dev::Payload, error::ErrorInternalServerError, web::Data, Error, FromRequest, HttpRequest,
-};
+use actix_web::{dev::Payload, web::Data, FromRequest, HttpRequest};
 use cadence::{
     BufferedUdpMetricSink, Counted, Metric, NopMetricSink, QueuingMetricSink, StatsdClient, Timed,
 };
 use futures::future;
 use futures::future::Ready;
+use slog::{Key, Record, KV};
 
 use crate::error::ApiError;
 use crate::server::ServerState;
-use crate::web::tags::Tags;
+use crate::tokenserver;
+use crate::web::tags::Taggable;
 
 #[derive(Debug, Clone)]
 pub struct MetricTimer {
     pub label: String,
     pub start: Instant,
-    pub tags: Tags,
+    pub tags: HashMap<String, String>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Default, Clone)]
 pub struct Metrics {
     pub client: Option<StatsdClient>,
-    pub tags: Option<Tags>,
+    pub tags: HashMap<String, String>,
     pub timer: Option<MetricTimer>,
 }
 
 impl Drop for Metrics {
     fn drop(&mut self) {
-        let tags = self.tags.clone().unwrap_or_default();
+        let tags = self.tags.clone();
         if let Some(client) = self.client.as_ref() {
             if let Some(timer) = self.timer.as_ref() {
                 let lapse = (Instant::now() - timer.start).as_millis() as u64;
-                trace!("⌚ Ending timer at nanos: {:?} : {:?}", &timer.label, lapse; &tags);
+                trace!("⌚ Ending timer at nanos: {:?} : {:?}", &timer.label, lapse; &MetricTags(tags));
                 let mut tagged = client.time_with_tags(&timer.label, lapse);
                 // Include any "hard coded" tags.
                 // tagged = tagged.with_tag("version", env!("CARGO_PKG_VERSION"));
-                let tags = timer.tags.tags.clone();
+                let tags = timer.tags.clone();
                 let keys = tags.keys();
                 for tag in keys {
                     tagged = tagged.with_tag(tag, tags.get(tag).unwrap())
@@ -59,31 +60,30 @@ impl Drop for Metrics {
 
 impl FromRequest for Metrics {
     type Config = ();
-    type Error = Error;
+    type Error = ();
     type Future = Ready<Result<Self, Self::Error>>;
 
     fn from_request(req: &HttpRequest, _: &mut Payload) -> Self::Future {
-        future::ok(metrics_from_request(
-            req,
-            req.app_data::<Data<ServerState>>()
-                .map(|state| state.metrics.clone()),
-        ))
-    }
-}
+        let client = {
+            let syncstorage_metrics = req
+                .app_data::<Data<ServerState>>()
+                .map(|state| state.metrics.clone());
+            let tokenserver_metrics = req
+                .app_data::<Data<tokenserver::ServerState>>()
+                .map(|state| state.metrics.clone());
 
-pub fn metrics_from_request(req: &HttpRequest, client: Option<Box<StatsdClient>>) -> Metrics {
-    let exts = req.extensions();
-    let def_tags = Tags::from(req.head());
-    let tags = exts.get::<Tags>().unwrap_or(&def_tags);
+            syncstorage_metrics.or(tokenserver_metrics)
+        };
 
-    if client.is_none() {
-        warn!("⚠️ metric error: No App State");
-    }
+        if client.is_none() {
+            warn!("⚠️ metric error: No App State");
+        }
 
-    Metrics {
-        client: client.as_deref().cloned(),
-        tags: Some(tags.clone()),
-        timer: None,
+        future::ok(Metrics {
+            client: client.as_deref().cloned(),
+            tags: req.get_tags(),
+            timer: None,
+        })
     }
 }
 
@@ -91,7 +91,7 @@ impl From<&StatsdClient> for Metrics {
     fn from(client: &StatsdClient) -> Self {
         Metrics {
             client: Some(client.clone()),
-            tags: None,
+            tags: HashMap::default(),
             timer: None,
         }
     }
@@ -101,7 +101,7 @@ impl From<&ServerState> for Metrics {
     fn from(state: &ServerState) -> Self {
         Metrics {
             client: Some(*state.metrics.clone()),
-            tags: None,
+            tags: HashMap::default(),
             timer: None,
         }
     }
@@ -116,50 +116,53 @@ impl Metrics {
         Self {
             client: Some(Self::sink()),
             timer: None,
-            tags: None,
+            tags: HashMap::default(),
         }
     }
 
-    pub fn start_timer(&mut self, label: &str, tags: Option<Tags>) {
-        let mut mtags = self.tags.clone().unwrap_or_default();
+    pub fn start_timer(&mut self, label: &str, tags: Option<HashMap<String, String>>) {
+        let mut mtags = self.tags.clone();
         if let Some(t) = tags {
             mtags.extend(t)
         }
 
+        let mtags = MetricTags(mtags);
         trace!("⌚ Starting timer... {:?}", &label; &mtags);
         self.timer = Some(MetricTimer {
             label: label.to_owned(),
             start: Instant::now(),
-            tags: mtags,
+            tags: mtags.0,
         });
     }
 
     // increment a counter with no tags data.
     pub fn incr(&self, label: &str) {
-        self.incr_with_tags(label, None)
+        self.incr_with_tags(label, HashMap::default())
     }
 
-    pub fn incr_with_tags(&self, label: &str, tags: Option<Tags>) {
+    pub fn incr_with_tags(&self, label: &str, tags: HashMap<String, String>) {
         self.count_with_tags(label, 1, tags)
     }
 
     pub fn incr_with_tag(&self, label: &str, key: &str, value: &str) {
-        self.incr_with_tags(label, Some(Tags::with_tag(key, value)))
+        let mut tags = HashMap::default();
+        tags.insert(key.to_owned(), value.to_owned());
+
+        self.incr_with_tags(label, tags);
     }
 
     pub fn count(&self, label: &str, count: i64) {
-        self.count_with_tags(label, count, None)
+        self.count_with_tags(label, count, HashMap::default())
     }
 
-    pub fn count_with_tags(&self, label: &str, count: i64, tags: Option<Tags>) {
+    pub fn count_with_tags(&self, label: &str, count: i64, tags: HashMap<String, String>) {
         if let Some(client) = self.client.as_ref() {
             let mut tagged = client.count_with_tags(label, count);
-            let mut mtags = self.tags.clone().unwrap_or_default();
-            if let Some(tags) = tags {
-                mtags.extend(tags);
-            }
-            for key in mtags.tags.keys().clone() {
-                if let Some(val) = mtags.tags.get(key) {
+            let mut mtags = self.tags.clone();
+            mtags.extend(tags);
+
+            for key in mtags.keys().clone() {
+                if let Some(val) = mtags.get(key) {
                     tagged = tagged.with_tag(key, val.as_ref());
                 }
             }
@@ -168,21 +171,12 @@ impl Metrics {
             match tagged.try_send() {
                 Err(e) => {
                     // eat the metric, but log the error
-                    warn!("⚠️ Metric {} error: {:?} ", label, e; mtags);
+                    warn!("⚠️ Metric {} error: {:?} ", label, e; MetricTags(mtags));
                 }
                 Ok(v) => trace!("☑️ {:?}", v.as_metric_str()),
             }
         }
     }
-}
-
-pub fn metrics_from_req(req: &HttpRequest) -> Result<Box<StatsdClient>, Error> {
-    Ok(req
-        .app_data::<Data<ServerState>>()
-        .ok_or_else(|| ErrorInternalServerError("Could not get state"))
-        .expect("Could not get state in metrics_from_req")
-        .metrics
-        .clone())
 }
 
 pub fn metrics_from_opts(
@@ -208,54 +202,14 @@ pub fn metrics_from_opts(
         .build())
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+/// A newtype used solely to allow us to implement KV on HashMap.
+struct MetricTags(HashMap<String, String>);
 
-    #[test]
-    fn test_tags() {
-        use actix_web::dev::RequestHead;
-        use actix_web::http::{header, uri::Uri};
-        use std::collections::HashMap;
-
-        let mut rh = RequestHead::default();
-        let path = "/1.5/42/storage/meta/global";
-        rh.uri = Uri::from_static(path);
-        rh.headers.insert(
-            header::USER_AGENT,
-            header::HeaderValue::from_static(
-                "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:72.0) Gecko/20100101 Firefox/72.0",
-            ),
-        );
-
-        let tags = Tags::from(&rh);
-
-        let mut result = HashMap::<String, String>::new();
-        result.insert("ua.os.ver".to_owned(), "NT 10.0".to_owned());
-        result.insert("ua.os.family".to_owned(), "Windows".to_owned());
-        result.insert("ua.browser.ver".to_owned(), "72.0".to_owned());
-        result.insert("ua.name".to_owned(), "Firefox".to_owned());
-        result.insert("ua.browser.family".to_owned(), "Firefox".to_owned());
-        result.insert("uri.method".to_owned(), "GET".to_owned());
-
-        assert_eq!(tags.tags, result)
-    }
-
-    #[test]
-    fn no_empty_tags() {
-        use actix_web::dev::RequestHead;
-        use actix_web::http::{header, uri::Uri};
-
-        let mut rh = RequestHead::default();
-        let path = "/1.5/42/storage/meta/global";
-        rh.uri = Uri::from_static(path);
-        rh.headers.insert(
-            header::USER_AGENT,
-            header::HeaderValue::from_static("Mozilla/5.0 (curl) Gecko/20100101 curl"),
-        );
-
-        let tags = Tags::from(&rh);
-        assert!(!tags.tags.contains_key("ua.os.ver"));
-        println!("{:?}", tags);
+impl KV for MetricTags {
+    fn serialize(&self, _rec: &Record<'_>, serializer: &mut dyn slog::Serializer) -> slog::Result {
+        for (key, val) in &self.0 {
+            serializer.emit_str(Key::from(key.clone()), val)?;
+        }
+        Ok(())
     }
 }

--- a/syncserver/src/server/test.rs
+++ b/syncserver/src/server/test.rs
@@ -90,8 +90,9 @@ macro_rules! init_app {
         async {
             crate::logging::init_logging(false).unwrap();
             let limits = Arc::new($settings.syncstorage.limits.clone());
+            let state = get_test_state(&$settings).await;
             test::init_service(build_app!(
-                get_test_state(&$settings).await,
+                state,
                 None::<tokenserver::ServerState>,
                 Arc::clone(&SECRETS),
                 limits,
@@ -207,8 +208,9 @@ where
 {
     let settings = get_test_settings();
     let limits = Arc::new(settings.syncstorage.limits.clone());
+    let state = get_test_state(&settings).await;
     let mut app = test::init_service(build_app!(
-        get_test_state(&settings).await,
+        state,
         None::<tokenserver::ServerState>,
         Arc::clone(&SECRETS),
         limits,
@@ -248,8 +250,9 @@ async fn test_endpoint_with_body(
 ) -> Bytes {
     let settings = get_test_settings();
     let limits = Arc::new(settings.syncstorage.limits.clone());
+    let state = get_test_state(&settings).await;
     let mut app = test::init_service(build_app!(
-        get_test_state(&settings).await,
+        state,
         None::<tokenserver::ServerState>,
         Arc::clone(&SECRETS),
         limits,

--- a/syncserver/src/tokenserver/extractors.rs
+++ b/syncserver/src/tokenserver/extractors.rs
@@ -4,6 +4,7 @@
 //! relevant types, and failing correctly with the appropriate errors if issues arise.
 
 use core::fmt::Debug;
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use actix_web::{
@@ -12,7 +13,7 @@ use actix_web::{
     web::{Data, Query},
     FromRequest, HttpRequest,
 };
-use futures::future::{self, LocalBoxFuture, Ready};
+use futures::future::LocalBoxFuture;
 use hex;
 use hmac::{Hmac, Mac, NewMac};
 use lazy_static::lazy_static;
@@ -29,7 +30,8 @@ use super::{
     db::{models::Db, params, pool::DbPool, results},
     LogItemsMutator, ServerState, TokenserverMetrics,
 };
-use crate::{server::metrics, web::tags::Tags};
+use crate::server::metrics::Metrics;
+use crate::web::tags::Taggable;
 
 lazy_static! {
     static ref CLIENT_STATE_REGEX: Regex = Regex::new("^[a-zA-Z0-9._-]{1,32}$").unwrap();
@@ -194,9 +196,7 @@ impl FromRequest for TokenserverRequest {
             let mut log_items_mutator = LogItemsMutator::from(&req);
             let auth_data = AuthData::extract(&req).await?;
 
-            // XXX: Tokenserver state will no longer be an Option once the Tokenserver
-            // code is rolled out, so we will eventually be able to remove this unwrap().
-            let state = get_server_state(&req)?.as_ref().as_ref().unwrap();
+            let state = get_server_state(&req)?.as_ref();
             let shared_secret = get_secret(&req)?;
             let fxa_metrics_hash_secret = &state.fxa_metrics_hash_secret.as_bytes();
 
@@ -342,9 +342,7 @@ impl FromRequest for Box<dyn DbPool> {
         let req = req.clone();
 
         Box::pin(async move {
-            // XXX: Tokenserver state will no longer be an Option once the Tokenserver
-            // code is rolled out, so we will eventually be able to remove this unwrap().
-            let state = get_server_state(&req)?.as_ref().as_ref().unwrap();
+            let state = get_server_state(&req)?.as_ref();
 
             Ok(state.db_pool.clone())
         })
@@ -437,9 +435,7 @@ impl FromRequest for AuthData {
         let req = req.clone();
 
         Box::pin(async move {
-            // XXX: The Tokenserver state will no longer be an Option once the Tokenserver
-            // code is rolled out, so we will eventually be able to remove this unwrap().
-            let state = get_server_state(&req)?.as_ref().as_ref().unwrap();
+            let state = get_server_state(&req)?.as_ref();
             let token = Token::extract(&req).await?;
 
             let TokenserverMetrics(mut metrics) = TokenserverMetrics::extract(&req).await?;
@@ -455,9 +451,12 @@ impl FromRequest for AuthData {
 
             match token {
                 Token::BrowserIdAssertion(assertion) => {
-                    let mut tags = Tags::default();
-                    tags.tags
-                        .insert("token_type".to_owned(), "BrowserID".to_owned());
+                    // Add a tag to the request extensions
+                    req.add_tag("token_type".to_owned(), "BrowserID".to_owned());
+
+                    // Start a timer with the same tag
+                    let mut tags = HashMap::default();
+                    tags.insert("token_type".to_owned(), "BrowserID".to_owned());
                     metrics.start_timer("token_verification", Some(tags));
                     let verify_output = state.browserid_verifier.verify(assertion).await?;
 
@@ -481,9 +480,12 @@ impl FromRequest for AuthData {
                     })
                 }
                 Token::OAuthToken(token) => {
-                    let mut tags = Tags::default();
-                    tags.tags
-                        .insert("token_type".to_owned(), "OAuth".to_owned());
+                    // Add a tag to the request extensions
+                    req.add_tag("token_type".to_owned(), "OAuth".to_owned());
+
+                    // Start a timer with the same tag
+                    let mut tags = HashMap::default();
+                    tags.insert("token_type".to_owned(), "OAuth".to_owned());
                     metrics.start_timer("token_verification", Some(tags));
                     let verify_output = state.oauth_verifier.verify(token).await?;
 
@@ -638,25 +640,18 @@ impl FromRequest for KeyId {
 impl FromRequest for TokenserverMetrics {
     type Config = ();
     type Error = TokenserverError;
-    type Future = Ready<Result<Self, Self::Error>>;
+    type Future = LocalBoxFuture<'static, Result<Self, Self::Error>>;
 
     fn from_request(req: &HttpRequest, _payload: &mut Payload) -> Self::Future {
-        let state = match get_server_state(req) {
-            // XXX: Tokenserver state will no longer be an Option once the Tokenserver
-            // code is rolled out, so we will eventually be able to remove this unwrap().
-            Ok(state) => state.as_ref().as_ref().unwrap(),
-            Err(e) => return future::err(e),
-        };
+        let req = req.clone();
 
-        future::ok(TokenserverMetrics(metrics::metrics_from_request(
-            req,
-            Some(state.metrics.clone()),
-        )))
+        // `Result::unwrap` is safe to use here, since Metrics::extract can never fail
+        Box::pin(async move { Ok(TokenserverMetrics(Metrics::extract(&req).await.unwrap())) })
     }
 }
 
-fn get_server_state(req: &HttpRequest) -> Result<&Data<Option<ServerState>>, TokenserverError> {
-    req.app_data::<Data<Option<ServerState>>>()
+fn get_server_state(req: &HttpRequest) -> Result<&Data<ServerState>, TokenserverError> {
+    req.app_data::<Data<ServerState>>()
         .ok_or_else(|| TokenserverError {
             context: "Failed to load the application state".to_owned(),
             ..TokenserverError::internal_error()
@@ -745,7 +740,7 @@ mod tests {
         let state = make_state(oauth_verifier, MockVerifier::default());
 
         let req = TestRequest::default()
-            .data(Some(state))
+            .data(state)
             .data(Arc::clone(&SECRETS))
             .header("authorization", "Bearer fake_token")
             .header("accept", "application/json,text/plain:q=0.5")
@@ -799,7 +794,7 @@ mod tests {
         let state = make_state(oauth_verifier, MockVerifier::default());
 
         let request = TestRequest::default()
-            .data(Some(state))
+            .data(state)
             .data(Arc::clone(&SECRETS))
             .header("authorization", "Bearer fake_token")
             .header("accept", "application/json,text/plain:q=0.5")
@@ -839,7 +834,7 @@ mod tests {
             };
 
             TestRequest::default()
-                .data(Some(make_state(oauth_verifier, MockVerifier::default())))
+                .data(make_state(oauth_verifier, MockVerifier::default()))
                 .data(Arc::clone(&SECRETS))
                 .header("authorization", "Bearer fake_token")
                 .header("accept", "application/json,text/plain:q=0.5")
@@ -944,7 +939,7 @@ mod tests {
             };
 
             TestRequest::default()
-                .data(Some(make_state(oauth_verifier, MockVerifier::default())))
+                .data(make_state(oauth_verifier, MockVerifier::default()))
                 .header("authorization", "Bearer fake_token")
                 .header("accept", "application/json,text/plain:q=0.5")
                 .param("application", "sync")

--- a/syncserver/src/web/extractors.rs
+++ b/syncserver/src/web/extractors.rs
@@ -43,7 +43,7 @@ use crate::tokenserver::auth::TokenserverOrigin;
 use crate::web::{
     auth::HawkPayload,
     error::{HawkErrorKind, ValidationErrorKind},
-    tags::Tags,
+    tags::Taggable,
     DOCKER_FLOW_ENDPOINTS,
 };
 const BATCH_MAX_IDS: usize = 100;
@@ -1167,13 +1167,10 @@ impl FromRequest for HawkIdentifier {
 
         if let Ok(ref hawk_id) = result {
             // Store the origin of the token as an extra to be included when emitting a Sentry error
-            let mut exts = req.extensions_mut();
-            let mut tags = Tags::default();
-            tags.add_extra(
-                "tokenserver_origin",
-                &hawk_id.tokenserver_origin.to_string(),
+            req.add_extra(
+                "tokenserver_origin".to_owned(),
+                hawk_id.tokenserver_origin.to_string(),
             );
-            tags.commit(&mut exts);
         }
 
         future::ready(result)

--- a/syncserver/src/web/middleware/sentry.rs
+++ b/syncserver/src/web/middleware/sentry.rs
@@ -1,21 +1,24 @@
+use std::collections::HashMap;
 use std::error::Error as StdError;
 use std::task::{Context, Poll};
 use std::{cell::RefCell, rc::Rc};
 
+use actix_http::HttpMessage;
 use actix_web::{
     dev::{Service, ServiceRequest, ServiceResponse, Transform},
-    web::Data,
-    Error, HttpMessage,
+    http::header::USER_AGENT,
+    Error, FromRequest,
 };
 use futures::future::{self, LocalBoxFuture};
 use sentry::protocol::Event;
 use sentry_backtrace::parse_stacktrace;
+use serde_json::value::Value;
 use syncserver_common::ReportableError;
 use tokenserver_common::error::TokenserverError;
 
 use crate::error::ApiError;
-use crate::server::{metrics::Metrics, ServerState};
-use crate::web::tags::Tags;
+use crate::server::{metrics::Metrics, user_agent};
+use crate::web::tags::Taggable;
 
 pub struct SentryWrapper;
 
@@ -56,10 +59,15 @@ pub struct SentryWrapperMiddleware<S> {
     service: Rc<RefCell<S>>,
 }
 
-pub fn report(tags: &Tags, mut event: Event<'static>) {
-    let tags = tags.clone();
-    event.tags = tags.clone().tag_tree();
-    event.extra = tags.extra_tree();
+pub fn report(
+    tags: HashMap<String, String>,
+    extra: HashMap<String, String>,
+    mut event: Event<'static>,
+) {
+    event.tags.extend(tags.into_iter());
+    event
+        .extra
+        .extend(extra.into_iter().map(|(k, v)| (k, Value::from(v))));
     trace!("Sentry: Sending error: {:?}", &event);
     sentry::capture_event(event);
 }
@@ -80,38 +88,16 @@ where
     }
 
     fn call(&mut self, sreq: ServiceRequest) -> Self::Future {
-        let mut tags = Tags::from(sreq.head());
-        sreq.extensions_mut().insert(tags.clone());
-        let metrics = sreq
-            .app_data::<Data<ServerState>>()
-            .map(|state| Metrics::from(state.get_ref()));
+        add_initial_tags(&sreq, sreq.head().method.to_string());
+        add_initial_extras(&sreq, sreq.head().uri.to_string());
 
         let fut = self.service.call(sreq);
 
         Box::pin(async move {
             let mut sresp = fut.await?;
-            // handed an actix_error::error::Error;
-            // Fetch out the tags (in case any have been added.) NOTE: request extensions
-            // are NOT automatically passed to responses. You need to check both.
-            if let Some(t) = sresp.request().extensions().get::<Tags>() {
-                trace!("Sentry: found tags in request: {:?}", &t.tags);
-                for (k, v) in t.tags.clone() {
-                    tags.tags.insert(k, v);
-                }
-                for (k, v) in t.extra.clone() {
-                    tags.extra.insert(k, v);
-                }
-            };
-            if let Some(t) = sresp.response().extensions().get::<Tags>() {
-                trace!("Sentry: found tags in response: {:?}", &t.tags);
-                for (k, v) in t.tags.clone() {
-                    tags.tags.insert(k, v);
-                }
-                for (k, v) in t.extra.clone() {
-                    tags.extra.insert(k, v);
-                }
-            };
-            //dbg!(&tags);
+            let tags = sresp.request().get_tags();
+            let extras = sresp.request().get_extras();
+
             match sresp.response().error() {
                 None => {
                     // Middleware errors are eaten by current versions of Actix. Errors are now added
@@ -123,7 +109,7 @@ where
                     {
                         for event in events {
                             trace!("Sentry: found an error stored in request: {:?}", &event);
-                            report(&tags, event);
+                            report(tags.clone(), extras.clone(), event);
                         }
                     }
                     if let Some(events) = sresp
@@ -133,15 +119,17 @@ where
                     {
                         for event in events {
                             trace!("Sentry: Found an error stored in response: {:?}", &event);
-                            report(&tags, event);
+                            report(tags.clone(), extras.clone(), event);
                         }
                     }
                 }
                 Some(e) => {
+                    let metrics = Metrics::extract(sresp.request()).await.unwrap();
+
                     if let Some(apie) = e.as_error::<ApiError>() {
-                        process_error(apie, metrics.as_ref(), &tags);
+                        process_error(apie, metrics, tags, extras);
                     } else if let Some(tokenserver_error) = e.as_error::<TokenserverError>() {
-                        process_error(tokenserver_error, metrics.as_ref(), &tags);
+                        process_error(tokenserver_error, metrics, tags, extras);
                     }
                 }
             }
@@ -150,18 +138,20 @@ where
     }
 }
 
-fn process_error<E>(err: &E, metrics: Option<&Metrics>, tags: &Tags)
-where
+fn process_error<E>(
+    err: &E,
+    metrics: Metrics,
+    tags: HashMap<String, String>,
+    extras: HashMap<String, String>,
+) where
     E: ReportableError + StdError + 'static,
 {
-    if let Some(metrics) = metrics {
-        if let Some(label) = err.metric_label() {
-            metrics.incr(&label);
-        }
+    if let Some(label) = err.metric_label() {
+        metrics.incr(&label);
     }
 
     if err.is_sentry_event() {
-        report(tags, event_from_error(err));
+        report(tags, extras, event_from_error(err));
     } else {
         trace!("Sentry: Not reporting error: {:?}", err);
     }
@@ -216,5 +206,95 @@ fn exception_from_error<E: StdError + ?Sized>(err: &E) -> sentry::protocol::Exce
         ty: sentry::parse_type_from_debug(&dbg).to_owned(),
         value: Some(err.to_string()),
         ..Default::default()
+    }
+}
+
+/// Adds HTTP-related tags to be included in every syncstorage or tokenserver request.
+fn add_initial_tags<T>(msg: &T, method: String)
+where
+    T: Taggable + HttpMessage,
+{
+    msg.add_tag("uri.method".to_owned(), method);
+}
+
+/// Adds HTTP-related extras to be included in every syncstorage or tokenserver request.
+fn add_initial_extras<T>(msg: &T, uri: String)
+where
+    T: Taggable + HttpMessage,
+{
+    if let Some(ua) = msg.headers().get(USER_AGENT) {
+        if let Ok(uas) = ua.to_str() {
+            let (ua_result, metrics_os, metrics_browser) = user_agent::parse_user_agent(uas);
+            msg.add_extra("ua.os.family".to_owned(), metrics_os.to_owned());
+            msg.add_extra("ua.browser.family".to_owned(), metrics_browser.to_owned());
+            msg.add_extra("ua.name".to_owned(), ua_result.name.to_owned());
+            msg.add_extra("ua.os.ver".to_owned(), ua_result.os_version.to_string());
+            msg.add_extra("ua.browser.ver".to_owned(), ua_result.version.to_owned());
+            msg.add_extra("ua".to_owned(), uas.to_string());
+        }
+    }
+
+    msg.add_extra("uri.path".to_owned(), uri);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_tags() {
+        use actix_web::{http::header, test::TestRequest};
+        use std::collections::HashMap;
+
+        let uri = "/1.5/42/storage/meta/global".to_owned();
+        let ua = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:72.0) Gecko/20100101 Firefox/72.0";
+        let req = TestRequest::default()
+            .uri(&uri)
+            .header(header::USER_AGENT, header::HeaderValue::from_static(ua))
+            .to_http_request();
+
+        add_initial_tags(&req, "GET".to_owned());
+        add_initial_extras(&req, uri.clone());
+
+        let mut tags = HashMap::<String, String>::new();
+        tags.insert("uri.method".to_owned(), "GET".to_owned());
+
+        for tag in tags.clone() {
+            req.add_tag(tag.0.clone(), tag.1.clone());
+        }
+
+        let mut extras = HashMap::<String, String>::new();
+        extras.insert("ua.os.ver".to_owned(), "NT 10.0".to_owned());
+        extras.insert("ua.os.family".to_owned(), "Windows".to_owned());
+        extras.insert("ua.browser.ver".to_owned(), "72.0".to_owned());
+        extras.insert("ua.name".to_owned(), "Firefox".to_owned());
+        extras.insert("ua.browser.family".to_owned(), "Firefox".to_owned());
+        extras.insert("ua".to_owned(), ua.to_owned());
+        extras.insert("uri.path".to_owned(), uri);
+
+        for extra in extras.clone() {
+            req.add_extra(extra.0.clone(), extra.1.clone())
+        }
+
+        assert_eq!(req.get_tags(), tags);
+        assert_eq!(req.get_extras(), extras);
+    }
+
+    #[test]
+    fn no_empty_tags() {
+        use actix_web::{http::header, test::TestRequest};
+
+        let uri = "/1.5/42/storage/meta/global".to_owned();
+        let req = TestRequest::default()
+            .uri(&uri)
+            .header(
+                header::USER_AGENT,
+                header::HeaderValue::from_static("Mozilla/5.0 (curl) Gecko/20100101 curl"),
+            )
+            .to_http_request();
+        add_initial_tags(&req, "GET".to_owned());
+        add_initial_extras(&req, uri);
+
+        assert!(!req.get_tags().contains_key("ua.os.ver"));
     }
 }

--- a/syncserver/src/web/tags.rs
+++ b/syncserver/src/web/tags.rs
@@ -1,185 +1,91 @@
-use core::cell::RefMut;
 use std::collections::{BTreeMap, HashMap};
 
-use actix_http::Extensions;
-use actix_web::{
-    dev::{Payload, RequestHead},
-    http::header::USER_AGENT,
-    Error, FromRequest, HttpRequest,
-};
-use futures::future;
-use futures::future::Ready;
-use serde::{
-    ser::{SerializeMap, Serializer},
-    Serialize,
-};
-use serde_json::value::Value;
-use slog::{Key, Record, KV};
+use actix_web::HttpMessage;
 
-use crate::server::user_agent::parse_user_agent;
+pub trait Taggable {
+    /// Adds a tag to be included in any metric or Sentry error emitted from this point in the
+    /// request lifecycle onwards. Tags **must** have low cardinality, meaning that the number of
+    /// distinct possible values associated with a given tag must be small.
+    fn add_tag(&self, key: String, value: String);
 
-#[derive(Clone, Debug, Default)]
-pub struct Tags {
-    pub tags: HashMap<String, String>,
-    pub extra: HashMap<String, String>,
+    /// Gets all the tags associated with `Self`.
+    fn get_tags(&self) -> HashMap<String, String>;
+
+    /// Adds an extra to be included in any Sentry error emitted from this point in the request
+    /// lifecycle onwards. Extras are intended to be used to report additional metadata that have
+    /// cardinality that is too high for tags. Note that extras will not be included with metrics.
+    fn add_extra(&self, key: String, value: String);
+
+    /// Gets all the extras associated with `Self`.
+    fn get_extras(&self) -> HashMap<String, String>;
 }
 
-impl Serialize for Tags {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let mut seq = serializer.serialize_map(Some(self.tags.len()))?;
-        for tag in self.tags.clone() {
-            if !tag.1.is_empty() {
-                seq.serialize_entry(&tag.0, &tag.1)?;
-            }
-        }
-        seq.end()
-    }
-}
+impl<T> Taggable for T
+where
+    T: HttpMessage,
+{
+    fn add_tag(&self, key: String, value: String) {
+        let mut exts = self.extensions_mut();
 
-fn insert_if_not_empty(label: &str, val: &str, tags: &mut HashMap<String, String>) {
-    if !val.is_empty() {
-        tags.insert(label.to_owned(), val.to_owned());
-    }
-}
-
-/// Tags are extra data to be recorded in metric and logging calls.
-///
-/// If additional tags are required or desired, you will need to add them to the
-/// mutable extensions, e.g.
-/// ```compile_fail
-///      let mut tags = Tags::default();
-///      tags.add_tag("SomeLabel", "whatever");
-///      tags.commit(&mut request.extensions_mut());
-/// ```
-impl Tags {
-    pub fn extend(&mut self, new_tags: Self) {
-        self.tags.extend(new_tags.tags);
-        self.extra.extend(new_tags.extra);
-    }
-
-    pub fn with_tags(tags: HashMap<String, String>) -> Tags {
-        if tags.is_empty() {
-            return Tags::default();
-        }
-        Tags {
-            tags,
-            extra: HashMap::new(),
-        }
-    }
-
-    pub fn with_tag(key: &str, value: &str) -> Self {
-        let mut tags = Tags::default();
-
-        tags.tags.insert(key.to_owned(), value.to_owned());
-
-        tags
-    }
-
-    pub fn add_extra(&mut self, key: &str, value: &str) {
-        if !value.is_empty() {
-            self.extra.insert(key.to_owned(), value.to_owned());
-        }
-    }
-
-    pub fn add_tag(&mut self, key: &str, value: &str) {
-        if !value.is_empty() {
-            self.tags.insert(key.to_owned(), value.to_owned());
-        }
-    }
-
-    pub fn get(&self, label: &str) -> String {
-        let none = "None".to_owned();
-        self.tags.get(label).map(String::from).unwrap_or(none)
-    }
-
-    pub fn tag_tree(self) -> BTreeMap<String, String> {
-        let mut result = BTreeMap::new();
-
-        for (k, v) in self.tags {
-            result.insert(k.clone(), v.clone());
-        }
-        result
-    }
-
-    pub fn extra_tree(self) -> BTreeMap<String, Value> {
-        let mut result = BTreeMap::new();
-
-        for (k, v) in self.extra {
-            result.insert(k.clone(), Value::from(v));
-        }
-        result
-    }
-
-    pub fn commit(self, exts: &mut RefMut<'_, Extensions>) {
         match exts.get_mut::<Tags>() {
-            Some(t) => t.extend(self),
-            None => exts.insert(self),
-        }
-    }
-}
-
-impl From<&RequestHead> for Tags {
-    fn from(req_head: &RequestHead) -> Self {
-        // Return an Option<> type because the later consumers (ApiErrors) presume that
-        // tags are optional and wrapped by an Option<> type.
-        let mut tags = HashMap::new();
-        let mut extra = HashMap::new();
-        if let Some(ua) = req_head.headers().get(USER_AGENT) {
-            if let Ok(uas) = ua.to_str() {
-                let (ua_result, metrics_os, metrics_browser) = parse_user_agent(uas);
-                insert_if_not_empty("ua.os.family", metrics_os, &mut tags);
-                insert_if_not_empty("ua.browser.family", metrics_browser, &mut tags);
-                insert_if_not_empty("ua.name", ua_result.name, &mut tags);
-                insert_if_not_empty("ua.os.ver", &ua_result.os_version.to_owned(), &mut tags);
-                insert_if_not_empty("ua.browser.ver", ua_result.version, &mut tags);
-                extra.insert("ua".to_owned(), uas.to_string());
+            Some(tags) => {
+                tags.0.insert(key, value);
+            }
+            None => {
+                let mut tags = Tags::default();
+                tags.0.insert(key, value);
+                exts.insert(tags);
             }
         }
-        tags.insert("uri.method".to_owned(), req_head.method.to_string());
-        // `uri.path` causes too much cardinality for influx but keep it in
-        // extra for sentry
-        extra.insert("uri.path".to_owned(), req_head.uri.to_string());
-        Tags { tags, extra }
     }
-}
 
-impl FromRequest for Tags {
-    type Config = ();
-    type Error = Error;
-    type Future = Ready<Result<Self, Self::Error>>;
+    fn get_tags(&self) -> HashMap<String, String> {
+        self.extensions()
+            .get::<Tags>()
+            .map(|tags_ref| tags_ref.0.clone())
+            .unwrap_or_default()
+    }
 
-    fn from_request(req: &HttpRequest, _: &mut Payload) -> Self::Future {
-        let tags = {
-            let exts = req.extensions();
-            match exts.get::<Tags>() {
-                Some(t) => t.clone(),
-                None => Tags::from(req.head()),
+    fn add_extra(&self, key: String, value: String) {
+        let mut exts = self.extensions_mut();
+
+        match exts.get_mut::<Extras>() {
+            Some(extras) => {
+                extras.0.insert(key, value);
             }
-        };
+            None => {
+                let mut extras = Extras::default();
+                extras.0.insert(key, value);
+                exts.insert(extras);
+            }
+        }
+    }
 
-        future::ok(tags)
+    fn get_extras(&self) -> HashMap<String, String> {
+        self.extensions()
+            .get::<Extras>()
+            .map(|extras_ref| extras_ref.0.clone())
+            .unwrap_or_default()
     }
 }
+
+/// Tags are metadata that will be included in both Sentry errors and metric emissions. Given that
+/// InfluxDB requires that tags have low cardinality, tags **must** have low cardinality. This
+/// means that the number of distinct values for a given tag across every request must be low.
+#[derive(Default)]
+struct Tags(HashMap<String, String>);
+
+// "Extras" are pieces of metadata with high cardinality to be included in Sentry errors.
+#[derive(Default)]
+struct Extras(HashMap<String, String>);
 
 impl From<Tags> for BTreeMap<String, String> {
     fn from(tags: Tags) -> BTreeMap<String, String> {
         let mut result = BTreeMap::new();
 
-        for (k, v) in tags.tags {
+        for (k, v) in tags.0 {
             result.insert(k.clone(), v.clone());
         }
         result
-    }
-}
-
-impl KV for Tags {
-    fn serialize(&self, _rec: &Record<'_>, serializer: &mut dyn slog::Serializer) -> slog::Result {
-        for (key, val) in &self.tags {
-            serializer.emit_str(Key::from(key.clone()), val)?;
-        }
-        Ok(())
     }
 }


### PR DESCRIPTION
## Description

The primary purpose of this change is to reduce the cardinality of the tags we're including with InfluxDB metrics by removing user agent data. I also wanted to make it more ergonomic to use (and more difficult to misuse) tags in general, so I made a few other improvements to our tagging code:
* Previously, there were several ways to construct a `Metrics` object, including ways that didn't involve deriving the object from the `HttpRequest`. This is bad because a `Metrics` that isn't derived from `HttpRequest` won't include any tags that were persisted to the request extensions. I removed the trait implementations and functions that enabled this; `FromRequest` is now the only way to construct a `Metrics` (without building a new client altogether using a host and port). This means that, if a tag is added to the request extensions, it will necessarily be included in all subsequent metric emissions in the request lifecycle
* The `Tags` type used to represent the tags we were including in Sentry errors **as well as** the tags we were passing in to `Metrics` methods (even though `Tags` included high-cardinality data, which metrics shouldn't support). It seemed like `Tags`'s scope was a little overloaded and its interface made it easy to accidentally include high-cardinality data with metrics data. I decided to simplify things by removing `Tags` altogether and adding a `Taggable` trait, which is implemented for all `T: HttpMessage`. It includes `add_tag` and `add_extra` methods, so that adding a tag or extra to the request extensions is simplified (i.e. it just involves calling `req.add_tag(key, value)`). I also added doc comments to highlight the important difference in cardinality between tags and extras
* All tags in the request extensions will be included in both Sentry errors and metrics; extras will only be included in Sentry errors

## Issue(s)

Closes #1436 