### PR TITLE
Fix the URL people should set to use their custom tokenserver

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ This will walk you through the steps to connect this project to your local copy 
     sync-1.5 = "http://localhost:8000/1.5/1"```
 
 
-3. In Firefox, go to `about:config`. Change `identity.sync.tokenserver.uri` to `http://localhost:5000/token/1.0/sync/1.5`.
+3. In Firefox, go to `about:config`. Change `identity.sync.tokenserver.uri` to `http://localhost:5000/1.0/sync/1.5`
 4. Restart Firefox. Now, try syncing. You should see new BSOs in your local MySQL instance.
 
 ## Logging


### PR DESCRIPTION
I tried running with the recommended `/token/1.0/sync/1.5`. It led to logs of:
```
INFO {"ua.os.family":"Linux","uri.path":"/token/1.0/sync/1.5","ua.name":"Firefox","ua.os.ver":"UNKNOWN","ua.browser.ver":"108.0","ua":"108.0","ua.browser.family":"Firefox","uri.method":"GET"}
```
which returned 404 and failed to sync.

Once fixing my firefox parameter, I now get the following log line:
```
INFO {"ua.browser.family":"Firefox","uid":"[censored]","metrics_uid":"[censored]","ua":"108.0","ua.os.family":"Linux","ua.name":"Firefox","uri.method":"GET","ua.os.ver":"UNKNOWN","first_seen_at":"[censored]","uri.path":"/1.0/sync/1.5","ua.browser.ver":"108.0"}
```
and sync actually works.

I guess the `/token` part of the URL originally came from a reverse-proxy that automatically needs it? Anyway, I can confirm that things work for me without it, and don't with it.

(For full disclosure, I do have a nginx rproxy in front of my syncserver; but it's configured as passthrough, and given the log lines copied above report the expected `uri.path`, I don't think my configuration of it is wrong)
