### PR TITLE
chore: fix the version.json in Docker builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,11 +60,6 @@ commands:
       - run:
           name: cargo build
           command: cargo build
-  setup-gcp-grpc:
-    steps:
-      - run:
-          name: Install grpcio dependencies
-          command: sudo apt-get update && sudo apt-get install -y cmake golang-go
   setup-mysql:
     steps:
       - run:
@@ -175,7 +170,6 @@ jobs:
       - checkout
       - display-rust
       - setup-rust-check
-      - setup-gcp-grpc
       - rust-check
       - rust-clippy-spanner
       - rust-clippy-mysql
@@ -208,7 +202,6 @@ jobs:
       - checkout
       - display-rust
       - setup-python
-      - setup-gcp-grpc
       - setup-mysql
       - create-tokenserver-database
       # XXX: currently the time needed to setup-sccache negates its savings
@@ -230,6 +223,7 @@ jobs:
       - setup_remote_docker:
           docker_layer_caching: true
       - checkout
+      - write-version
       - run:
           name: Build MySQL Docker image
           command: docker build -t app:build --build-arg DATABASE_BACKEND=mysql .
@@ -260,6 +254,7 @@ jobs:
       - setup_remote_docker:
           docker_layer_caching: true
       - checkout
+      - write-version
       - run:
           name: Build Spanner Docker image
           command: docker build -t app:build --build-arg DATABASE_BACKEND=spanner .


### PR DESCRIPTION
## Description

and don't bother installing grpcio deps for the default build of mysql

(The switch to building separate Docker images left out version.json write)