### PR TITLE
Chore/contributor rollup

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -7,5 +7,6 @@ ignore = [
     "RUSTSEC-2020-0071",
     "RUSTSEC-2021-0124",
     "RUSTSEC-2023-0034", # Bound by actix-http 2.2, Reqwest 0.10
+    "RUSTSEC-2023-0044", # Bound to native-tls 0.2.11, request 0.10.10, hyper-tls 0.4.3
     "RUSTSEC-2023-0052", # Bound by reqwest, various tls libs
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -816,6 +816,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "curl"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "509bd11746c7ac09ebd19f0b17782eae80aadee26237658a6b4808afb5c11a22"
+dependencies = [
+ "curl-sys",
+ "libc",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "socket2 0.4.9",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "curl-sys"
+version = "0.4.67+curl-8.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cc35d066510b197a0f72de863736641539957628c8a42e70e27c66849e77c34"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+ "windows-sys",
+]
+
+[[package]]
 name = "deadpool"
 version = "0.5.2"
 source = "git+https://github.com/mozilla-services/deadpool?branch=deadpool-v0.5.2-issue92#ede2a1f1fa22a7266cf4681edd2b988dfd333af9"
@@ -2841,6 +2871,7 @@ version = "0.31.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0097a48cd1999d983909f07cb03b15241c5af29e5e679379efac1c06296abecc"
 dependencies = [
+ "curl",
  "httpdate 1.0.3",
  "native-tls",
  "reqwest 0.11.22",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,8 +14,8 @@ dependencies = [
  "futures-sink",
  "log",
  "pin-project 0.4.30",
- "tokio",
- "tokio-util",
+ "tokio 0.2.25",
+ "tokio-util 0.3.1",
 ]
 
 [[package]]
@@ -77,7 +77,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "fxhash",
- "h2",
+ "h2 0.2.7",
  "http",
  "httparse",
  "indexmap",
@@ -133,7 +133,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "smallvec",
- "tokio",
+ "tokio 0.2.25",
 ]
 
 [[package]]
@@ -149,7 +149,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "log",
- "mio",
+ "mio 0.6.23",
  "mio-uds",
  "num_cpus",
  "slab",
@@ -294,9 +294,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea5d730647d4fadd988536d06fecce94b7b4f2a7efdae548f1cf4b63205518ab"
+checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
 dependencies = [
  "memchr",
 ]
@@ -376,7 +376,7 @@ checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -469,7 +469,7 @@ dependencies = [
  "cexpr",
  "clang-sys",
  "clap",
- "env_logger",
+ "env_logger 0.9.3",
  "lazy_static",
  "lazycell",
  "log",
@@ -495,19 +495,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 
 [[package]]
-name = "bitmaps"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
-dependencies = [
- "typenum",
-]
-
-[[package]]
 name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
@@ -523,9 +523,9 @@ dependencies = [
 
 [[package]]
 name = "brotli"
-version = "3.3.4"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1a0b1dbcc8ae29329621f8d4f0d835787c1c38bb1401979b49d13b0b305ff68"
+checksum = "516074a47ef4bce09577a3b379392300159ce5b1ba2e501ff1c819950066100f"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -534,9 +534,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "2.3.4"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b6561fd3f895a11e8f72af2cb7d22e08366bebc2b6b57f7744c4bda27034744"
+checksum = "da74e2b81409b1b743f8f0c62cc6254afefb8b8e50bbfe3735550f7aeefa3448"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -550,9 +550,9 @@ checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
 name = "byteorder"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -623,8 +623,7 @@ dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "js-sys",
- "num-traits 0.2.16",
- "serde 1.0.188",
+ "num-traits 0.2.17",
  "wasm-bindgen",
  "windows-targets",
 ]
@@ -807,43 +806,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-mac"
-version = "0.11.1"
+name = "crypto-common"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
- "subtle",
-]
-
-[[package]]
-name = "curl"
-version = "0.4.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "509bd11746c7ac09ebd19f0b17782eae80aadee26237658a6b4808afb5c11a22"
-dependencies = [
- "curl-sys",
- "libc",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "socket2 0.4.9",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "curl-sys"
-version = "0.4.66+curl-8.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70c44a72e830f0e40ad90dda8a6ab6ed6314d39776599a58a2e5e37fbc6db5b9"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
- "vcpkg",
- "windows-sys",
+ "typenum",
 ]
 
 [[package]]
@@ -856,17 +825,17 @@ dependencies = [
  "crossbeam-queue",
  "num_cpus",
  "serde 1.0.188",
- "tokio",
+ "tokio 0.2.25",
 ]
 
 [[package]]
 name = "debugid"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6ee87af31d84ef885378aebca32be3d682b0e0dc119d5b4860a2c5bb5046730"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
 dependencies = [
  "serde 1.0.188",
- "uuid",
+ "uuid 1.4.1",
 ]
 
 [[package]]
@@ -945,6 +914,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer 0.10.4",
+ "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -1033,6 +1013,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
+dependencies = [
+ "humantime",
+ "is-terminal",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "erased-serde"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1043,52 +1036,31 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.3"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "136526188508e25c6fef639d7927dfb3e0e3084488bf202267829cf7fc23dbdd"
+checksum = "ac3e13f66a2f95e32a39eaa81f6b95d42878ca0e1db0c7543723dfe12557e860"
 dependencies = [
- "errno-dragonfly",
  "libc",
  "windows-sys",
 ]
 
 [[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
+name = "fastrand"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+
+[[package]]
+name = "findshlibs"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40b9e59cd0f7e0806cca4be089683ecb6434e602038df21fe6bf6711b2f07f64"
 dependencies = [
  "cc",
+ "lazy_static",
  "libc",
+ "winapi 0.3.9",
 ]
-
-[[package]]
-name = "failure"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
-dependencies = [
- "backtrace",
- "failure_derive",
-]
-
-[[package]]
-name = "failure_derive"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "synstructure",
-]
-
-[[package]]
-name = "fastrand"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
 
 [[package]]
 name = "flate2"
@@ -1208,7 +1180,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -1297,9 +1269,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "google-cloud-rust-raw"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1887de8efd052e35bf75e4ed4bc78de35b69447a4b6d9f2e7ede52579512f318"
+checksum = "fbabcfb0bcc5e3222191c3f0fba962b0cbf4242d2effe2a865090eee492ffc9c"
 dependencies = [
  "futures 0.3.28",
  "grpcio",
@@ -1351,10 +1323,29 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio",
- "tokio-util",
+ "tokio 0.2.25",
+ "tokio-util 0.3.1",
  "tracing",
  "tracing-futures",
+]
+
+[[package]]
+name = "h2"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91fc23aa11be92976ef4729127f1a74adf36d8436f7816b185d18df956790833"
+dependencies = [
+ "bytes 1.5.0",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio 1.33.0",
+ "tokio-util 0.7.9",
+ "tracing",
 ]
 
 [[package]]
@@ -1407,22 +1398,20 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hkdf"
-version = "0.11.0"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01706d578d5c281058480e673ae4086a9f4710d8df1ad80a5b03e39ece5f886b"
+checksum = "791a029f6b9fc27657f6f188ec6e5e43f6911f6f878e0dc5501396e09809d437"
 dependencies = [
- "digest",
  "hmac",
 ]
 
 [[package]]
 name = "hmac"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "crypto-mac",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1467,6 +1456,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-body"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
+dependencies = [
+ "bytes 1.5.0",
+ "http",
+ "pin-project-lite 0.2.13",
+]
+
+[[package]]
 name = "httparse"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1477,6 +1477,12 @@ name = "httpdate"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "humantime"
@@ -1494,15 +1500,39 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.2.7",
  "http",
- "http-body",
+ "http-body 0.3.1",
  "httparse",
- "httpdate",
+ "httpdate 0.3.2",
  "itoa 0.4.8",
  "pin-project 1.1.3",
  "socket2 0.3.19",
- "tokio",
+ "tokio 0.2.25",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper"
+version = "0.14.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffb1cfd654a8219eaef89881fdb3bb3b1cdc5fa75ded05d6933b2b382e395468"
+dependencies = [
+ "bytes 1.5.0",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.21",
+ "http",
+ "http-body 0.4.5",
+ "httparse",
+ "httpdate 1.0.3",
+ "itoa 1.0.9",
+ "pin-project-lite 0.2.13",
+ "socket2 0.4.9",
+ "tokio 1.33.0",
  "tower-service",
  "tracing",
  "want",
@@ -1516,10 +1546,10 @@ checksum = "37743cc83e8ee85eacfce90f2f4102030d9ff0a95244098d781e9bee4a90abb6"
 dependencies = [
  "bytes 0.5.6",
  "futures-util",
- "hyper",
+ "hyper 0.13.10",
  "log",
  "rustls",
- "tokio",
+ "tokio 0.2.25",
  "tokio-rustls",
  "webpki",
 ]
@@ -1531,10 +1561,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d979acc56dcb5b8dddba3917601745e877576475aa046df3226eabdecef78eed"
 dependencies = [
  "bytes 0.5.6",
- "hyper",
+ "hyper 0.13.10",
  "native-tls",
- "tokio",
+ "tokio 0.2.25",
  "tokio-tls",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes 1.5.0",
+ "hyper 0.14.27",
+ "native-tls",
+ "tokio 1.33.0",
+ "tokio-native-tls",
 ]
 
 [[package]]
@@ -1597,20 +1640,6 @@ name = "if_chain"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb56e1aa765b4b4f3aadfab769793b7087bb03a4ea4920644a6d238e2df5b9ed"
-
-[[package]]
-name = "im"
-version = "14.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "696059c87b83c5a258817ecd67c3af915e3ed141891fc35a1e79908801cf0ce7"
-dependencies = [
- "bitmaps",
- "rand_core 0.5.1",
- "rand_xoshiro",
- "sized-chunks",
- "typenum",
- "version_check",
-]
 
 [[package]]
 name = "indexmap"
@@ -1756,9 +1785,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.148"
+version = "0.2.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
+checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
 
 [[package]]
 name = "libloading"
@@ -1790,9 +1819,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.7"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a9bad9f94746442c783ca431b22403b519cd7fbeed0533fdd6328b2f2212128"
+checksum = "da2479e8c062e40bf0066ffa0bc823de0a9368974af99c9f6df941d2c231e03f"
 
 [[package]]
 name = "lock_api"
@@ -1839,9 +1868,9 @@ checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 
 [[package]]
 name = "memchr"
-version = "2.6.3"
+version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
+checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
 name = "migrations_internals"
@@ -1915,6 +1944,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
+dependencies = [
+ "libc",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "windows-sys",
+]
+
+[[package]]
 name = "mio-uds"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1922,7 +1962,7 @@ checksum = "afcb699eb26d4332647cc848492bbc15eafb26f08d0304550d5aa1f612e066f0"
 dependencies = [
  "iovec",
  "libc",
- "mio",
+ "mio 0.6.23",
 ]
 
 [[package]]
@@ -2021,14 +2061,14 @@ version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
 dependencies = [
- "num-traits 0.2.16",
+ "num-traits 0.2.17",
 ]
 
 [[package]]
 name = "num-traits"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
+checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
 dependencies = [
  "autocfg",
 ]
@@ -2096,7 +2136,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -2115,6 +2155,17 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "os_info"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "006e42d5b888366f1880eda20371fedde764ed2213dc8496f49622fa0c99cd5e"
+dependencies = [
+ "log",
+ "serde 1.0.188",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2239,7 +2290,7 @@ checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -2304,9 +2355,9 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.67"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
+checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
 dependencies = [
  "unicode-ident",
 ]
@@ -2463,15 +2514,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_xoshiro"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9fcdd2e881d02f1d9390ae47ad8e5696a9e4be7b547a1da2afbc61973217004"
-dependencies = [
- "rand_core 0.5.1",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2502,9 +2544,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.9.5"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "697061221ea1b4a94a624f67d0ae2bfe4e22b8a17b6a192afb11046542cc8c47"
+checksum = "d119d7c7ca818f8a53c300863d4f87566aac09943aef5b355bb83969dae75d87"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2514,9 +2556,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.8"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2f401f4955220693b56f8ec66ee9c78abffd8d1c4f23dc41a23839eb88f0795"
+checksum = "465c6fc0621e4abc4187a2bda0937bfd4f722c2730b29562e19689ea796c9a4b"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2525,9 +2567,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.5"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
+checksum = "56d84fdd47036b038fc80dd333d10b6aab10d5d31f4a366e20014def75328d33"
 
 [[package]]
 name = "reqwest"
@@ -2541,10 +2583,10 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http",
- "http-body",
- "hyper",
+ "http-body 0.3.1",
+ "hyper 0.13.10",
  "hyper-rustls",
- "hyper-tls",
+ "hyper-tls 0.4.3",
  "ipnet",
  "js-sys",
  "lazy_static",
@@ -2558,7 +2600,7 @@ dependencies = [
  "serde 1.0.188",
  "serde_json",
  "serde_urlencoded",
- "tokio",
+ "tokio 0.2.25",
  "tokio-rustls",
  "tokio-tls",
  "url 2.4.1",
@@ -2567,6 +2609,44 @@ dependencies = [
  "web-sys",
  "webpki-roots",
  "winreg 0.7.0",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.11.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "046cd98826c46c2ac8ddecae268eb5c2e58628688a5fc7a2643704a73faba95b"
+dependencies = [
+ "base64 0.21.4",
+ "bytes 1.5.0",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.21",
+ "http",
+ "http-body 0.4.5",
+ "hyper 0.14.27",
+ "hyper-tls 0.5.0",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding 2.3.0",
+ "pin-project-lite 0.2.13",
+ "serde 1.0.188",
+ "serde_json",
+ "serde_urlencoded",
+ "system-configuration",
+ "tokio 1.33.0",
+ "tokio-native-tls",
+ "tower-service",
+ "url 2.4.1",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg 0.50.0",
 ]
 
 [[package]]
@@ -2627,14 +2707,14 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.18",
+ "semver 1.0.20",
 ]
 
 [[package]]
 name = "rustix"
-version = "0.38.14"
+version = "0.38.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "747c788e9ce8e92b12cd485c49ddf90723550b654b32508f979b71a7b1ecda4f"
+checksum = "5a74ee2d7c2581cd139b42447d7d9389b889bdaad3a73f1ebb16f2a3237bb19c"
 dependencies = [
  "bitflags 2.4.0",
  "errno",
@@ -2745,9 +2825,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.18"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
+checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
 
 [[package]]
 name = "semver-parser"
@@ -2757,94 +2837,110 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "sentry"
-version = "0.19.1"
+version = "0.31.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebd0927ec4a785fc4328abe9089afbe074b3874983b3373fc328a73a9f8310cb"
+checksum = "0097a48cd1999d983909f07cb03b15241c5af29e5e679379efac1c06296abecc"
 dependencies = [
- "curl",
- "httpdate",
- "reqwest",
+ "httpdate 1.0.3",
+ "native-tls",
+ "reqwest 0.11.22",
  "sentry-backtrace",
  "sentry-contexts",
  "sentry-core",
- "sentry-failure",
+ "sentry-debug-images",
  "sentry-panic",
- "serde_json",
+ "sentry-tracing",
+ "tokio 1.33.0",
+ "ureq",
 ]
 
 [[package]]
 name = "sentry-backtrace"
-version = "0.19.1"
+version = "0.31.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4585422b92435a04569441aef8dc3417eb9d7547fd591b67fdf6fdfe204232c9"
+checksum = "18a7b80fa1dd6830a348d38a8d3a9761179047757b7dca29aef82db0118b9670"
 dependencies = [
  "backtrace",
- "lazy_static",
+ "once_cell",
  "regex",
  "sentry-core",
 ]
 
 [[package]]
 name = "sentry-contexts"
-version = "0.19.1"
+version = "0.31.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d607b3be0593e026f1c089f0086c244429fe3026eca8e075e8f9e834703ee4c0"
+checksum = "7615dc588930f1fd2e721774f25844ae93add2dbe2d3c2f995ce5049af898147"
 dependencies = [
  "hostname",
- "lazy_static",
  "libc",
- "regex",
- "rustc_version 0.2.3",
+ "os_info",
+ "rustc_version 0.4.0",
  "sentry-core",
  "uname",
 ]
 
 [[package]]
 name = "sentry-core"
-version = "0.19.1"
+version = "0.31.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9c118347dc0958e66f8b0f3866f0d85bbf8a63bffe64603baebe3f989e929e6"
+checksum = "8f51264e4013ed9b16558cce43917b983fa38170de2ca480349ceb57d71d6053"
 dependencies = [
- "im",
- "lazy_static",
- "rand 0.7.3",
+ "once_cell",
+ "rand 0.8.5",
  "sentry-types",
+ "serde 1.0.188",
+ "serde_json",
 ]
 
 [[package]]
-name = "sentry-failure"
-version = "0.19.1"
+name = "sentry-debug-images"
+version = "0.31.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8599d375040329e106653a133a1d876af53df8b504cff1de7b6f4471fd41eec3"
+checksum = "2fe6180fa564d40bb942c9f0084ffb5de691c7357ead6a2b7a3154fae9e401dd"
 dependencies = [
- "failure",
- "sentry-backtrace",
+ "findshlibs",
+ "once_cell",
  "sentry-core",
 ]
 
 [[package]]
 name = "sentry-panic"
-version = "0.19.1"
+version = "0.31.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3943c3fc7fff39244158b625bb2235a27e7e4d0b862b5e52cb57db51e6a6e6e"
+checksum = "323160213bba549f9737317b152af116af35c0410f4468772ee9b606d3d6e0fa"
 dependencies = [
  "sentry-backtrace",
  "sentry-core",
 ]
 
 [[package]]
-name = "sentry-types"
-version = "0.19.1"
+name = "sentry-tracing"
+version = "0.31.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87b41bac48a3586249431fa9efb88cd1414c3455117eb57c02f5bda9634e158d"
+checksum = "38033822128e73f7b6ca74c1631cef8868890c6cb4008a291cf73530f87b4eac"
 dependencies = [
- "chrono",
+ "sentry-backtrace",
+ "sentry-core",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "sentry-types"
+version = "0.31.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e663b3eb62ddfc023c9cf5432daf5f1a4f6acb1df4d78dd80b740b32dd1a740"
+dependencies = [
  "debugid",
+ "hex",
+ "rand 0.8.5",
  "serde 1.0.188",
  "serde_json",
  "thiserror",
+ "time 0.3.29",
  "url 2.4.1",
- "uuid",
+ "uuid 1.4.1",
 ]
 
 [[package]]
@@ -2882,7 +2978,7 @@ checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -2914,10 +3010,10 @@ version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.9.0",
  "cfg-if 1.0.0",
  "cpufeatures",
- "digest",
+ "digest 0.9.0",
  "opaque-debug",
 ]
 
@@ -2938,15 +3034,13 @@ checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
 
 [[package]]
 name = "sha2"
-version = "0.9.9"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
- "block-buffer",
  "cfg-if 1.0.0",
  "cpufeatures",
- "digest",
- "opaque-debug",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2962,16 +3056,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "sized-chunks"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59044ea371ad781ff976f7b06480b9f0180e834eda94114f2afb4afc12b7718"
-dependencies = [
- "bitmaps",
- "typenum",
 ]
 
 [[package]]
@@ -3063,7 +3147,7 @@ dependencies = [
  "slog",
  "term",
  "thread_local",
- "time 0.3.28",
+ "time 0.3.29",
 ]
 
 [[package]]
@@ -3091,6 +3175,16 @@ checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
 dependencies = [
  "libc",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "socket2"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4031e820eb552adee9295814c0ced9e5cf38ddf1e8b7d566d6de8e2538ea989e"
+dependencies = [
+ "libc",
+ "windows-sys",
 ]
 
 [[package]]
@@ -3177,9 +3271,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "subtle"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"
@@ -3194,9 +3288,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.37"
+version = "2.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7303ef2c05cd654186cb250d29049a24840ca25d2747c25c0381c8d9e2f582e8"
+checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3218,7 +3312,7 @@ dependencies = [
  "chrono",
  "docopt",
  "dyn-clone",
- "env_logger",
+ "env_logger 0.10.0",
  "futures 0.3.28",
  "hawk",
  "hex",
@@ -3228,7 +3322,7 @@ dependencies = [
  "mime",
  "rand 0.8.5",
  "regex",
- "reqwest",
+ "reqwest 0.10.10",
  "sentry",
  "sentry-backtrace",
  "serde 1.0.188",
@@ -3248,12 +3342,12 @@ dependencies = [
  "syncstorage-db",
  "syncstorage-settings",
  "thiserror",
- "time 0.3.28",
+ "time 0.3.29",
  "tokenserver-auth",
  "tokenserver-common",
  "tokenserver-db",
  "tokenserver-settings",
- "tokio",
+ "tokio 0.2.25",
  "urlencoding",
  "validator",
  "validator_derive",
@@ -3309,7 +3403,7 @@ version = "0.14.0"
 dependencies = [
  "async-trait",
  "cadence",
- "env_logger",
+ "env_logger 0.10.0",
  "futures 0.3.28",
  "hostname",
  "lazy_static",
@@ -3323,7 +3417,7 @@ dependencies = [
  "syncstorage-mysql",
  "syncstorage-settings",
  "syncstorage-spanner",
- "tokio",
+ "tokio 0.2.25",
 ]
 
 [[package]]
@@ -3355,7 +3449,7 @@ dependencies = [
  "diesel",
  "diesel_logger",
  "diesel_migrations",
- "env_logger",
+ "env_logger 0.10.0",
  "futures 0.3.28",
  "http",
  "slog-scope",
@@ -3375,7 +3469,7 @@ dependencies = [
  "rand 0.8.5",
  "serde 1.0.188",
  "syncserver-common",
- "time 0.3.28",
+ "time 0.3.29",
 ]
 
 [[package]]
@@ -3386,7 +3480,7 @@ dependencies = [
  "backtrace",
  "cadence",
  "deadpool",
- "env_logger",
+ "env_logger 0.10.0",
  "futures 0.3.28",
  "google-cloud-rust-raw",
  "grpcio",
@@ -3399,21 +3493,30 @@ dependencies = [
  "syncstorage-db-common",
  "syncstorage-settings",
  "thiserror",
- "tokio",
+ "tokio 0.2.25",
  "url 2.4.1",
- "uuid",
+ "uuid 0.8.2",
 ]
 
 [[package]]
-name = "synstructure"
-version = "0.12.6"
+name = "system-configuration"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "unicode-xid",
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -3466,22 +3569,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.48"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6d7a740b8a666a7e828dd00da9c0dc290dff53154ea77ac109281de90589b7"
+checksum = "1177e8c6d7ede7afde3585fd2513e611227efd6481bd78d2e82ba1ce16557ed4"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.48"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49922ecae66cc8a249b77e68d1d0623c1b2c514f0060c27cdc68bd62a1219d35"
+checksum = "10712f02019e9288794769fba95cd6847df9874d49d871d062172f9dd41bc4cc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -3520,9 +3623,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f6bb557fd245c28e6411aa56b6403c689ad95061f50e4be16c274e70a17e48"
+checksum = "426f806f4089c493dcac0d24c29c01e2c38baf8e30f1b716ee37e83d200b18fe"
 dependencies = [
  "deranged",
  "itoa 1.0.9",
@@ -3530,14 +3633,14 @@ dependencies = [
  "num_threads",
  "serde 1.0.188",
  "time-core",
- "time-macros 0.2.14",
+ "time-macros 0.2.15",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
@@ -3551,9 +3654,9 @@ dependencies = [
 
 [[package]]
 name = "time-macros"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a942f44339478ef67935ab2bbaec2fb0322496cf3cbe84b261e06ac3814c572"
+checksum = "4ad70d68dba9e1f8aceda7aa6711965dfec1cac869f311a51bd08b3a2ccbce20"
 dependencies = [
  "time-core",
 ]
@@ -3595,13 +3698,13 @@ dependencies = [
  "futures 0.3.28",
  "mockito",
  "pyo3",
- "reqwest",
+ "reqwest 0.10.10",
  "serde 1.0.188",
  "serde_json",
  "syncserver-common",
  "tokenserver-common",
  "tokenserver-settings",
- "tokio",
+ "tokio 0.2.25",
 ]
 
 [[package]]
@@ -3625,7 +3728,7 @@ dependencies = [
  "diesel",
  "diesel_logger",
  "diesel_migrations",
- "env_logger",
+ "env_logger 0.10.0",
  "futures 0.3.28",
  "http",
  "serde 1.0.188",
@@ -3638,7 +3741,7 @@ dependencies = [
  "thiserror",
  "tokenserver-common",
  "tokenserver-settings",
- "tokio",
+ "tokio 0.2.25",
 ]
 
 [[package]]
@@ -3662,14 +3765,29 @@ dependencies = [
  "lazy_static",
  "libc",
  "memchr",
- "mio",
+ "mio 0.6.23",
  "mio-uds",
- "num_cpus",
  "pin-project-lite 0.1.12",
  "signal-hook-registry",
  "slab",
  "tokio-macros",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "tokio"
+version = "1.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f38200e3ef7995e5ef13baec2f432a6da0aa9ac495b2c0e8f3b7eec2c92d653"
+dependencies = [
+ "backtrace",
+ "bytes 1.5.0",
+ "libc",
+ "mio 0.8.8",
+ "num_cpus",
+ "pin-project-lite 0.2.13",
+ "socket2 0.5.4",
+ "windows-sys",
 ]
 
 [[package]]
@@ -3684,6 +3802,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio 1.33.0",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3691,7 +3819,7 @@ checksum = "e12831b255bcfa39dc0436b01e19fea231a37db570686c06ee72c423479f889a"
 dependencies = [
  "futures-core",
  "rustls",
- "tokio",
+ "tokio 0.2.25",
  "webpki",
 ]
 
@@ -3702,7 +3830,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a70f4fcd7b3b24fb194f837560168208f669ca8cb70d0c4b862944452396343"
 dependencies = [
  "native-tls",
- "tokio",
+ "tokio 0.2.25",
 ]
 
 [[package]]
@@ -3716,7 +3844,21 @@ dependencies = [
  "futures-sink",
  "log",
  "pin-project-lite 0.1.12",
- "tokio",
+ "tokio 0.2.25",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d68074620f57a0b21594d9735eb2e98ab38b17f80d3fcb189fca266771ca60d"
+dependencies = [
+ "bytes 1.5.0",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite 0.2.13",
+ "tokio 1.33.0",
+ "tracing",
 ]
 
 [[package]]
@@ -3753,6 +3895,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
 dependencies = [
  "once_cell",
+ "valuable",
 ]
 
 [[package]]
@@ -3763,6 +3906,15 @@ checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
  "pin-project 1.1.3",
  "tracing",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
+dependencies = [
+ "tracing-core",
 ]
 
 [[package]]
@@ -3781,7 +3933,7 @@ dependencies = [
  "rand 0.7.3",
  "smallvec",
  "thiserror",
- "tokio",
+ "tokio 0.2.25",
  "url 2.4.1",
 ]
 
@@ -3800,7 +3952,7 @@ dependencies = [
  "resolv-conf",
  "smallvec",
  "thiserror",
- "tokio",
+ "tokio 0.2.25",
  "trust-dns-proto",
 ]
 
@@ -3862,12 +4014,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
-
-[[package]]
 name = "unindent"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3878,6 +4024,19 @@ name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "ureq"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5ccd538d4a604753ebc2f17cd9946e89b77bf87f6a8e2309667c6f2e87855e3"
+dependencies = [
+ "base64 0.21.4",
+ "log",
+ "native-tls",
+ "once_cell",
+ "url 2.4.1",
+]
 
 [[package]]
 name = "url"
@@ -3919,26 +4078,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "validator"
-version = "0.14.0"
+name = "uuid"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d0f08911ab0fee2c5009580f04615fa868898ee57de10692a45da0c3bcc3e5e"
+checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
 dependencies = [
- "idna 0.2.3",
+ "serde 1.0.188",
+]
+
+[[package]]
+name = "validator"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b92f40481c04ff1f4f61f304d61793c7b56ff76ac1469f1beb199b1445b253bd"
+dependencies = [
+ "idna 0.4.0",
  "lazy_static",
  "regex",
  "serde 1.0.188",
  "serde_derive",
  "serde_json",
  "url 2.4.1",
- "validator_types",
 ]
 
 [[package]]
 name = "validator_derive"
-version = "0.14.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d85135714dba11a1bd0b3eb1744169266f1a38977bf4e3ff5e2e1acb8c2b7eee"
+checksum = "bc44ca3088bb3ba384d9aecf40c6a23a676ce23e09bdaca2073d99c207f864af"
 dependencies = [
  "if_chain",
  "lazy_static",
@@ -3952,13 +4119,19 @@ dependencies = [
 
 [[package]]
 name = "validator_types"
-version = "0.14.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded9d97e1d42327632f5f3bae6403c04886e2de3036261ef42deebd931a6a291"
+checksum = "111abfe30072511849c5910134e8baf8dc05de4c0e5903d681cbd5c9c4d611e3"
 dependencies = [
  "proc-macro2",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vcpkg"
@@ -4032,7 +4205,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
  "wasm-bindgen-shared",
 ]
 
@@ -4066,7 +4239,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4261,10 +4434,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "woothee"
-version = "0.11.0"
+name = "winreg"
+version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d5a45c5d9c772e577c263597681448fd91a46aed911783394eec396e45d4ee"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if 1.0.0",
+ "windows-sys",
+]
+
+[[package]]
+name = "woothee"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "896174c6a4779d4d7d4523dd27aef7d46609eda2497e370f6c998325c6bf6971"
 dependencies = [
  "lazy_static",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,19 +1,19 @@
 [workspace]
 resolver = "2"
 members = [
-    "syncserver-common",
-    "syncserver-db-common",
-    "syncserver-settings",
-    "syncstorage-db",
-    "syncstorage-db-common",
-    "syncstorage-mysql",
-    "syncstorage-settings",
-    "syncstorage-spanner",
-    "tokenserver-auth",
-    "tokenserver-common",
-    "tokenserver-db",
-    "tokenserver-settings",
-    "syncserver",
+  "syncserver-common",
+  "syncserver-db-common",
+  "syncserver-settings",
+  "syncstorage-db",
+  "syncstorage-db-common",
+  "syncstorage-mysql",
+  "syncstorage-settings",
+  "syncstorage-spanner",
+  "tokenserver-auth",
+  "tokenserver-common",
+  "tokenserver-db",
+  "tokenserver-settings",
+  "syncserver",
 ]
 default-members = ["syncserver"]
 
@@ -28,12 +28,14 @@ edition = "2021"
 license = "MPL-2.0"
 
 [workspace.dependencies]
+actix-web = "3"
+
 base64 = "0.21"
 cadence = "0.29"
 backtrace = "0.3"
 chrono = "0.4"
 docopt = "1.1"
-env_logger = "0.9"
+env_logger = "0.10"
 futures = { version = "0.3", features = ["compat"] }
 hex = "0.4"
 http = "0.2"
@@ -41,14 +43,12 @@ lazy_static = "1.4"
 protobuf = "=2.25.2" # pin to 2.25.2 to prevent side updating
 rand = "0.8"
 regex = "1.4"
-sentry = { version = "0.19", features = [
-  "with_curl_transport",
-] } # pin to 0.19 until on-prem sentry server is updated
-sentry-backtrace = "0.19"
+sentry = { version = "0.31" }
+sentry-backtrace = "0.31"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = { version = "1.0", features = ["arbitrary_precision"] }
-sha2 = "0.9"
+sha2 = "0.10"
 slog = { version = "2.5", features = [
   "max_level_info",
   "release_max_level_info",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ lazy_static = "1.4"
 protobuf = "=2.25.2" # pin to 2.25.2 to prevent side updating
 rand = "0.8"
 regex = "1.4"
-sentry = { version = "0.31" }
+sentry = { version = "0.31", features = ["curl"] }
 sentry-backtrace = "0.31"
 serde = "1.0"
 serde_derive = "1.0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # NOTE: Ensure builder's Rust version matches CI's in .circleci/config.yml
-FROM lukemathwalker/cargo-chef:0.1.62-rust-1.72-buster as chef
+FROM docker.io/lukemathwalker/cargo-chef:0.1.62-rust-1.72-buster as chef
 WORKDIR /app
 
 FROM chef AS planner
@@ -51,7 +51,7 @@ RUN \
     cargo install --path ./syncserver --no-default-features --features=syncstorage-db/$DATABASE_BACKEND --locked --root /app && \
     if [ "$DATABASE_BACKEND" = "spanner" ] ; then cargo install --path ./syncstorage-spanner --locked --root /app --bin purge_ttl ; fi
 
-FROM debian:buster-slim
+FROM docker.io/library/debian:buster-slim
 WORKDIR /app
 COPY --from=builder /app/requirements.txt /app
 COPY --from=builder /app/mysql_pubkey.asc /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # NOTE: Ensure builder's Rust version matches CI's in .circleci/config.yml
-FROM docker.io/lukemathwalker/cargo-chef:0.1.62-rust-1.72-buster as chef
+FROM docker.io/lukemathwalker/cargo-chef:0.1.62-rust-1.72-bullseye as chef
 WORKDIR /app
 
 FROM chef AS planner
@@ -12,7 +12,7 @@ COPY --from=planner /app/mysql_pubkey.asc mysql_pubkey.asc
 
 # cmake is required to build grpcio-sys for Spanner builds
 RUN \
-    echo "deb https://repo.mysql.com/apt/debian/ buster mysql-8.0" >> /etc/apt/sources.list && \
+    echo "deb https://repo.mysql.com/apt/debian/ bullseye mysql-8.0" >> /etc/apt/sources.list && \
     # mysql_pubkey.asc from:
     # https://dev.mysql.com/doc/refman/8.0/en/checking-gpg-signature.html
     # related:
@@ -32,7 +32,7 @@ COPY --from=cacher /app/target /app/target
 COPY --from=cacher $CARGO_HOME /app/$CARGO_HOME
 
 RUN \
-    echo "deb https://repo.mysql.com/apt/debian/ buster mysql-8.0" >> /etc/apt/sources.list && \
+    echo "deb https://repo.mysql.com/apt/debian/ bullseye mysql-8.0" >> /etc/apt/sources.list && \
     # mysql_pubkey.asc from:
     # https://dev.mysql.com/doc/refman/8.0/en/checking-gpg-signature.html
     # related:
@@ -51,7 +51,7 @@ RUN \
     cargo install --path ./syncserver --no-default-features --features=syncstorage-db/$DATABASE_BACKEND --locked --root /app && \
     if [ "$DATABASE_BACKEND" = "spanner" ] ; then cargo install --path ./syncstorage-spanner --locked --root /app --bin purge_ttl ; fi
 
-FROM docker.io/library/debian:buster-slim
+FROM docker.io/library/debian:bullseye-slim
 WORKDIR /app
 COPY --from=builder /app/requirements.txt /app
 COPY --from=builder /app/mysql_pubkey.asc /app
@@ -67,7 +67,7 @@ RUN \
     apt-get -q update && \
     # and ca-certificates needed for https://repo.mysql.com
     apt-get install -y gnupg ca-certificates && \
-    echo "deb https://repo.mysql.com/apt/debian/ buster mysql-8.0" >> /etc/apt/sources.list && \
+    echo "deb https://repo.mysql.com/apt/debian/ bullseye mysql-8.0" >> /etc/apt/sources.list && \
     apt-key adv --import mysql_pubkey.asc && \
     # update again now that we trust repo.mysql.com
     apt-get -q update && \

--- a/docker-compose.mysql.yaml
+++ b/docker-compose.mysql.yaml
@@ -1,64 +1,70 @@
+# NOTE: This docker-compose file was constructed to create a base for
+# use by the End-to-end tests. It has not been fully tested for use in
+# constructing a true, stand-alone sync server.
+# If you're interested in doing that, please join our community in the
+# github issues and comments.
+#
 # Application runs off of port 8000.
 # you can test if it's available with
 # curl "http://localhost:8000/__heartbeat__"
 
-version: '3'
+version: "3"
 services:
-    sync-db:
-        image: mysql:5.7
-        volumes:
-            - sync_db_data:/var/lib/mysql
-        restart: always
-        ports:
-            - "3306"
-        environment:
-            #MYSQL_RANDOM_ROOT_PASSWORD: yes
-            MYSQL_ROOT_PASSWORD: random
-            MYSQL_DATABASE: syncstorage
-            MYSQL_USER: test
-            MYSQL_PASSWORD: test
+  sync-db:
+    image: docker.io/library/mysql:5.7
+    volumes:
+      - sync_db_data:/var/lib/mysql
+    restart: always
+    ports:
+      - "3306"
+    environment:
+      #MYSQL_RANDOM_ROOT_PASSWORD: yes
+      MYSQL_ROOT_PASSWORD: random
+      MYSQL_DATABASE: syncstorage
+      MYSQL_USER: test
+      MYSQL_PASSWORD: test
 
-    tokenserver-db:
-        image: mysql:5.7
-        volumes:
-            - tokenserver_db_data:/var/lib/mysql
-        restart: always
-        ports:
-            - "3306"
-        environment:
-            #MYSQL_RANDOM_ROOT_PASSWORD: yes
-            MYSQL_ROOT_PASSWORD: random
-            MYSQL_DATABASE: tokenserver
-            MYSQL_USER: test
-            MYSQL_PASSWORD: test
+  tokenserver-db:
+    image: docker.io/library/mysql:5.7
+    volumes:
+      - tokenserver_db_data:/var/lib/mysql
+    restart: always
+    ports:
+      - "3306"
+    environment:
+      #MYSQL_RANDOM_ROOT_PASSWORD: yes
+      MYSQL_ROOT_PASSWORD: random
+      MYSQL_DATABASE: tokenserver
+      MYSQL_USER: test
+      MYSQL_PASSWORD: test
 
-    mock-fxa-server:
-        image: app:build
-        restart: "no"
-        entrypoint: python3 /app/tools/integration_tests/tokenserver/mock_fxa_server.py
-        environment:
-            MOCK_FXA_SERVER_HOST: 0.0.0.0
-            MOCK_FXA_SERVER_PORT: 6000
+  mock-fxa-server:
+    image: app:build
+    restart: "no"
+    entrypoint: python3 /app/tools/integration_tests/tokenserver/mock_fxa_server.py
+    environment:
+      MOCK_FXA_SERVER_HOST: 0.0.0.0
+      MOCK_FXA_SERVER_PORT: 6000
 
-    syncserver:
-        # NOTE: The naming in the rest of this repository has been updated to reflect the fact
-        # that Syncstorage and Tokenserver are now part of one repository/server called
-        # "Syncserver" (updated from "syncstorage-rs"). We keep the legacy naming below for
-        # backwards compatibility with previous Docker images.
-        image: ${SYNCSTORAGE_RS_IMAGE:-syncstorage-rs:latest}
-        restart: always
-        ports:
-            - "8000:8000"
-        depends_on:
-            - sync-db
-            - tokenserver-db
-        environment:
-            SYNC_HOST: 0.0.0.0
-            SYNC_MASTER_SECRET: secret0
-            SYNC_SYNCSTORAGE__DATABASE_URL: mysql://test:test@sync-db:3306/syncstorage
-            SYNC_TOKENSERVER__DATABASE_URL: mysql://test:test@tokenserver-db:3306/tokenserver
-            SYNC_TOKENSERVER__RUN_MIGRATIONS: "true"
+  syncserver:
+    # NOTE: The naming in the rest of this repository has been updated to reflect the fact
+    # that Syncstorage and Tokenserver are now part of one repository/server called
+    # "Syncserver" (updated from "syncstorage-rs"). We keep the legacy naming below for
+    # backwards compatibility with previous Docker images.
+    image: ${SYNCSTORAGE_RS_IMAGE:-syncstorage-rs:latest}
+    restart: always
+    ports:
+      - "8000:8000"
+    depends_on:
+      - sync-db
+      - tokenserver-db
+    environment:
+      SYNC_HOST: 0.0.0.0
+      SYNC_MASTER_SECRET: secret0
+      SYNC_SYNCSTORAGE__DATABASE_URL: mysql://test:test@sync-db:3306/syncstorage
+      SYNC_TOKENSERVER__DATABASE_URL: mysql://test:test@tokenserver-db:3306/tokenserver
+      SYNC_TOKENSERVER__RUN_MIGRATIONS: "true"
 
 volumes:
-    sync_db_data:
-    tokenserver_db_data:
+  sync_db_data:
+  tokenserver_db_data:

--- a/syncserver-common/Cargo.toml
+++ b/syncserver-common/Cargo.toml
@@ -1,18 +1,18 @@
 [package]
 name = "syncserver-common"
-version.workspace=true
-license.workspace=true
-authors.workspace=true
-edition.workspace=true
+version.workspace = true
+license.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
-cadence.workspace=true
-futures.workspace=true
-sha2.workspace=true
-serde.workspace=true
-serde_json.workspace=true
-slog.workspace=true
-slog-scope.workspace=true
+cadence.workspace = true
+futures.workspace = true
+sha2.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+slog.workspace = true
+slog-scope.workspace = true
+actix-web.workspace = true
 
-actix-web = "3"
-hkdf = "0.11"
+hkdf = "0.12"

--- a/syncserver/Cargo.toml
+++ b/syncserver/Cargo.toml
@@ -1,51 +1,49 @@
 [package]
 name = "syncserver"
 default-run = "syncserver"
-version.workspace=true
-license.workspace=true
-authors.workspace=true
-edition.workspace=true
+version.workspace = true
+license.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
-backtrace.workspace=true
-base64.workspace=true
-cadence.workspace=true
-chrono.workspace=true
-docopt.workspace=true
-env_logger.workspace=true
-futures.workspace=true
-hex.workspace=true
-lazy_static.workspace=true
-rand.workspace=true
-regex.workspace=true
-sentry-backtrace.workspace=true
-serde.workspace=true
-serde_derive.workspace=true
-serde_json.workspace=true
-sha2.workspace=true
-slog.workspace=true
-slog-async.workspace=true
-slog-envlogger.workspace=true
-slog-mozlog-json.workspace=true
-slog-scope.workspace=true
-slog-stdlog.workspace=true
-slog-term.workspace=true
+actix-web.workspace = true
+backtrace.workspace = true
+base64.workspace = true
+cadence.workspace = true
+chrono.workspace = true
+docopt.workspace = true
+env_logger.workspace = true
+futures.workspace = true
+hex.workspace = true
+lazy_static.workspace = true
+rand.workspace = true
+regex.workspace = true
+sentry.workspace = true
+sentry-backtrace.workspace = true
+serde.workspace = true
+serde_derive.workspace = true
+serde_json.workspace = true
+sha2.workspace = true
+slog.workspace = true
+slog-async.workspace = true
+slog-envlogger.workspace = true
+slog-mozlog-json.workspace = true
+slog-scope.workspace = true
+slog-stdlog.workspace = true
+slog-term.workspace = true
 
 actix-http = "2"
-actix-web = "3"
 actix-rt = "1"                                                       # Pin to 1.0, due to dependencies on Tokio
 actix-cors = "0.5"
 async-trait = "0.1.40"
 dyn-clone = "1.0.4"
 hostname = "0.3.1"
 hawk = "3.2"
-hmac = "0.11"
+hmac = "0.12"
 mime = "0.3"
 reqwest = { version = "0.10.10", features = ["json", "rustls-tls"] }
 # pin to 0.19: https://github.com/getsentry/sentry-rust/issues/277
-sentry = { version = "0.19", features = [
-  "with_curl_transport",
-] } # pin to 0.19 until on-prem sentry server is updated
 syncserver-common = { path = "../syncserver-common" }
 syncserver-db-common = { path = "../syncserver-db-common" }
 syncserver-settings = { path = "../syncserver-settings" }
@@ -60,9 +58,9 @@ tokenserver-settings = { path = "../tokenserver-settings" }
 # pinning to 0.2.4 due to high number of dependencies (actix, bb8, deadpool, etc.)
 tokio = { version = "0.2.4", features = ["macros", "sync"] }
 urlencoding = "2.1"
-validator = "0.14"
-validator_derive = "0.14"
-woothee = "0.11"
+validator = "0.16"
+validator_derive = "0.16"
+woothee = "0.13"
 
 [features]
 default = ["syncstorage-db/mysql"]

--- a/syncserver/src/main.rs
+++ b/syncserver/src/main.rs
@@ -2,7 +2,7 @@
 #[macro_use]
 extern crate slog_scope;
 
-use std::{error::Error, sync::Arc};
+use std::error::Error;
 
 use docopt::Docopt;
 use serde::Deserialize;
@@ -32,16 +32,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let settings = Settings::with_env_and_config_file(args.flag_config.as_deref())?;
     init_logging(!settings.human_logs).expect("Logging failed to initialize");
     debug!("Starting up...");
-    // Set SENTRY_DSN environment variable to enable Sentry.
-    // Avoid its default reqwest transport for now due to issues w/
-    // likely grpcio's boringssl
-    let curl_transport_factory = |options: &sentry::ClientOptions| {
-        Arc::new(sentry::transports::CurlHttpTransport::new(options))
-            as Arc<dyn sentry::internals::Transport>
-    };
     let _sentry = sentry::init(sentry::ClientOptions {
         // Note: set "debug: true," to diagnose sentry issues
-        transport: Some(Arc::new(curl_transport_factory)),
         release: sentry::release_name!(),
         ..sentry::ClientOptions::default()
     });

--- a/syncserver/src/server/test.rs
+++ b/syncserver/src/server/test.rs
@@ -10,7 +10,7 @@ use actix_web::{
 use base64::{engine, Engine};
 use chrono::offset::Utc;
 use hawk::{self, Credentials, Key, RequestBuilder};
-use hmac::{Hmac, Mac, NewMac};
+use hmac::{Hmac, Mac};
 use lazy_static::lazy_static;
 use rand::{thread_rng, Rng};
 use serde::de::DeserializeOwned;

--- a/syncserver/src/tokenserver/extractors.rs
+++ b/syncserver/src/tokenserver/extractors.rs
@@ -16,7 +16,7 @@ use actix_web::{
 use base64::{engine, Engine};
 use futures::future::LocalBoxFuture;
 use hex;
-use hmac::{Hmac, Mac, NewMac};
+use hmac::{Hmac, Mac};
 use lazy_static::lazy_static;
 use regex::Regex;
 use serde::Deserialize;

--- a/syncserver/src/web/auth.rs
+++ b/syncserver/src/web/auth.rs
@@ -11,7 +11,7 @@ use std::convert::TryInto;
 use base64::{engine, Engine};
 use chrono::offset::Utc;
 use hawk::{self, Header as HawkHeader, Key, RequestBuilder};
-use hmac::{Hmac, Mac, NewMac};
+use hmac::{Hmac, Mac};
 use serde::{Deserialize, Serialize};
 use sha2::Sha256;
 use syncserver_common;
@@ -201,7 +201,7 @@ impl HawkPayload {
 fn verify_hmac(info: &[u8], key: &[u8], expected: &[u8]) -> ApiResult<()> {
     let mut hmac = Hmac::<Sha256>::new_from_slice(key)?;
     hmac.update(info);
-    hmac.verify(expected).map_err(From::from)
+    hmac.verify(expected.into()).map_err(From::from)
 }
 
 #[cfg(test)]

--- a/syncserver/src/web/error.rs
+++ b/syncserver/src/web/error.rs
@@ -7,7 +7,7 @@ use actix_web::Error as ActixError;
 use base64::DecodeError;
 
 use hawk::Error as ParseError;
-use hmac::crypto_mac::{InvalidKeyLength, MacError};
+use hmac::digest::{InvalidLength, MacError};
 use serde::{
     ser::{SerializeSeq, Serializer},
     Serialize,
@@ -69,7 +69,7 @@ pub enum HawkErrorKind {
     InvalidHeader,
 
     #[error("{}", _0)]
-    InvalidKeyLength(InvalidKeyLength),
+    InvalidKeyLength(InvalidLength),
 
     #[error("{}", _0)]
     Json(JsonError),
@@ -166,7 +166,7 @@ impl_fmt_display!(HawkError, HawkErrorKind);
 impl_fmt_display!(ValidationError, ValidationErrorKind);
 
 from_error!(DecodeError, ApiError, HawkErrorKind::Base64);
-from_error!(InvalidKeyLength, ApiError, HawkErrorKind::InvalidKeyLength);
+from_error!(InvalidLength, ApiError, HawkErrorKind::InvalidKeyLength);
 from_error!(JsonError, ApiError, HawkErrorKind::Json);
 from_error!(MacError, ApiError, HawkErrorKind::Hmac);
 from_error!(ToStrError, ApiError, HawkErrorKind::Header);

--- a/syncserver/src/web/extractors.rs
+++ b/syncserver/src/web/extractors.rs
@@ -1749,7 +1749,7 @@ mod tests {
         Error, HttpResponse,
     };
     use hawk::{Credentials, Key, RequestBuilder};
-    use hmac::{Hmac, Mac, NewMac};
+    use hmac::{Hmac, Mac};
     use rand::{thread_rng, Rng};
     use serde_json::{self, json};
     use sha2::Sha256;

--- a/syncstorage-spanner/Cargo.toml
+++ b/syncstorage-spanner/Cargo.toml
@@ -1,39 +1,42 @@
 [package]
 name = "syncstorage-spanner"
-version.workspace=true
-license.workspace=true
-authors.workspace=true
-edition.workspace=true
+version.workspace = true
+license.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
-backtrace.workspace=true
-cadence.workspace=true
-env_logger.workspace=true
-futures.workspace=true
-http.workspace=true
-slog-scope.workspace=true
+backtrace.workspace = true
+cadence.workspace = true
+env_logger.workspace = true
+futures.workspace = true
+http.workspace = true
+slog-scope.workspace = true
 
 async-trait = "0.1.40"
 # Pin to 0.5 for now, to keep it under tokio 0.2 (issue977).
 # Fix for #803 (deadpool#92) points to our fork for now
 #deadpool = "0.5"  # pin to 0.5
 deadpool = { git = "https://github.com/mozilla-services/deadpool", branch = "deadpool-v0.5.2-issue92" }
-google-cloud-rust-raw = "0.14.0"
+google-cloud-rust-raw = "0.15.0"
 # Some versions of OpenSSL 1.1.1 conflict with grpcio's built-in boringssl which can cause
 # syncserver to either fail to either compile, or start. In those cases, try
 # `cargo build --features grpcio/openssl ...`
-grpcio = { version = "0.12.0" }
+grpcio = { version = "0.12.1" }
 log = { version = "0.4", features = [
   "max_level_debug",
   "release_max_level_info",
 ] }
-protobuf = {version="2.25.2"} # must match what's used by googleapis-raw
+protobuf = { version = "2.28.0" } # must match what's used by googleapis-raw
 syncserver-common = { path = "../syncserver-common" }
 syncserver-db-common = { path = "../syncserver-db-common" }
 syncstorage-db-common = { path = "../syncstorage-db-common" }
 syncstorage-settings = { path = "../syncstorage-settings" }
 thiserror = "1.0.26"
-tokio = { version = "0.2.4", features = ["macros", "sync"] } # pinning to 0.2.4 due to high number of dependencies (actix, bb8, deadpool, etc.)
+tokio = { version = "0.2.4", features = [
+  "macros",
+  "sync",
+] } # pinning to 0.2.4 due to high number of dependencies (actix, bb8, deadpool, etc.)
 url = "2.1"
 uuid = { version = "0.8.2", features = ["serde", "v4"] }
 

--- a/tokenserver-common/Cargo.toml
+++ b/tokenserver-common/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "tokenserver-common"
-version.workspace=true
-license.workspace=true
-authors.workspace=true
-edition.workspace=true
+version.workspace = true
+license.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
-backtrace.workspace=true
-serde.workspace=true
-serde_json.workspace=true
+actix-web.workspace = true
+backtrace.workspace = true
+serde.workspace = true
+serde_json.workspace = true
 
-actix-web = "3"
 syncserver-common = { path = "../syncserver-common" }
 thiserror = "1.0.26"

--- a/tools/integration_tests/requirements.txt
+++ b/tools/integration_tests/requirements.txt
@@ -7,10 +7,10 @@ pyjwt
 pyramid
 pyramid_hawkauth
 pyfxa
+pytest
 requests
 simplejson
 sqlalchemy
 tokenlib
-unittest2
 webtest
 wsgiproxy2

--- a/tools/integration_tests/test_storage.py
+++ b/tools/integration_tests/test_storage.py
@@ -842,7 +842,7 @@ class TestStorage(StorageFunctionalTestCase):
         # This can't be run against a live server.
         raise unittest.SkipTest
         if self.distant:
-            raise unittest2.SkipTest
+            raise unittest.SkipTest
 
         # Clear out any data that's already in the store.
         self.retry_delete(self.root + "/storage")

--- a/tools/integration_tests/test_storage.py
+++ b/tools/integration_tests/test_storage.py
@@ -14,7 +14,8 @@ consider it a bug.
 
 """
 
-import unittest2
+# unittest imported by pytest requirement
+import unittest
 
 
 import re
@@ -701,7 +702,7 @@ class TestStorage(StorageFunctionalTestCase):
     def test_x_timestamp_header(self):
         # This can't be run against a live server.
         if self.distant:
-            raise unittest2.SkipTest
+            raise unittest.SkipTest
 
         bsos = [{"id": str(i).zfill(2), "payload": "xxx"} for i in range(5)]
         self.retry_post_json(self.root + "/storage/xxx_col2", bsos)
@@ -839,7 +840,7 @@ class TestStorage(StorageFunctionalTestCase):
 
     def test_overquota(self):
         # This can't be run against a live server.
-        raise unittest2.SkipTest
+        raise unittest.SkipTest
         if self.distant:
             raise unittest2.SkipTest
 
@@ -897,7 +898,7 @@ class TestStorage(StorageFunctionalTestCase):
             # Can't run against live server if it doesn't
             # report the right config options.
             if self.distant:
-                raise unittest2.SkipTest
+                raise unittest.SkipTest
             max_bytes = get_limit_config(self.config, "max_post_bytes")
             max_count = get_limit_config(self.config, "max_post_records")
             max_req_bytes = get_limit_config(self.config, "max_request_bytes")
@@ -1483,7 +1484,7 @@ class TestStorage(StorageFunctionalTestCase):
         # This can't be run against a live server because we
         # have to forge an auth token to test things properly.
         if self.distant:
-            raise unittest2.SkipTest
+            raise unittest.SkipTest
 
         # Write some items while we've got a good token.
         bsos = [{"id": str(i).zfill(2), "payload": "xxx"} for i in range(3)]
@@ -2122,7 +2123,7 @@ class TestStorage(StorageFunctionalTestCase):
             if batch1 == batch2:
                 break
         else:
-            raise unittest2.SkipTest("failed to generate conflicting batchid")
+            raise unittest.SkipTest("failed to generate conflicting batchid")
 
     def test_that_we_dont_resurrect_committed_batches(self):
         # This retry loop tries to trigger a situation where we:
@@ -2146,7 +2147,7 @@ class TestStorage(StorageFunctionalTestCase):
             if batch1 == batch2:
                 break
         else:
-            raise unittest2.SkipTest("failed to trigger re-use of batchid")
+            raise unittest.SkipTest("failed to trigger re-use of batchid")
         # Despite having the same batchid, the second batch should
         # be completely independent of the first.
         resp = self.app.get(self.root + "/storage/xxx_col2")

--- a/tools/integration_tests/test_support.py
+++ b/tools/integration_tests/test_support.py
@@ -25,7 +25,8 @@ import sys
 import time
 import tokenlib
 import urllib.parse as urlparse
-import unittest2
+# unittest imported by pytest requirement
+import unittest
 import uuid
 from webtest import TestApp
 from zope.interface import implementer
@@ -234,7 +235,7 @@ def restore_env(*keys):
     return decorator
 
 
-class TestCase(unittest2.TestCase):
+class TestCase(unittest.TestCase):
     """TestCase with some generic helper methods."""
 
     def setUp(self):
@@ -420,7 +421,7 @@ class StorageFunctionalTestCase(FunctionalTestCase, StorageTestCase):
     def _switch_user(self):
         # It's hard to reliably switch users when testing a live server.
         if self.distant:
-            raise unittest2.SkipTest("Skipped when testing a live server")
+            raise unittest.SkipTest("Skipped when testing a live server")
         # Temporarily authenticate as a different user.
         orig_user_id = self.user_id
         orig_auth_token = self.auth_token
@@ -866,13 +867,13 @@ def run_live_functional_tests(TestCaseClass, argv=None):
     os.environ["MOZSVC_TEST_REMOTE"] = "localhost"
 
     # Now use the unittest2 runner to execute them.
-    suite = unittest2.TestSuite()
+    suite = unittest.TestSuite()
     import test_storage
 
     test_prefix = os.environ.get("SYNC_TEST_PREFIX", "test")
-    suite.addTest(unittest2.findTestCases(test_storage, test_prefix))
-    # suite.addTest(unittest2.makeSuite(LiveTestCases, prefix=test_prefix))
-    runner = unittest2.TextTestRunner(
+    suite.addTest(unittest.findTestCases(test_storage, test_prefix))
+    # suite.addTest(unittest.makeSuite(LiveTestCases, prefix=test_prefix))
+    runner = unittest.TextTestRunner(
         stream=sys.stderr,
         failfast=opts.failfast,
         verbosity=2,

--- a/tools/spanner/Dockerfile
+++ b/tools/spanner/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7.7-buster
+FROM python:3.11-bullseye
 
 COPY purge_ttl.py count_expired_rows.py count_users.py requirements.txt /app/
 


### PR DESCRIPTION
## Description

These needed to be rolled in due to various dependency changes.

 * Fix the URL people should set to use their Custom Server (https://github.com/mozilla-services/syncstorage-rs/pull/1453) -
[Ekleog](https://github.com/Ekleog)
 * Make docker files more podman friendly (https://github.com/mozilla-services/syncstorage-rs/pull/1431) -
[mb](https://github.com/mb)

* This PR also updates a number of dependencies:
   * Uses rust 1.72 (required by later versions of libraries) and python 3.11 (because of 3.7 EoL)
   * Switches unittest to pytest's unittest (to deal with python 3.11)
   * Adds CVE declarations to `audit.toml`
   * update from `buster` to `bullseye` because, at this point, might as well set a solid base.
