### PR TITLE
feat: add dynamic routing headers to all Spanner ops

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3387,6 +3387,7 @@ dependencies = [
  "cadence",
  "deadpool",
  "env_logger",
+ "form_urlencoded",
  "futures 0.3.28",
  "google-cloud-rust-raw",
  "grpcio",

--- a/syncstorage-settings/src/lib.rs
+++ b/syncstorage-settings/src/lib.rs
@@ -79,6 +79,8 @@ pub struct Settings {
     pub database_use_test_transactions: bool,
     #[cfg(debug_assertions)]
     pub database_spanner_use_mutations: bool,
+    /// Whether leader aware router headers are sent to Spanner
+    pub database_spanner_route_to_leader: bool,
 
     /// Server-enforced limits for request payloads.
     pub limits: ServerLimits,
@@ -112,6 +114,7 @@ impl Default for Settings {
             database_use_test_transactions: false,
             #[cfg(debug_assertions)]
             database_spanner_use_mutations: true,
+            database_spanner_route_to_leader: false,
             limits: ServerLimits::default(),
             statsd_label: "syncstorage".to_string(),
             enable_quota: false,

--- a/syncstorage-spanner/Cargo.toml
+++ b/syncstorage-spanner/Cargo.toml
@@ -19,6 +19,7 @@ async-trait = "0.1.40"
 #deadpool = "0.5"  # pin to 0.5
 deadpool = { git = "https://github.com/mozilla-services/deadpool", branch = "deadpool-v0.5.2-issue92" }
 google-cloud-rust-raw = "0.14.0"
+form_urlencoded = "1.2"
 # Some versions of OpenSSL 1.1.1 conflict with grpcio's built-in boringssl which can cause
 # syncserver to either fail to either compile, or start. In those cases, try
 # `cargo build --features grpcio/openssl ...`

--- a/syncstorage-spanner/src/lib.rs
+++ b/syncstorage-spanner/src/lib.rs
@@ -9,6 +9,7 @@ mod macros;
 mod batch;
 mod error;
 mod manager;
+mod metadata;
 mod models;
 mod pool;
 mod support;

--- a/syncstorage-spanner/src/manager/deadpool.rs
+++ b/syncstorage-spanner/src/manager/deadpool.rs
@@ -37,7 +37,7 @@ impl SpannerSessionManager {
         blocking_threadpool: Arc<BlockingThreadpool>,
     ) -> Result<Self, DbError> {
         Ok(Self {
-            settings: SpannerSessionSettings::from(settings)?,
+            settings: SpannerSessionSettings::from_settings(settings)?,
             env: Arc::new(EnvBuilder::new().build()),
             metrics: metrics.clone(),
             blocking_threadpool,

--- a/syncstorage-spanner/src/manager/deadpool.rs
+++ b/syncstorage-spanner/src/manager/deadpool.rs
@@ -6,28 +6,26 @@ use grpcio::{EnvBuilder, Environment};
 use syncserver_common::{BlockingThreadpool, Metrics};
 use syncstorage_settings::Settings;
 
-use super::session::{create_spanner_session, recycle_spanner_session, SpannerSession};
+use super::session::{
+    create_spanner_session, recycle_spanner_session, SpannerSession, SpannerSessionSettings,
+};
 use crate::error::DbError;
 
 pub(crate) type Conn = deadpool::managed::Object<SpannerSession, DbError>;
 
 pub(crate) struct SpannerSessionManager {
-    database_name: String,
+    settings: SpannerSessionSettings,
     /// The gRPC environment
     env: Arc<Environment>,
     metrics: Metrics,
-    test_transactions: bool,
-    max_lifespan: Option<u32>,
-    max_idle: Option<u32>,
-    emulator_host: Option<String>,
     blocking_threadpool: Arc<BlockingThreadpool>,
 }
 
 impl fmt::Debug for SpannerSessionManager {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("deadpool::SpannerSessionManager")
-            .field("database_name", &self.database_name)
-            .field("test_transactions", &self.test_transactions)
+            .field("settings", &self.settings)
+            .field("blocking_threadpool", &self.blocking_threadpool)
             .finish()
     }
 }
@@ -38,27 +36,10 @@ impl SpannerSessionManager {
         metrics: &Metrics,
         blocking_threadpool: Arc<BlockingThreadpool>,
     ) -> Result<Self, DbError> {
-        let database_name = settings
-            .spanner_database_name()
-            .ok_or_else(|| {
-                DbError::internal(format!("invalid database url: {}", settings.database_url))
-            })?
-            .to_owned();
-        let env = Arc::new(EnvBuilder::new().build());
-
-        #[cfg(not(debug_assertions))]
-        let test_transactions = false;
-        #[cfg(debug_assertions)]
-        let test_transactions = settings.database_use_test_transactions;
-
         Ok(Self {
-            database_name,
-            env,
+            settings: SpannerSessionSettings::from(settings)?,
+            env: Arc::new(EnvBuilder::new().build()),
             metrics: metrics.clone(),
-            test_transactions,
-            max_lifespan: settings.database_pool_connection_lifespan,
-            max_idle: settings.database_pool_connection_max_idle,
-            emulator_host: settings.spanner_emulator_host.clone(),
             blocking_threadpool,
         })
     }
@@ -68,11 +49,9 @@ impl SpannerSessionManager {
 impl Manager<SpannerSession, DbError> for SpannerSessionManager {
     async fn create(&self) -> Result<SpannerSession, DbError> {
         let session = create_spanner_session(
+            &self.settings,
             Arc::clone(&self.env),
             self.metrics.clone(),
-            &self.database_name,
-            self.test_transactions,
-            self.emulator_host.clone(),
             self.blocking_threadpool.clone(),
         )
         .await?;
@@ -80,14 +59,8 @@ impl Manager<SpannerSession, DbError> for SpannerSessionManager {
     }
 
     async fn recycle(&self, conn: &mut SpannerSession) -> RecycleResult<DbError> {
-        recycle_spanner_session(
-            conn,
-            &self.database_name,
-            &self.metrics,
-            self.max_lifespan,
-            self.max_idle,
-        )
-        .await
-        .map_err(RecycleError::Backend)
+        recycle_spanner_session(conn, &self.metrics)
+            .await
+            .map_err(RecycleError::Backend)
     }
 }

--- a/syncstorage-spanner/src/manager/session.rs
+++ b/syncstorage-spanner/src/manager/session.rs
@@ -72,7 +72,7 @@ pub struct SpannerSessionSettings {
 }
 
 impl SpannerSessionSettings {
-    pub fn from(settings: &Settings) -> Result<Self, DbError> {
+    pub fn from_settings(settings: &Settings) -> Result<Self, DbError> {
         let database = settings
             .spanner_database_name()
             .ok_or_else(|| {

--- a/syncstorage-spanner/src/manager/session.rs
+++ b/syncstorage-spanner/src/manager/session.rs
@@ -4,10 +4,11 @@ use google_cloud_rust_raw::spanner::v1::{
     spanner::{CreateSessionRequest, GetSessionRequest, Session},
     spanner_grpc::SpannerClient,
 };
-use grpcio::{CallOption, ChannelBuilder, ChannelCredentials, Environment, MetadataBuilder};
+use grpcio::{CallOption, ChannelBuilder, ChannelCredentials, Environment};
 use syncserver_common::{BlockingThreadpool, Metrics};
+use syncstorage_settings::Settings;
 
-use crate::error::DbError;
+use crate::{error::DbError, metadata::MetadataBuilder};
 
 const SPANNER_ADDRESS: &str = "spanner.googleapis.com:443";
 
@@ -21,25 +22,103 @@ pub struct SpannerSession {
     pub session: Session,
     /// The underlying client (Connection/Channel) for interacting with spanner
     pub client: SpannerClient,
-    pub(crate) use_test_transactions: bool,
+    /// Session Settings
+    pub settings: SpannerSessionSettings,
     /// A second based UTC for SpannerSession creation.
     /// Session has a similar `create_time` value that is managed by protobuf,
     /// but some clock skew issues are possible.
     pub(crate) create_time: i64,
-    /// Whether we are using the Spanner emulator
-    pub using_spanner_emulator: bool,
+}
+
+impl SpannerSession {
+    /// Return [CallOption] including a Dynamic Routing header for this
+    /// [SpannerSession] in its [grpcio::Metdata]
+    ///
+    /// The more common form of [grpcio::Metdata] used by Spanner operations
+    /// such as `begin`, `commit`, `execute_sql`, etc.
+    pub fn session_opt(&self) -> Result<CallOption, grpcio::Error> {
+        // NOTE: this could also be cached (then cloned)
+        let meta = self
+            .settings
+            .metadata_builder()
+            .routing_param("session", self.session.get_name())
+            .build()?;
+        Ok(CallOption::default().headers(meta))
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct SpannerSessionSettings {
+    /// The database name
+    pub database: String,
+
+    /// Whether [SpannerDb] uses mutations, which should be more efficient for
+    /// some of its bulk operations
+    pub use_mutations: bool,
+
+    /// Whether the Leader Aware Routing header should be included in gRPC
+    /// metdata
+    pub route_to_leader: bool,
+
+    /// Max age of a Session
+    pub max_lifespan: Option<u32>,
+    /// Max idle time of a Session
+    pub max_idle: Option<u32>,
+
+    /// For tests: disables transactions from committing
+    pub(crate) use_test_transactions: bool,
+    /// Spanner emulator hostname when set to Spanner emulator mode
+    pub emulator_host: Option<String>,
+}
+
+impl SpannerSessionSettings {
+    pub fn from(settings: &Settings) -> Result<Self, DbError> {
+        let database = settings
+            .spanner_database_name()
+            .ok_or_else(|| {
+                DbError::internal(format!("Invalid database url: {}", settings.database_url))
+            })?
+            .to_owned();
+
+        #[cfg(not(debug_assertions))]
+        let (use_test_transactions, use_mutations) = (false, true);
+        #[cfg(debug_assertions)]
+        let (use_test_transactions, use_mutations) = (
+            settings.database_use_test_transactions,
+            settings.database_spanner_use_mutations,
+        );
+
+        Ok(Self {
+            database,
+            use_mutations,
+            route_to_leader: settings.database_spanner_route_to_leader,
+            max_lifespan: settings.database_pool_connection_lifespan,
+            max_idle: settings.database_pool_connection_max_idle,
+            use_test_transactions,
+            emulator_host: settings.spanner_emulator_host.clone(),
+        })
+    }
+
+    /// Whether the Spanner emulator's in use
+    pub fn using_spanner_emulator(&self) -> bool {
+        self.emulator_host.is_some()
+    }
+
+    /// Build [grpcio::Metadata] with a Resource prefix and other applicable
+    /// settings
+    pub fn metadata_builder(&self) -> MetadataBuilder {
+        MetadataBuilder::with_prefix(&self.database).route_to_leader(self.route_to_leader)
+    }
 }
 
 /// Create a Session (and the underlying gRPC Channel)
 pub async fn create_spanner_session(
+    settings: &SpannerSessionSettings,
     env: Arc<Environment>,
     mut metrics: Metrics,
-    database_name: &str,
-    use_test_transactions: bool,
-    emulator_host: Option<String>,
     blocking_threadpool: Arc<BlockingThreadpool>,
 ) -> Result<SpannerSession, DbError> {
-    let using_spanner_emulator = emulator_host.is_some();
+    let emulator_host = settings.emulator_host.clone();
     let chan = blocking_threadpool
         .spawn(move || -> Result<grpcio::Channel, DbError> {
             if let Some(spanner_emulator_address) = emulator_host {
@@ -66,28 +145,34 @@ pub async fn create_spanner_session(
     let client = SpannerClient::new(chan);
 
     // Connect to the instance and create a Spanner session.
-    let session = create_session(&client, database_name).await?;
+    let session = create_session(&client, settings).await?;
 
     Ok(SpannerSession {
         session,
         client,
-        use_test_transactions,
+        // NOTE: later versions of deadpool provide an Object::pool method
+        // where we could get Settings from (via Manager) instead of cloning
+        settings: settings.clone(),
         create_time: crate::now(),
-        using_spanner_emulator,
     })
 }
 
 /// Recycle a cached Session for reuse
 pub async fn recycle_spanner_session(
     conn: &mut SpannerSession,
-    database_name: &str,
     metrics: &Metrics,
-    max_lifetime: Option<u32>,
-    max_idle: Option<u32>,
 ) -> Result<(), DbError> {
+    let settings = &conn.settings;
+    let session = conn.session.get_name();
     let now = crate::now();
     let mut req = GetSessionRequest::new();
-    req.set_name(conn.session.get_name().to_owned());
+    req.set_name(session.to_owned());
+    let meta = settings
+        .metadata_builder()
+        .routing_param("name", session)
+        .build()?;
+    let opt = CallOption::default().headers(meta);
+
     /*
     Connections can sometimes produce GOAWAY errors. GOAWAYs are HTTP2 frame
     errors that are (usually) sent before a given connection is shut down. It
@@ -108,20 +193,20 @@ pub async fn recycle_spanner_session(
     result in the client re-trying.
 
      */
-    match conn.client.get_session_async(&req)?.await {
+    match conn.client.get_session_async_opt(&req, opt)?.await {
         Ok(this_session) => {
             // Remember, this_session may not be related to
             // the SpannerSession.session, so you may need
             // to reflect changes if you want a more permanent
             // data reference.
-            if this_session.get_name() != conn.session.get_name() {
+            if this_session.get_name() != session {
                 warn!(
                     "This session may not be the session you want {} != {}",
                     this_session.get_name(),
                     conn.session.get_name()
                 );
             }
-            if let Some(max_life) = max_lifetime {
+            if let Some(max_life) = settings.max_lifespan {
                 // use our create time. (this_session has it's own
                 // `create_time` timestamp, but clock drift could
                 // be an issue.)
@@ -133,7 +218,7 @@ pub async fn recycle_spanner_session(
                 }
             }
             // check how long that this has been idle...
-            if let Some(max_idle) = max_idle {
+            if let Some(max_idle) = settings.max_idle {
                 // use the Protobuf last use time from the saved
                 // reference Session. It's not perfect, but it's good enough.
                 let idle = conn
@@ -157,7 +242,7 @@ pub async fn recycle_spanner_session(
             grpcio::Error::RpcFailure(ref status)
                 if status.code() == grpcio::RpcStatusCode::NOT_FOUND =>
             {
-                conn.session = create_session(&conn.client, database_name).await?;
+                conn.session = create_session(&conn.client, settings).await?;
                 Ok(())
             }
             _ => Err(e.into()),
@@ -167,13 +252,14 @@ pub async fn recycle_spanner_session(
 
 async fn create_session(
     client: &SpannerClient,
-    database_name: &str,
+    settings: &SpannerSessionSettings,
 ) -> Result<Session, grpcio::Error> {
     let mut req = CreateSessionRequest::new();
-    req.database = database_name.to_owned();
-    let mut meta = MetadataBuilder::new();
-    meta.add_str("google-cloud-resource-prefix", database_name)?;
-    meta.add_str("x-goog-api-client", "gcp-grpc-rs")?;
-    let opt = CallOption::default().headers(meta.build());
+    req.database = settings.database.clone();
+    let meta = settings
+        .metadata_builder()
+        .routing_param("database", &settings.database)
+        .build()?;
+    let opt = CallOption::default().headers(meta);
     client.create_session_async_opt(&req, opt)?.await
 }

--- a/syncstorage-spanner/src/metadata.rs
+++ b/syncstorage-spanner/src/metadata.rs
@@ -1,0 +1,129 @@
+/// gRPC metadata Resource prefix header
+///
+/// Generic across Google APIs. This "improves routing by the backend" as
+/// described by other clients
+const PREFIX_KEY: &str = "google-cloud-resource-prefix";
+
+/// gRPC metadata Client information header
+///
+/// A `User-Agent` like header, likely its main use is for GCP's metrics
+const METRICS_KEY: &str = "x-goog-api-client";
+
+/// gRPC metadata Dynamic Routing header:
+/// https://google.aip.dev/client-libraries/4222
+///
+/// See the googleapis protobuf for which routing header params are used for
+/// each Spanner operation (under the `google.api.http` option).
+///
+/// https://github.com/googleapis/googleapis/blob/master/google/spanner/v1/spanner.proto
+const ROUTING_KEY: &str = "x-goog-request-params";
+
+/// gRPC metadata Leader Aware Routing header
+///
+/// Not well documented. Added to clients in early 2023 defaulting to disabled.
+/// Clients have began defaulting it to enabled in late 2023.
+///
+/// "Enabling leader aware routing would route all requests in RW/PDML
+/// transactions to the leader region." as described by other Spanner clients
+const LEADER_AWARE_KEY: &str = "x-goog-spanner-route-to-leader";
+
+/// Builds the [grpcio::Metadata] for all db operations
+#[derive(Default)]
+pub struct MetadataBuilder<'a> {
+    prefix: &'a str,
+    routing_params: Vec<(&'a str, &'a str)>,
+    route_to_leader: bool,
+}
+
+impl<'a> MetadataBuilder<'a> {
+    /// Initialize a new builder with a [PREFIX_KEY] header for the given
+    /// resource
+    pub fn with_prefix(prefix: &'a str) -> Self {
+        Self {
+            prefix,
+            ..Default::default()
+        }
+    }
+
+    /// Add a [ROUTING_KEY] header
+    pub fn routing_param(mut self, key: &'a str, value: &'a str) -> Self {
+        self.routing_params.push((key, value));
+        self
+    }
+
+    /// Toggle the [LEADER_AWARE_KEY] header
+    pub fn route_to_leader(mut self, route_to_leader: bool) -> Self {
+        self.route_to_leader = route_to_leader;
+        self
+    }
+
+    /// Build the [grpcio::Metadata]
+    pub fn build(self) -> Result<grpcio::Metadata, grpcio::Error> {
+        let mut meta = grpcio::MetadataBuilder::new();
+        meta.add_str(PREFIX_KEY, self.prefix)?;
+        meta.add_str(METRICS_KEY, "gcp-grpc-rs")?;
+        if self.route_to_leader {
+            meta.add_str(LEADER_AWARE_KEY, "true")?;
+        }
+        if !self.routing_params.is_empty() {
+            meta.add_str(ROUTING_KEY, &self.routing_header())?;
+        }
+        Ok(meta.build())
+    }
+
+    fn routing_header(self) -> String {
+        let mut ser = form_urlencoded::Serializer::new(String::new());
+        for (key, val) in self.routing_params {
+            ser.append_pair(key, val);
+        }
+        // python-spanner (python-api-core) doesn't encode '/':
+        // https://github.com/googleapis/python-api-core/blob/6251eab/google/api_core/gapic_v1/routing_header.py#L85
+        ser.finish().replace("%2F", "/")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::HashMap, str};
+
+    use super::{MetadataBuilder, LEADER_AWARE_KEY, METRICS_KEY, PREFIX_KEY, ROUTING_KEY};
+
+    pub const DB: &str = "/projects/sync/instances/test/databases/sync1";
+    pub const SESSION: &str = "/projects/sync/instances/test/databases/sync1/sessions/f00B4r_quuX";
+
+    #[test]
+    fn basic() {
+        let meta = MetadataBuilder::with_prefix(DB)
+            .routing_param("session", SESSION)
+            .routing_param("foo", "bar baz")
+            .build()
+            .unwrap();
+        let meta: HashMap<_, _> = meta.into_iter().collect();
+
+        assert_eq!(meta.len(), 3);
+        assert_eq!(str::from_utf8(meta.get(PREFIX_KEY).unwrap()).unwrap(), DB);
+        assert_eq!(
+            str::from_utf8(meta.get(METRICS_KEY).unwrap()).unwrap(),
+            "gcp-grpc-rs"
+        );
+        assert_eq!(
+            str::from_utf8(meta.get(ROUTING_KEY).unwrap()).unwrap(),
+            format!("session={SESSION}&foo=bar+baz")
+        );
+    }
+
+    #[test]
+    fn leader_aware() {
+        let meta = MetadataBuilder::with_prefix(DB)
+            .route_to_leader(true)
+            .build()
+            .unwrap();
+        let meta: HashMap<_, _> = meta.into_iter().collect();
+
+        assert_eq!(meta.len(), 3);
+        assert_eq!(
+            str::from_utf8(meta.get(LEADER_AWARE_KEY).unwrap()).unwrap(),
+            "true"
+        );
+    }
+}

--- a/syncstorage-spanner/src/metadata.rs
+++ b/syncstorage-spanner/src/metadata.rs
@@ -27,6 +27,9 @@ const ROUTING_KEY: &str = "x-goog-request-params";
 /// transactions to the leader region." as described by other Spanner clients
 const LEADER_AWARE_KEY: &str = "x-goog-spanner-route-to-leader";
 
+/// Our user agent value for [METRICS_KEY]
+const USER_AGENT: &str = "gcp-grpc-rs";
+
 /// Builds the [grpcio::Metadata] for all db operations
 #[derive(Default)]
 pub struct MetadataBuilder<'a> {
@@ -61,7 +64,7 @@ impl<'a> MetadataBuilder<'a> {
     pub fn build(self) -> Result<grpcio::Metadata, grpcio::Error> {
         let mut meta = grpcio::MetadataBuilder::new();
         meta.add_str(PREFIX_KEY, self.prefix)?;
-        meta.add_str(METRICS_KEY, "gcp-grpc-rs")?;
+        meta.add_str(METRICS_KEY, USER_AGENT)?;
         if self.route_to_leader {
             meta.add_str(LEADER_AWARE_KEY, "true")?;
         }
@@ -86,7 +89,9 @@ impl<'a> MetadataBuilder<'a> {
 mod tests {
     use std::{collections::HashMap, str};
 
-    use super::{MetadataBuilder, LEADER_AWARE_KEY, METRICS_KEY, PREFIX_KEY, ROUTING_KEY};
+    use super::{
+        MetadataBuilder, LEADER_AWARE_KEY, METRICS_KEY, PREFIX_KEY, ROUTING_KEY, USER_AGENT,
+    };
 
     pub const DB: &str = "/projects/sync/instances/test/databases/sync1";
     pub const SESSION: &str = "/projects/sync/instances/test/databases/sync1/sessions/f00B4r_quuX";
@@ -104,7 +109,7 @@ mod tests {
         assert_eq!(str::from_utf8(meta.get(PREFIX_KEY).unwrap()).unwrap(), DB);
         assert_eq!(
             str::from_utf8(meta.get(METRICS_KEY).unwrap()).unwrap(),
-            "gcp-grpc-rs"
+            USER_AGENT
         );
         assert_eq!(
             str::from_utf8(meta.get(ROUTING_KEY).unwrap()).unwrap(),

--- a/syncstorage-spanner/src/support.rs
+++ b/syncstorage-spanner/src/support.rs
@@ -18,7 +18,7 @@ use syncstorage_db_common::{
     params, results, util::to_rfc3339, util::SyncTimestamp, UserIdentifier, DEFAULT_BSO_TTL,
 };
 
-use super::{error::DbError, pool::Conn, DbResult};
+use crate::{error::DbError, pool::Conn, DbResult};
 
 pub trait IntoSpannerValue {
     const TYPE_CODE: TypeCode;
@@ -167,7 +167,7 @@ impl ExecuteSqlRequestBuilder {
     pub fn execute_async(self, conn: &Conn) -> DbResult<StreamedResultSetAsync> {
         let stream = conn
             .client
-            .execute_streaming_sql(&self.prepare_request(conn))?;
+            .execute_streaming_sql_opt(&self.prepare_request(conn), conn.session_opt()?)?;
         Ok(StreamedResultSetAsync::new(stream))
     }
 
@@ -175,7 +175,7 @@ impl ExecuteSqlRequestBuilder {
     pub async fn execute_dml_async(self, conn: &Conn) -> DbResult<i64> {
         let rs = conn
             .client
-            .execute_sql_async(&self.prepare_request(conn))?
+            .execute_sql_async_opt(&self.prepare_request(conn), conn.session_opt()?)?
             .await?;
         Ok(rs.get_stats().get_row_count_exact())
     }


### PR DESCRIPTION
## Description

and support the seemingly undocumented new leader aware routing header recently added to other spanner clients (via a setting, disabled by default)

## Issue(s)

SYNC-3922
Closes #1490
