### PR TITLE
fix: disable sentry's debug-images feature

### DIFF
--- a/syncserver/src/main.rs
+++ b/syncserver/src/main.rs
@@ -32,18 +32,24 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let settings = Settings::with_env_and_config_file(args.flag_config.as_deref())?;
     init_logging(!settings.human_logs).expect("Logging failed to initialize");
     debug!("Starting up...");
+
     // Set SENTRY_DSN environment variable to enable Sentry.
     // Avoid its default reqwest transport for now due to issues w/
     // likely grpcio's boringssl
     let curl_transport_factory = |options: &sentry::ClientOptions| {
         Arc::new(sentry::transports::CurlHttpTransport::new(options)) as Arc<dyn sentry::Transport>
     };
-    let _sentry = sentry::init(sentry::ClientOptions {
+    // debug-images conflicts w/ our debug = 1 rustc build option:
+    // https://github.com/getsentry/sentry-rust/issues/574
+    let mut opts = sentry::apply_defaults(sentry::ClientOptions {
         // Note: set "debug: true," to diagnose sentry issues
         transport: Some(Arc::new(curl_transport_factory)),
         release: sentry::release_name!(),
         ..sentry::ClientOptions::default()
     });
+    opts.integrations.retain(|i| i.name() != "debug-images");
+    opts.default_integrations = false;
+    let _sentry = sentry::init(opts);
 
     // Setup and run the server
     let banner = settings.banner();


### PR DESCRIPTION
which produced errors when sentry ingests events

https://github.com/getsentry/sentry-rust/issues/574

## Issue(s)

[SYNC-4023](https://mozilla-hub.atlassian.net/browse/SYNC-4023)


[SYNC-4023]: https://mozilla-hub.atlassian.net/browse/SYNC-4023?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ