### PR TITLE
bug: Use google specified UA for x-goog-api-client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -514,9 +514,9 @@ dependencies = [
 
 [[package]]
 name = "boringssl-src"
-version = "0.5.2+6195bf8"
+version = "0.6.0+e46383f"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ab565ccc5e276ea82a2013dd08bf2c999866b06daf1d4f30fee419c4aaec6d5"
+checksum = "5edec42197c014d84ea2396589f0da14b2257f63f319442b5e8475a077b90457"
 dependencies = [
  "cmake",
 ]
@@ -1302,9 +1302,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "google-cloud-rust-raw"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbabcfb0bcc5e3222191c3f0fba962b0cbf4242d2effe2a865090eee492ffc9c"
+checksum = "05cfec9367aefac6e90f42db5dee124b64fa5bcf84adf4236a861453373d851c"
 dependencies = [
  "futures 0.3.28",
  "grpcio",
@@ -1313,9 +1313,9 @@ dependencies = [
 
 [[package]]
 name = "grpcio"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "609832ca501baeb662dc81932fda9ed83f5d058f4b899a807ba222ce696f430a"
+checksum = "9e398946b5721d72478eb647260a1b7c1d5f70f0de35399846c3913bd369a33e"
 dependencies = [
  "futures-executor",
  "futures-util",
@@ -1328,9 +1328,9 @@ dependencies = [
 
 [[package]]
 name = "grpcio-sys"
-version = "0.12.1+1.46.5-patched"
+version = "0.13.0+1.56.2-patched"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf625d1803b6f44203f0428ddace847fb4994def5c803fc8a7a2f18fb3daec62"
+checksum = "b3dae9132320ae1b03ea55b5ddc88ca72a31fb85fa631a241a40157f5feffe43"
 dependencies = [
  "bindgen",
  "boringssl-src",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1302,9 +1302,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "google-cloud-rust-raw"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05cfec9367aefac6e90f42db5dee124b64fa5bcf84adf4236a861453373d851c"
+checksum = "864a48916c62ddbd1dc289be6d041d8ca61160c9c6169298e5cf3da11baf8370"
 dependencies = [
  "futures 0.3.28",
  "grpcio",

--- a/syncstorage-spanner/Cargo.toml
+++ b/syncstorage-spanner/Cargo.toml
@@ -17,8 +17,8 @@ async-trait = "0.1.40"
 # Pin to 0.5 for now, to keep it under tokio 0.2 (issue977).
 # Fix for #803 (deadpool#92) points to our fork for now
 #deadpool = "0.5"  # pin to 0.5
+google-cloud-rust-raw = { version = "0.16.1", features = ["spanner"] }
 deadpool = { git = "https://github.com/mozilla-services/deadpool", branch = "deadpool-v0.5.2-issue92" }
-google-cloud-rust-raw = "0.16.0"
 form_urlencoded = "1.2"
 # Some versions of OpenSSL 1.1.1 conflict with grpcio's built-in boringssl which can cause
 # syncserver to either fail to either compile, or start. In those cases, try

--- a/syncstorage-spanner/Cargo.toml
+++ b/syncstorage-spanner/Cargo.toml
@@ -18,12 +18,12 @@ async-trait = "0.1.40"
 # Fix for #803 (deadpool#92) points to our fork for now
 #deadpool = "0.5"  # pin to 0.5
 deadpool = { git = "https://github.com/mozilla-services/deadpool", branch = "deadpool-v0.5.2-issue92" }
-google-cloud-rust-raw = "0.15.0"
+google-cloud-rust-raw = "0.16.0"
 form_urlencoded = "1.2"
 # Some versions of OpenSSL 1.1.1 conflict with grpcio's built-in boringssl which can cause
 # syncserver to either fail to either compile, or start. In those cases, try
 # `cargo build --features grpcio/openssl ...`
-grpcio = { version = "0.12.1" }
+grpcio = { version = "0.13.0", features = ["openssl"] }
 log = { version = "0.4", features = [
   "max_level_debug",
   "release_max_level_info",

--- a/syncstorage-spanner/src/metadata.rs
+++ b/syncstorage-spanner/src/metadata.rs
@@ -28,7 +28,7 @@ const ROUTING_KEY: &str = "x-goog-request-params";
 const LEADER_AWARE_KEY: &str = "x-goog-spanner-route-to-leader";
 
 /// The USER_AGENT string is a static value specified by Google.
-/// It's meaning is not to be known to the uninitiated.
+/// Its meaning is not to be known to the uninitiated.
 const USER_AGENT: &str = "gl-external/1.0 gccl/1.0";
 
 /// Builds the [grpcio::Metadata] for all db operations

--- a/syncstorage-spanner/src/metadata.rs
+++ b/syncstorage-spanner/src/metadata.rs
@@ -70,7 +70,7 @@ impl<'a> MetadataBuilder<'a> {
         let ua = USER_AGENT.get_or_init(|| format!("gl-external/{VERSION} gccl/{VERSION}"));
 
         meta.add_str(PREFIX_KEY, self.prefix)?;
-        meta.add_str(METRICS_KEY, &ua)?;
+        meta.add_str(METRICS_KEY, ua)?;
         if self.route_to_leader {
             meta.add_str(LEADER_AWARE_KEY, "true")?;
         }

--- a/syncstorage-spanner/src/metadata.rs
+++ b/syncstorage-spanner/src/metadata.rs
@@ -113,7 +113,6 @@ mod tests {
         let ua = USER_AGENT
             .to_owned()
             .replace("{version}", env!("CARGO_PKG_VERSION"));
-        dbg!(&ua);
         assert_eq!(str::from_utf8(meta.get(METRICS_KEY).unwrap()).unwrap(), &ua);
         assert_eq!(
             str::from_utf8(meta.get(ROUTING_KEY).unwrap()).unwrap(),


### PR DESCRIPTION
## Description

Use suggested UA for GRPCIO header. This uses the syncserver crate version. We *may* want to use the version of `google-cloud-rust` instead?

Closes SYNC-4047