### PR TITLE
Upgrades rustc in CI and Docker to 1.75

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,7 +161,7 @@ commands:
 jobs:
   checks:
     docker:
-      - image: cimg/rust:1.72.0
+      - image: cimg/rust:1.75.0
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
@@ -178,7 +178,7 @@ jobs:
 
   build-and-test:
     docker:
-      - image: cimg/rust:1.72.0
+      - image: cimg/rust:1.75.0
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
@@ -214,7 +214,7 @@ jobs:
       #- save-sccache-cache
   build-mysql-image:
     docker:
-      - image: cimg/rust:1.60.0
+      - image: cimg/rust:1.75.0
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
@@ -245,7 +245,7 @@ jobs:
 
   build-spanner-image:
     docker:
-      - image: cimg/rust:1.60.0
+      - image: cimg/rust:1.75.0
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ commands:
           name: Setup Rust checks
           command: |
             rustup component add rustfmt
-            cargo install cargo-audit
+            cargo install --locked cargo-audit
             rustup component add clippy
   setup-python:
     steps:
@@ -140,7 +140,7 @@ commands:
       - run:
           name: Install sccache
           command: |
-            cargo install sccache
+            cargo install --locked sccache
             # This configures Rust to use sccache.
             echo 'export "RUSTC_WRAPPER"="sccache"' >> $BASH_ENV
             # This is the maximum space sccache cache will use on disk.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # NOTE: Ensure builder's Rust version matches CI's in .circleci/config.yml
-FROM docker.io/lukemathwalker/cargo-chef:0.1.62-rust-1.72-bullseye as chef
+FROM docker.io/lukemathwalker/cargo-chef:0.1.62-rust-1.75-bullseye as chef
 WORKDIR /app
 
 FROM chef AS planner

--- a/syncserver/src/server/test.rs
+++ b/syncserver/src/server/test.rs
@@ -145,7 +145,7 @@ fn create_request(
             "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:72.0) Gecko/20100101 Firefox/72.0",
         ));
     if let Some(body) = payload {
-        req = req.set_json(&body);
+        req = req.set_json(body);
     };
     if let Some(h) = headers {
         for (k, v) in h {

--- a/syncstorage-spanner/src/models.rs
+++ b/syncstorage-spanner/src/models.rs
@@ -1842,10 +1842,7 @@ impl SpannerDb {
             sqlparam_types.insert("payload".to_owned(), payload.spanner_type());
             sqlparams.insert("payload".to_string(), payload.into_spanner_value());
             let now_millis = timestamp.as_i64();
-            let ttl = bso.ttl.map_or(i64::from(DEFAULT_BSO_TTL), |ttl| {
-                ttl.try_into()
-                    .expect("Could not get ttl in put_bso_async_test")
-            }) * 1000;
+            let ttl = bso.ttl.map_or(i64::from(DEFAULT_BSO_TTL), |ttl| ttl.into()) * 1000;
             let expirystring = to_rfc3339(now_millis + ttl)?;
             debug!(
                 "!!!!! [test] INSERT expirystring:{:?}, timestamp:{:?}, ttl:{:?}",


### PR DESCRIPTION
## Description
Looks like our Rust version was still 1.72, which is OK, but it seems like cargo-audit now depends on clap 4.5, which itself required 1.74 (see https://app.circleci.com/pipelines/github/mozilla-services/syncstorage-rs/4909/workflows/427c8cef-e69e-46f3-947f-aa9dc61b3353/jobs/18546)

**I'm keeping it as a draft till we see the tests pass**

Also, It might not be a good idea to upgrade all the way to 1.76, especially since 1.76 just got released today, so I'm open to making this 1.75 (or 1.74)

I also fixed the clippy issues that came with the upgrade

