### PR TITLE
fix: don't emit a content-type header for 304s

### DIFF
--- a/syncserver/src/web/handlers.rs
+++ b/syncserver/src/web/handlers.rs
@@ -579,7 +579,7 @@ pub async fn lbheartbeat(req: HttpRequest) -> Result<HttpResponse, ApiError> {
         Some(s) => s,
         None => {
             error!("⚠️ Could not load the app state");
-            return Ok(HttpResponse::InternalServerError().body(""));
+            return Ok(HttpResponse::InternalServerError().finish());
         }
     };
 

--- a/syncserver/src/web/transaction.rs
+++ b/syncserver/src/web/transaction.rs
@@ -147,9 +147,8 @@ impl DbTransactionPool {
                     };
                     if status != StatusCode::OK {
                         return Ok(HttpResponse::build(status)
-                            .content_type("application/json")
                             .insert_header((X_LAST_MODIFIED, resource_ts.as_header()))
-                            .body("".to_owned()));
+                            .finish());
                     };
                 }
 


### PR DESCRIPTION
## Description

or bodyless 412s

and kill the old periodic reporter (moved to
server::spawn_metric_periodic_reporter)

## Issue(s)

Closes SYNC-4162
