### PR TITLE
chore(docs): add line break to do not display backticks

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,8 @@ This will walk you through the steps to connect this project to your local copy 
     sqluri = pymysql://sample_user:sample_password@127.0.0.1/syncstorage_rs
 
     [endpoints]
-    sync-1.5 = "http://localhost:8000/1.5/1"```
+    sync-1.5 = "http://localhost:8000/1.5/1"
+    ```
 
 3. In Firefox, go to `about:config`. Change `identity.sync.tokenserver.uri` to `http://localhost:5000/1.0/sync/1.5`.
 4. Restart Firefox. Now, try syncing. You should see new BSOs in your local MySQL instance.


### PR DESCRIPTION
## Description

Simple fix, to don't display backticks on GitHub.com

## Testing

Loko at the rendered file ;)

## Issue(s)

Closes [link](link).
