### PR TITLE
Release/0.15.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+<a name="0.14.5"></a>
+## 0.14.5 (2024-04-16)
+
+
+#### Bug Fixes
+
+*   Add try/except handler for force (#1535) ([b777fa0d](https://github.com/mozilla-services/syncstorage-rs/commit/b777fa0d967472ca34b023c606cfc5ef5309bf73))
+*   add line break to do not display backticks (#1529) ([143e93b6](https://github.com/mozilla-services/syncstorage-rs/commit/143e93b66f27e0d03509d17db8da53f9397fe73e))
+
+#### Chore
+
+*   bump mio per RUSTSEC-2024-0019 (#1530) ([b4306d93](https://github.com/mozilla-services/syncstorage-rs/commit/b4306d9379930ab6602a4efdb1278e4eb302b567))
+
+
+
 <a name="0.14.4"></a>
 ## 0.14.4 (2023-12-11)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2574,7 +2574,7 @@ checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "syncserver"
-version = "0.14.5"
+version = "0.15.2"
 dependencies = [
  "actix-cors",
  "actix-http",
@@ -2629,7 +2629,7 @@ dependencies = [
 
 [[package]]
 name = "syncserver-common"
-version = "0.14.5"
+version = "0.15.2"
 dependencies = [
  "actix-web",
  "cadence",
@@ -2644,7 +2644,7 @@ dependencies = [
 
 [[package]]
 name = "syncserver-db-common"
-version = "0.14.5"
+version = "0.15.2"
 dependencies = [
  "backtrace",
  "deadpool",
@@ -2658,7 +2658,7 @@ dependencies = [
 
 [[package]]
 name = "syncserver-settings"
-version = "0.14.5"
+version = "0.15.2"
 dependencies = [
  "config 0.11.0",
  "num_cpus",
@@ -2672,7 +2672,7 @@ dependencies = [
 
 [[package]]
 name = "syncstorage-db"
-version = "0.14.5"
+version = "0.15.2"
 dependencies = [
  "async-trait",
  "cadence",
@@ -2695,7 +2695,7 @@ dependencies = [
 
 [[package]]
 name = "syncstorage-db-common"
-version = "0.14.5"
+version = "0.15.2"
 dependencies = [
  "async-trait",
  "backtrace",
@@ -2714,7 +2714,7 @@ dependencies = [
 
 [[package]]
 name = "syncstorage-mysql"
-version = "0.14.5"
+version = "0.15.2"
 dependencies = [
  "async-trait",
  "backtrace",
@@ -2737,7 +2737,7 @@ dependencies = [
 
 [[package]]
 name = "syncstorage-settings"
-version = "0.14.5"
+version = "0.15.2"
 dependencies = [
  "rand",
  "serde 1.0.197",
@@ -2747,7 +2747,7 @@ dependencies = [
 
 [[package]]
 name = "syncstorage-spanner"
-version = "0.14.5"
+version = "0.15.2"
 dependencies = [
  "async-trait",
  "backtrace",
@@ -2912,7 +2912,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokenserver-auth"
-version = "0.14.5"
+version = "0.15.2"
 dependencies = [
  "async-trait",
  "base64",
@@ -2939,7 +2939,7 @@ dependencies = [
 
 [[package]]
 name = "tokenserver-common"
-version = "0.14.5"
+version = "0.15.2"
 dependencies = [
  "actix-web",
  "backtrace",
@@ -2952,7 +2952,7 @@ dependencies = [
 
 [[package]]
 name = "tokenserver-db"
-version = "0.14.5"
+version = "0.15.2"
 dependencies = [
  "async-trait",
  "backtrace",
@@ -2977,7 +2977,7 @@ dependencies = [
 
 [[package]]
 name = "tokenserver-settings"
-version = "0.14.5"
+version = "0.15.2"
 dependencies = [
  "jsonwebtoken",
  "serde 1.0.197",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2574,7 +2574,7 @@ checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "syncserver"
-version = "0.14.4"
+version = "0.14.5"
 dependencies = [
  "actix-cors",
  "actix-http",
@@ -2629,7 +2629,7 @@ dependencies = [
 
 [[package]]
 name = "syncserver-common"
-version = "0.14.4"
+version = "0.14.5"
 dependencies = [
  "actix-web",
  "cadence",
@@ -2644,7 +2644,7 @@ dependencies = [
 
 [[package]]
 name = "syncserver-db-common"
-version = "0.14.4"
+version = "0.14.5"
 dependencies = [
  "backtrace",
  "deadpool",
@@ -2658,7 +2658,7 @@ dependencies = [
 
 [[package]]
 name = "syncserver-settings"
-version = "0.14.4"
+version = "0.14.5"
 dependencies = [
  "config 0.11.0",
  "num_cpus",
@@ -2672,7 +2672,7 @@ dependencies = [
 
 [[package]]
 name = "syncstorage-db"
-version = "0.14.4"
+version = "0.14.5"
 dependencies = [
  "async-trait",
  "cadence",
@@ -2695,7 +2695,7 @@ dependencies = [
 
 [[package]]
 name = "syncstorage-db-common"
-version = "0.14.4"
+version = "0.14.5"
 dependencies = [
  "async-trait",
  "backtrace",
@@ -2714,7 +2714,7 @@ dependencies = [
 
 [[package]]
 name = "syncstorage-mysql"
-version = "0.14.4"
+version = "0.14.5"
 dependencies = [
  "async-trait",
  "backtrace",
@@ -2737,7 +2737,7 @@ dependencies = [
 
 [[package]]
 name = "syncstorage-settings"
-version = "0.14.4"
+version = "0.14.5"
 dependencies = [
  "rand",
  "serde 1.0.197",
@@ -2747,7 +2747,7 @@ dependencies = [
 
 [[package]]
 name = "syncstorage-spanner"
-version = "0.14.4"
+version = "0.14.5"
 dependencies = [
  "async-trait",
  "backtrace",
@@ -2912,7 +2912,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokenserver-auth"
-version = "0.14.4"
+version = "0.14.5"
 dependencies = [
  "async-trait",
  "base64",
@@ -2939,7 +2939,7 @@ dependencies = [
 
 [[package]]
 name = "tokenserver-common"
-version = "0.14.4"
+version = "0.14.5"
 dependencies = [
  "actix-web",
  "backtrace",
@@ -2952,7 +2952,7 @@ dependencies = [
 
 [[package]]
 name = "tokenserver-db"
-version = "0.14.4"
+version = "0.14.5"
 dependencies = [
  "async-trait",
  "backtrace",
@@ -2977,7 +2977,7 @@ dependencies = [
 
 [[package]]
 name = "tokenserver-settings"
-version = "0.14.4"
+version = "0.14.5"
 dependencies = [
  "jsonwebtoken",
  "serde 1.0.197",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 default-members = ["syncserver"]
 
 [workspace.package]
-version = "0.14.4"
+version = "0.14.5"
 authors = [
   "Ben Bangert <ben@groovie.org>",
   "Phil Jenvey <pjenvey@underboss.org>",
@@ -46,8 +46,15 @@ lazy_static = "1.4"
 protobuf = "=2.25.2" # pin to 2.25.2 to prevent side updating
 rand = "0.8"
 regex = "1.4"
-reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"]}
-sentry = { version = "0.31", default-features = false, features = ["curl", "backtrace", "contexts", "debug-images"] }
+reqwest = { version = "0.11", default-features = false, features = [
+  "rustls-tls",
+] }
+sentry = { version = "0.31", default-features = false, features = [
+  "curl",
+  "backtrace",
+  "contexts",
+  "debug-images",
+] }
 sentry-backtrace = "0.31"
 serde = "1.0"
 serde_derive = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 default-members = ["syncserver"]
 
 [workspace.package]
-version = "0.14.5"
+version = "0.15.2"
 authors = [
   "Ben Bangert <ben@groovie.org>",
   "Phil Jenvey <pjenvey@underboss.org>",


### PR DESCRIPTION

#### Bug Fixes

*   Add try/except handler for force (#1535) ([b777fa0d](https://github.com/mozilla-services/syncstorage-rs/commit/b777fa0d967472ca34b023c606cfc5ef5309bf73))
*   add line break to do not display backticks (#1529) ([143e93b6](https://github.com/mozilla-services/syncstorage-rs/commit/143e93b66f27e0d03509d17db8da53f9397fe73e))
*  Use correct version, since it's not been updated in Cargo.toml for a while.

#### Chore

*   bump mio per RUSTSEC-2024-0019 (#1530) ([b4306d93](https://github.com/mozilla-services/syncstorage-rs/commit/b4306d9379930ab6602a4efdb1278e4eb302b567))

