### PR TITLE
bug: Allow threadpool size to be set.

### DIFF
--- a/syncserver-db-common/Cargo.toml
+++ b/syncserver-db-common/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "syncserver-db-common"
-version.workspace=true
-license.workspace=true
-authors.workspace=true
-edition.workspace=true
+version.workspace = true
+license.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
-backtrace.workspace=true
-futures.workspace=true
-http.workspace=true
-thiserror.workspace=true
+backtrace.workspace = true
+futures.workspace = true
+http.workspace = true
+thiserror.workspace = true
 
 deadpool = { git = "https://github.com/mozilla-services/deadpool", tag = "deadpool-v0.7.0" }
 diesel = { version = "1.4", features = ["mysql", "r2d2"] }

--- a/syncserver-settings/src/lib.rs
+++ b/syncserver-settings/src/lib.rs
@@ -38,6 +38,8 @@ pub struct Settings {
     pub cors_allowed_methods: Option<Vec<String>>,
     pub cors_allowed_headers: Option<Vec<String>>,
 
+    pub actix_threadpool: Option<usize>,
+
     // TOOD: Eventually, the below settings will be enabled or disabled via Cargo features
     pub syncstorage: SyncstorageSettings,
     pub tokenserver: TokenserverSettings,
@@ -205,6 +207,7 @@ impl Default for Settings {
                 .collect(),
             ),
             cors_max_age: Some(1728000),
+            actix_threadpool: Some(512),
             syncstorage: SyncstorageSettings::default(),
             tokenserver: TokenserverSettings::default(),
         }

--- a/syncserver-settings/src/lib.rs
+++ b/syncserver-settings/src/lib.rs
@@ -38,7 +38,7 @@ pub struct Settings {
     pub cors_allowed_methods: Option<Vec<String>>,
     pub cors_allowed_headers: Option<Vec<String>>,
 
-    pub actix_threadpool: Option<usize>,
+    pub worker_max_blocking_threads: Option<usize>,
 
     // TOOD: Eventually, the below settings will be enabled or disabled via Cargo features
     pub syncstorage: SyncstorageSettings,
@@ -207,7 +207,7 @@ impl Default for Settings {
                 .collect(),
             ),
             cors_max_age: Some(1728000),
-            actix_threadpool: Some(512),
+            worker_max_blocking_threads: Some(512),
             syncstorage: SyncstorageSettings::default(),
             tokenserver: TokenserverSettings::default(),
         }

--- a/syncserver-settings/src/lib.rs
+++ b/syncserver-settings/src/lib.rs
@@ -1,8 +1,6 @@
 #[macro_use]
 extern crate slog_scope;
 
-use std::env::{self, VarError};
-
 use config::{Config, ConfigError, Environment, File};
 use serde::{Deserialize, Deserializer};
 use syncserver_common::{

--- a/syncserver-settings/src/lib.rs
+++ b/syncserver-settings/src/lib.rs
@@ -37,9 +37,8 @@ pub struct Settings {
     pub cors_allowed_headers: Option<Vec<String>>,
 
     /// The maximum number of blocking threads that can be used by the worker.
-    /// Note, we don't want "None" here because we use this as part of the
-    /// metric periodic reporter. The default value is 512. Setting the value to
-    /// `0` will
+    /// Note, we don't want "Option" here because we use this as part of the
+    /// metric periodic reporter. The default value is 512.
     pub worker_max_blocking_threads: usize,
 
     // TOOD: Eventually, the below settings will be enabled or disabled via Cargo features

--- a/syncserver/src/server/mod.rs
+++ b/syncserver/src/server/mod.rs
@@ -318,6 +318,12 @@ impl Server {
         }
 
         let server = server
+            .worker_max_blocking_threads(settings.actix_threadpool.unwrap_or_else(|| {
+                env::var("ACTIX_THREADPOOL")
+                    .unwrap_or("512".to_owned())
+                    .parse()
+                    .unwrap_or(512)
+            }))
             .bind(format!("{}:{}", host, port))
             .expect("Could not get Server in Server::with_settings")
             .run();
@@ -358,6 +364,12 @@ impl Server {
         });
 
         let server = server
+            .worker_max_blocking_threads(settings.actix_threadpool.unwrap_or_else(|| {
+                env::var("ACTIX_THREADPOOL")
+                    .unwrap_or("512".to_owned())
+                    .parse()
+                    .unwrap_or(512)
+            }))
             .bind(format!("{}:{}", host, port))
             .expect("Could not get Server in Server::with_settings")
             .run();

--- a/syncserver/src/server/mod.rs
+++ b/syncserver/src/server/mod.rs
@@ -1,6 +1,6 @@
 //! Main application server
 
-use std::{convert::Infallible, env, num::NonZeroUsize, sync::Arc, time::Duration};
+use std::{convert::Infallible, num::NonZeroUsize, sync::Arc, time::Duration};
 
 use actix_cors::Cors;
 use actix_web::{
@@ -261,7 +261,10 @@ impl Server {
             &Metrics::from(&metrics),
             blocking_threadpool.clone(),
         )?;
-        let worker_max_blocking_threads = calculate_worker_max_blocking_threads(&settings);
+        let worker_thread_count =
+            calculate_worker_max_blocking_threads(settings.worker_max_blocking_threads);
+        // This is used as part of the metric reporter, which is only run when tokenserver is not
+        let total_thread_count = settings.worker_max_blocking_threads;
         let limits = Arc::new(settings.syncstorage.limits);
         let limits_json =
             serde_json::to_string(&*limits).expect("ServerLimits failed to serialize");
@@ -289,6 +292,7 @@ impl Server {
                 metrics.clone(),
                 db_pool.clone(),
                 blocking_threadpool,
+                total_thread_count,
             )?;
 
             None
@@ -319,7 +323,7 @@ impl Server {
         }
 
         let server = server
-            .worker_max_blocking_threads(worker_max_blocking_threads)
+            .worker_max_blocking_threads(worker_thread_count)
             .bind(format!("{}:{}", host, port))
             .expect("Could not get Server in Server::with_settings")
             .run();
@@ -330,10 +334,18 @@ impl Server {
         settings: Settings,
     ) -> Result<dev::Server, ApiError> {
         let settings_copy = settings.clone();
+
         let host = settings.host.clone();
         let port = settings.port;
         let secrets = Arc::new(settings.master_secret.clone());
         let blocking_threadpool = Arc::new(BlockingThreadpool::default());
+        // Adjust the thread count to include FxA blocking threads.
+        let thread_count = settings.worker_max_blocking_threads
+            + settings
+                .tokenserver
+                .additional_blocking_threads_for_fxa_requests
+                .unwrap_or(0) as usize;
+        let worker_thread_count = calculate_worker_max_blocking_threads(thread_count);
         let tokenserver_state = tokenserver::ServerState::from_settings(
             &settings.tokenserver,
             syncserver_common::metrics_from_opts(
@@ -349,6 +361,7 @@ impl Server {
             tokenserver_state.metrics.clone(),
             tokenserver_state.db_pool.clone(),
             blocking_threadpool,
+            thread_count,
         )?;
 
         let server = HttpServer::new(move || {
@@ -360,7 +373,7 @@ impl Server {
         });
 
         let server = server
-            .worker_max_blocking_threads(calculate_worker_max_blocking_threads(&settings))
+            .worker_max_blocking_threads(worker_thread_count)
             .bind(format!("{}:{}", host, port))
             .expect("Could not get Server in Server::with_settings")
             .run();
@@ -368,17 +381,9 @@ impl Server {
     }
 }
 
-fn calculate_worker_max_blocking_threads(settings: &Settings) -> usize {
+fn calculate_worker_max_blocking_threads(count: usize) -> usize {
     let parallelism = std::thread::available_parallelism().map_or(2, NonZeroUsize::get);
-    std::cmp::max(
-        settings.worker_max_blocking_threads.unwrap_or_else(|| {
-            env::var("ACTIX_THREADPOOL")
-                .unwrap_or("512".to_owned())
-                .parse()
-                .unwrap_or(512)
-        }) / parallelism,
-        1,
-    )
+    std::cmp::max(count / parallelism, 1)
 }
 
 fn build_cors(settings: &Settings) -> Cors {
@@ -454,13 +459,12 @@ fn spawn_metric_periodic_reporter<T: GetPoolState + Send + 'static>(
     metrics: Arc<StatsdClient>,
     pool: T,
     blocking_threadpool: Arc<BlockingThreadpool>,
+    thread_count: usize,
 ) -> Result<(), DbError> {
     let hostname = hostname::get()
         .expect("Couldn't get hostname")
         .into_string()
         .expect("Couldn't get hostname");
-    let blocking_threadpool_size =
-        str::parse::<u64>(&env::var("ACTIX_THREADPOOL").unwrap()).unwrap();
     tokio::spawn(async move {
         loop {
             let PoolState {
@@ -480,7 +484,7 @@ fn spawn_metric_periodic_reporter<T: GetPoolState + Send + 'static>(
                 .send();
 
             let active_threads = blocking_threadpool.active_threads();
-            let idle_threads = blocking_threadpool_size - active_threads;
+            let idle_threads = thread_count as u64 - active_threads;
             metrics
                 .gauge_with_tags("blocking_threadpool.active", active_threads)
                 .with_tag("hostname", &hostname)

--- a/syncserver/src/web/auth.rs
+++ b/syncserver/src/web/auth.rs
@@ -206,6 +206,7 @@ fn verify_hmac(info: &[u8], key: &[u8], expected: &[u8]) -> ApiResult<()> {
 
 #[cfg(test)]
 mod tests {
+
     use super::{HawkPayload, Secrets};
 
     #[test]
@@ -532,9 +533,10 @@ mod tests {
         }
     }
 
-    impl ToString for HawkHeader {
-        fn to_string(&self) -> String {
-            format!(
+    impl std::fmt::Display for HawkHeader {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+            write!(
+                f,
                 "Hawk id=\"{}\", mac=\"{}\", nonce=\"{}\", ts=\"{}\"",
                 self.id, self.mac, self.nonce, self.ts
             )

--- a/syncserver/src/web/transaction.rs
+++ b/syncserver/src/web/transaction.rs
@@ -44,8 +44,8 @@ impl DbTransactionPool {
     /// transaction is rolled back. If the action succeeds, the transaction is
     /// NOT committed. Further processing is required before we are sure the
     /// action has succeeded (ex. check HTTP response for internal error).
-    async fn transaction_internal<'a, A: 'a, R, F>(
-        &'a self,
+    async fn transaction_internal<A, R, F>(
+        &self,
         request: HttpRequest,
         action: A,
     ) -> Result<(R, Box<dyn Db<Error = DbError>>), ApiError>
@@ -90,7 +90,7 @@ impl DbTransactionPool {
     }
 
     /// Perform an action inside of a DB transaction.
-    pub async fn transaction<'a, A: 'a, R, F>(
+    pub async fn transaction<'a, A, R, F>(
         &'a self,
         request: HttpRequest,
         action: A,
@@ -108,7 +108,7 @@ impl DbTransactionPool {
 
     /// Perform an action inside of a DB transaction. This method will rollback
     /// if the HTTP response is an error.
-    pub async fn transaction_http<'a, A: 'a, F>(
+    pub async fn transaction_http<'a, A, F>(
         &'a self,
         request: HttpRequest,
         action: A,

--- a/syncstorage-db-common/src/params.rs
+++ b/syncstorage-db-common/src/params.rs
@@ -61,10 +61,10 @@ pub struct Offset {
     pub offset: u64,
 }
 
-impl ToString for Offset {
-    fn to_string(&self) -> String {
+impl std::fmt::Display for Offset {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         // issue559: Disable ':' support for now.
-        self.offset.to_string()
+        write!(f, "{}", self.offset)
         /*
         match self.timestamp {
             None => self.offset.to_string(),

--- a/syncstorage-mysql/Cargo.toml
+++ b/syncstorage-mysql/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "syncstorage-mysql"
-version.workspace=true
-license.workspace=true
-authors.workspace=true
-edition.workspace=true
+version.workspace = true
+license.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
-backtrace.workspace=true
-base64.workspace=true
-futures.workspace=true
-http.workspace=true
-slog-scope.workspace=true
-thiserror.workspace=true
+backtrace.workspace = true
+base64.workspace = true
+futures.workspace = true
+http.workspace = true
+slog-scope.workspace = true
+thiserror.workspace = true
 
 async-trait = "0.1.40"
 diesel = { version = "1.4", features = ["mysql", "r2d2"] }
@@ -24,5 +24,5 @@ syncstorage-settings = { path = "../syncstorage-settings" }
 url = "2.1"
 
 [dev-dependencies]
-env_logger.workspace=true
+env_logger.workspace = true
 syncserver-settings = { path = "../syncserver-settings" }

--- a/syncstorage-mysql/src/diesel_ext.rs
+++ b/syncstorage-mysql/src/diesel_ext.rs
@@ -38,6 +38,8 @@ impl QueryFragment<Mysql> for LockInShareMode {
     }
 }
 
+// May be used for certain legacy MySQL versions
+#[allow(dead_code)]
 /// Emit 'ON DUPLICATE KEY UPDATE'
 pub trait IntoDuplicateValueClause {
     type ValueClause;
@@ -45,6 +47,7 @@ pub trait IntoDuplicateValueClause {
     fn into_value_clause(self) -> Self::ValueClause;
 }
 
+#[allow(dead_code)]
 pub trait OnDuplicateKeyUpdateDsl<T, U, Op, Ret> {
     fn on_duplicate_key_update<X>(self, expression: X) -> OnDuplicateKeyUpdate<T, U, Op, Ret, X>
     where

--- a/syncstorage-mysql/src/models.rs
+++ b/syncstorage-mysql/src/models.rs
@@ -167,8 +167,7 @@ impl MysqlDb {
             .session
             .borrow()
             .coll_locks
-            .get(&(user_id as u32, collection_id))
-            .is_some()
+            .contains_key(&(user_id as u32, collection_id))
         {
             return Ok(());
         }

--- a/syncstorage-spanner/src/manager/session.rs
+++ b/syncstorage-spanner/src/manager/session.rs
@@ -255,7 +255,7 @@ async fn create_session(
     settings: &SpannerSessionSettings,
 ) -> Result<Session, grpcio::Error> {
     let mut req = CreateSessionRequest::new();
-    req.database = settings.database.clone();
+    req.database.clone_from(&settings.database);
     let meta = settings
         .metadata_builder()
         .routing_param("database", &settings.database)

--- a/syncstorage-spanner/src/models.rs
+++ b/syncstorage-spanner/src/models.rs
@@ -222,8 +222,7 @@ impl SpannerDb {
             .session
             .borrow()
             .coll_locks
-            .get(&(params.user_id.clone(), collection_id))
-            .is_some()
+            .contains_key(&(params.user_id.clone(), collection_id))
         {
             return Ok(());
         }

--- a/syncstorage-spanner/src/support.rs
+++ b/syncstorage-spanner/src/support.rs
@@ -468,6 +468,9 @@ where
     }
 }
 
+// this is legacy, but may be used by the Stand Alone MySQL server. Allow it
+// as dead code for now.
+#[allow(dead_code)]
 pub trait MapAndThenTrait {
     /// Return an iterator adaptor that applies the provided closure to every
     /// DbResult::Ok value. DbResult::Err values are unchanged.
@@ -485,4 +488,5 @@ pub trait MapAndThenTrait {
     }
 }
 
+#[allow(dead_code)]
 impl<I, T, E> MapAndThenTrait for I where I: Sized + Iterator<Item = Result<T, E>> {}

--- a/tokenserver-auth/src/crypto.rs
+++ b/tokenserver-auth/src/crypto.rs
@@ -6,7 +6,7 @@ use serde::de::DeserializeOwned;
 use sha2::Sha256;
 use tokenserver_common::TokenserverError;
 pub const SHA256_OUTPUT_LEN: usize = 32;
-/// A triat representing all the required cryptographic operations by the token server
+/// A trait representing all the required cryptographic operations by the token server
 pub trait Crypto {
     type Error;
     /// HKDF key derivation
@@ -22,6 +22,7 @@ pub trait Crypto {
     /// Signs the `payload` using HMAC given the `key`
     fn hmac_sign(&self, key: &[u8], payload: &[u8]) -> Result<Vec<u8>, Self::Error>;
 
+    #[allow(dead_code)]
     /// Verify an HMAC signature on a payload given a shared key
     fn hmac_verify(&self, key: &[u8], payload: &[u8], signature: &[u8]) -> Result<(), Self::Error>;
 

--- a/tokenserver-auth/src/oauth/py.rs
+++ b/tokenserver-auth/src/oauth/py.rs
@@ -68,7 +68,7 @@ impl Verifier {
                         ("alg", &alg),
                         ("kid", kid),
                         ("use", "sig"),
-                        ("n", &n),
+                        ("n", n),
                         ("e", e),
                     ]
                     .into_py_dict(py);

--- a/tokenserver-settings/src/lib.rs
+++ b/tokenserver-settings/src/lib.rs
@@ -61,7 +61,8 @@ pub struct Settings {
     /// The database ID of the Spanner node.
     pub spanner_node_id: Option<i32>,
     /// The number of additional blocking threads to add to the blocking threadpool to handle
-    /// OAuth verification requests to FxA. This value is added to the `ACTIX_THREADPOOL` env var.
+    /// OAuth verification requests to FxA. This value is added to the worker_max_blocking_threads
+    /// config var.
     /// Note that this setting only applies if the OAuth public JWK is not cached, since OAuth
     /// verifications do not require requests to FXA if the JWK is set on Tokenserver. The server
     /// will return an error at startup if the JWK is not cached and this setting is `None`.


### PR DESCRIPTION
It appears that the replacement for setting ACTIX_THREADPOOL would be to call `ServiceBuilder.worker_max_blocking_threads()` This PR introduces the ability to set this value ~either~ by using the `worker_max_blocking_threads` configuration variable ~or `ACTIX_THREADPOOL` environment variable~.

Closes #SYNC-4271

