### PR TITLE
docs: Remove commented code, unneeded TODO, unneeded collision tracking

### DIFF
--- a/syncserver-common/src/lib.rs
+++ b/syncserver-common/src/lib.rs
@@ -85,7 +85,6 @@ pub trait ReportableError: std::fmt::Display {
     }
 
     /// Experimental: return key value pairs for Sentry Event's extra data
-    /// TODO: should probably return Vec<(&str, Value)> or Vec<(String, Value)>
     fn extras(&self) -> Vec<(&str, Value)> {
         vec![]
     }

--- a/syncserver/src/server/mod.rs
+++ b/syncserver/src/server/mod.rs
@@ -94,7 +94,6 @@ macro_rules! build_app {
             ))
             .wrap_fn(middleware::weave::set_weave_timestamp)
             .wrap_fn(tokenserver::logging::handle_request_log_line)
-            //.wrap_fn(middleware::sentry::report_error)
             .wrap_fn(middleware::rejectua::reject_user_agent)
             .wrap($cors)
             .wrap_fn(middleware::emit_http_status_with_tokenserver_origin)
@@ -203,7 +202,6 @@ macro_rules! build_app_without_syncstorage {
                 "api_error".to_owned(),
             ))
             // These are our wrappers
-            //.wrap_fn(middleware::sentry::report_error)
             .wrap_fn(tokenserver::logging::handle_request_log_line)
             .wrap_fn(middleware::rejectua::reject_user_agent)
             // Followed by the "official middleware" so they run first.

--- a/syncstorage-mysql/src/test.rs
+++ b/syncstorage-mysql/src/test.rs
@@ -53,12 +53,9 @@ fn static_collection_id() -> DbResult<()> {
     // The integration tests can create collections that start
     // with `xxx%`. We should not include those in our counts for local
     // unit tests.
-    // Note: not sure why but as of 11/02/20, `.not_like("xxx%")` is apparently
-    // swedish-ci. Commenting that out for now.
     let results: HashMap<i32, String> = collections::table
         .select((collections::id, collections::name))
         .filter(collections::name.ne(""))
-        //.filter(collections::name.not_like("xxx%")) // from most integration tests
         .filter(collections::name.ne("xxx_col2")) // from server::test
         .filter(collections::name.ne("col2")) // from older intergration tests
         .load(&db.inner.conn)?


### PR DESCRIPTION
removed commented out code from last PR, as well as spanner collision detection, since we haven't seen any in over 3 months.
