### PR TITLE
feat: debug "Invalid OAuth token" (verifier returns None) error cases

### DIFF
--- a/tokenserver-auth/src/oauth/verify.py
+++ b/tokenserver-auth/src/oauth/verify.py
@@ -16,4 +16,6 @@ class FxaOAuthClient:
             # Serialize the data to make it easier to parse in Rust
             return json.dumps(token_data)
         except (ClientError, TrustError):
-            return None
+            # XXX: debugging
+            #return None
+            raise


### PR DESCRIPTION
temporarily switch it to a "pyo3 error" so it's logged

Issue SYNC-4363

We're getting a lot of "Invalid OAuth token" errors in sentry on both stage and prod w/ 0.17.x -- I don't understand what's causing them so hopefully this helps show the underlying cause.

This should switch these errors from ["Invalid OAuth token"](https://github.com/mozilla-services/syncstorage-rs/blob/dc0d571c055741297a77dd47c70b7ef55b552530/tokenserver-auth/src/oauth/py.rs#L161) to ["pyo3 error"](https://github.com/mozilla-services/syncstorage-rs/blob/dc0d571c055741297a77dd47c70b7ef55b552530/tokenserver-auth/src/oauth/py.rs#L147), with an [accompanying Python traceback emitted to the logs](https://github.com/mozilla-services/syncstorage-rs/blob/dc0d571c055741297a77dd47c70b7ef55b552530/tokenserver-auth/src/oauth/py.rs#L136) that wasn't previously emitted for this error -- with it returning `None` the underlying error was ate/ignored.

The aim of this change is to gain more verbose logging of this issue on stage. I don't plan on rolling this change out to prod for now (hopefully the feedback from stage leads to a solution with an accompanying rollback of this change)