### PR TITLE
feat: track the pool's queued vs actually active tasks

### DIFF
--- a/syncserver-common/src/middleware/sentry.rs
+++ b/syncserver-common/src/middleware/sentry.rs
@@ -99,7 +99,7 @@ where
                             // add an info here, temporarily turn on info level debugging on a given server,
                             // capture it, and then turn it off before we run out of money.
                             if let Some(label) = reportable_err.metric_label() {
-                                info!("Sentry: Sending error to metrics: {:?}", reportable_err);
+                                debug!("Sentry: Sending error to metrics: {:?}", reportable_err);
                                 let _ = metrics.incr(&format!("{}.{}", metric_label, label));
                             }
                             debug!("Sentry: Not reporting error (service error): {:?}", error);
@@ -121,7 +121,7 @@ where
                 if let Some(reportable_err) = error.as_error::<E>() {
                     if !reportable_err.is_sentry_event() {
                         if let Some(label) = reportable_err.metric_label() {
-                            info!("Sentry: Sending error to metrics: {:?}", reportable_err);
+                            debug!("Sentry: Sending error to metrics: {:?}", reportable_err);
                             let _ = metrics.incr(&format!("{}.{}", metric_label, label));
                         }
                         debug!("Not reporting error (service error): {:?}", error);

--- a/syncserver/src/server/test.rs
+++ b/syncserver/src/server/test.rs
@@ -82,7 +82,9 @@ fn get_test_settings() -> Settings {
 
 async fn get_test_state(settings: &Settings) -> ServerState {
     let metrics = Arc::new(Metrics::sink());
-    let blocking_threadpool = Arc::new(BlockingThreadpool::default());
+    let blocking_threadpool = Arc::new(BlockingThreadpool::new(
+        settings.worker_max_blocking_threads,
+    ));
 
     ServerState {
         db_pool: Box::new(

--- a/syncstorage-db/src/tests/support.rs
+++ b/syncstorage-db/src/tests/support.rs
@@ -23,7 +23,7 @@ pub async fn db_pool(settings: Option<SyncstorageSettings>) -> Result<DbPoolImpl
     settings.database_use_test_transactions = use_test_transactions;
 
     let metrics = Metrics::noop();
-    let pool = DbPoolImpl::new(&settings, &metrics, Arc::new(BlockingThreadpool::default()))?;
+    let pool = DbPoolImpl::new(&settings, &metrics, Arc::new(BlockingThreadpool::new(512)))?;
     Ok(pool)
 }
 

--- a/syncstorage-mysql/src/test.rs
+++ b/syncstorage-mysql/src/test.rs
@@ -20,7 +20,7 @@ pub fn db(settings: &SyncstorageSettings) -> DbResult<MysqlDb> {
     let pool = MysqlDbPool::new(
         settings,
         &Metrics::noop(),
-        Arc::new(BlockingThreadpool::default()),
+        Arc::new(BlockingThreadpool::new(512)),
     )?;
     pool.get_sync()
 }

--- a/tokenserver-db/src/models.rs
+++ b/tokenserver-db/src/models.rs
@@ -2092,14 +2092,16 @@ mod tests {
     async fn db_pool() -> DbResult<TokenserverPool> {
         let _ = env_logger::try_init();
 
-        let mut settings = Settings::test_settings().tokenserver;
-        settings.run_migrations = true;
+        let mut settings = Settings::test_settings();
+        settings.tokenserver.run_migrations = true;
         let use_test_transactions = true;
 
         TokenserverPool::new(
-            &settings,
+            &settings.tokenserver,
             &Metrics::noop(),
-            Arc::new(BlockingThreadpool::default()),
+            Arc::new(BlockingThreadpool::new(
+                settings.worker_max_blocking_threads,
+            )),
             use_test_transactions,
         )
     }


### PR DESCRIPTION
and consider idle threads as a "max" value as the underlying tokio threadpool will exit threads idle for too long

Closes SYNC-4424