### PR TITLE
feat: create DAU glean schema and configs

### DIFF
--- a/glean/metrics.yaml
+++ b/glean/metrics.yaml
@@ -8,6 +8,83 @@ $schema: moz://mozilla.org/schemas/glean/metrics/2-0-0
 
 # Category
 syncstorage:
-  #Event
-  dau:
-    type: "event"
+  sync_event:
+    type: event
+    description: |
+      Event to record an instance of sync backend activity initiated by client.
+    notification_emails:
+      - jrconlin@mozilla.com
+      - pjenvey@mozilla.com
+      - tkorris@mozilla.com
+    bugs:
+      - https://github.com/mozilla-services/syncstorage-rs/issues
+    data_reviews:
+      # TODO
+    expires: never
+
+  sync_user_id:
+    type: uuid
+    # yamllint disable
+    description: >
+      Sync user identifier. Used to determine which user has initiated sync
+      activity. A single user could make numerous sync actions in a given time
+      and this id is required to ensure only a single count of daily active use
+      is made given a number of actions.
+    # yamllint enable
+    notification_emails:
+      - jrconlin@mozilla.com
+      - pjenvey@mozilla.com
+      - tkorris@mozilla.com
+    bugs:
+      - https://github.com/mozilla-services/syncstorage-rs/issues
+    data_reviews:
+      # TODO
+    expires: never
+
+  user_agent:
+    type: string
+    # yamllint disable
+    description: |
+      User Agent from which sync action was initiated.
+      Firefox Desktop, Fenix, or Firefox iOS.
+    # yamllint enable
+    notification_emails:
+      - jrconlin@mozilla.com
+      - pjenvey@mozilla.com
+      - tkorris@mozilla.com
+    bugs:
+      - https://github.com/mozilla-services/syncstorage-rs/issues
+    data_reviews:
+      # TODO
+    expires: never
+
+  timestamp:
+    type: datetime
+    description: |
+      Timestamp of sync activity.
+    notification_emails:
+      - jrconlin@mozilla.com
+      - pjenvey@mozilla.com
+      - tkorris@mozilla.com
+    bugs:
+      - https://github.com/mozilla-services/syncstorage-rs/issues
+    data_reviews:
+      # TODO
+    expires: never
+
+  collection:
+    type: string
+    # yamllint disable
+    description: |
+      Related individual collection where sync activity took place.
+      Includes bookmarks, history, forms, prefs, tabs, and passwords.
+    # yamllint enable
+    notification_emails:
+      - jrconlin@mozilla.com
+      - pjenvey@mozilla.com
+      - tkorris@mozilla.com
+    bugs:
+      - https://github.com/mozilla-services/syncstorage-rs/issues
+    data_reviews:
+      # TODO
+    expires: never

--- a/glean/metrics.yaml
+++ b/glean/metrics.yaml
@@ -1,0 +1,13 @@
+## This file describes the syncserver daily active user (DAU) metrics.
+## This defines the various allowed metrics that are to be captured.
+## Each metric is written as a JSON blob to the default logger output.
+
+---
+# Schema
+$schema: moz://mozilla.org/schemas/glean/metrics/2-0-0
+
+# Category
+syncstorage:
+  #Event
+  dau:
+    type: "event"

--- a/glean/metrics.yaml
+++ b/glean/metrics.yaml
@@ -41,27 +41,13 @@ syncstorage:
       # TODO
     expires: never
 
-  user_agent:
+  platform:
     type: string
     # yamllint disable
     description: |
-      User Agent from which sync action was initiated.
+      Pleatform from which sync action was initiated.
       Firefox Desktop, Fenix, or Firefox iOS.
     # yamllint enable
-    notification_emails:
-      - jrconlin@mozilla.com
-      - pjenvey@mozilla.com
-      - tkorris@mozilla.com
-    bugs:
-      - https://github.com/mozilla-services/syncstorage-rs/issues
-    data_reviews:
-      # TODO
-    expires: never
-
-  timestamp:
-    type: datetime
-    description: |
-      Timestamp of sync activity.
     notification_emails:
       - jrconlin@mozilla.com
       - pjenvey@mozilla.com

--- a/glean/metrics.yaml
+++ b/glean/metrics.yaml
@@ -19,7 +19,7 @@ syncstorage:
     bugs:
       - https://github.com/mozilla-services/syncstorage-rs/issues
     data_reviews:
-      # TODO
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1923967
     expires: never
 
   hashed_fxa_uid:
@@ -41,7 +41,7 @@ syncstorage:
     bugs:
       - https://github.com/mozilla-services/syncstorage-rs/issues
     data_reviews:
-      # TODO
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1923967
     expires: never
 
   platform:
@@ -58,7 +58,7 @@ syncstorage:
     bugs:
       - https://github.com/mozilla-services/syncstorage-rs/issues
     data_reviews:
-      # TODO
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1923967
     expires: never
 
   collection:
@@ -75,5 +75,5 @@ syncstorage:
     bugs:
       - https://github.com/mozilla-services/syncstorage-rs/issues
     data_reviews:
-      # TODO
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1923967
     expires: never

--- a/glean/metrics.yaml
+++ b/glean/metrics.yaml
@@ -66,7 +66,7 @@ syncstorage:
     # yamllint disable
     description: |
       Device family from which sync action was initiated.
-      Desktop PC, Tablet, Mobile.
+      Desktop PC, Tablet, Mobile, and Other.
     # yamllint enable
     notification_emails:
       - jrconlin@mozilla.com

--- a/glean/metrics.yaml
+++ b/glean/metrics.yaml
@@ -1,4 +1,4 @@
-## This file describes the syncserver daily active user (DAU) metrics.
+## This file describes the syncserver-rs daily active user (DAU) metrics.
 ## This defines the various allowed metrics that are to be captured.
 ## Each metric is written as a JSON blob to the default logger output.
 
@@ -22,14 +22,17 @@ syncstorage:
       # TODO
     expires: never
 
-  sync_user_id:
+  hashed_fxa_uid:
     type: uuid
     # yamllint disable
     description: >
-      Sync user identifier. Used to determine which user has initiated sync
-      activity. A single user could make numerous sync actions in a given time
+      User identifier. Uses `hashed_fxa_uid` for accurate count of sync actions.
+      Used to determine which user has initiated sync activity.
+      A single user could make numerous sync actions in a given time
       and this id is required to ensure only a single count of daily active use
-      is made given a number of actions.
+      is made, given a number of actions. Sync_id is not used due to possibility
+      of new keys being generated during resets or timeouts, whenever encryption
+      keys change.
     # yamllint enable
     notification_emails:
       - jrconlin@mozilla.com
@@ -45,7 +48,7 @@ syncstorage:
     type: string
     # yamllint disable
     description: |
-      Pleatform from which sync action was initiated.
+      Platform from which sync action was initiated.
       Firefox Desktop, Fenix, or Firefox iOS.
     # yamllint enable
     notification_emails:

--- a/glean/metrics.yaml
+++ b/glean/metrics.yaml
@@ -61,6 +61,23 @@ syncstorage:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1923967
     expires: never
 
+  device_family:
+    type: string
+    # yamllint disable
+    description: |
+      Device family from which sync action was initiated.
+      Desktop PC, Tablet, Mobile.
+    # yamllint enable
+    notification_emails:
+      - jrconlin@mozilla.com
+      - pjenvey@mozilla.com
+      - tkorris@mozilla.com
+    bugs:
+      - https://github.com/mozilla-services/syncstorage-rs/issues
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1923967
+    expires: never
+
   collection:
     type: string
     # yamllint disable

--- a/glean/pings.yaml
+++ b/glean/pings.yaml
@@ -1,4 +1,20 @@
 ## Describes the pings being sent out to Glean.
 
 # Schema
-$schema: moz://mozilla.org/schemas/glean/pings/1-0-0
+$schema: moz://mozilla.org/schemas/glean/pings/2-0-0
+
+# Name
+syncstorage:
+  # Ping parameters
+  description: |
+    Ping record for sync active use metrics.
+  notification_emails:
+    - jrconlin@mozilla.com
+    - pjenvey@mozilla.com
+    - tkorris@mozilla.com
+  bugs:
+    - https://github.com/mozilla-services/syncstorage-rs/issues
+  data_reviews:
+    # TODO
+  expires: never
+  include_client_id: false

--- a/glean/pings.yaml
+++ b/glean/pings.yaml
@@ -15,6 +15,6 @@ syncstorage:
   bugs:
     - https://github.com/mozilla-services/syncstorage-rs/issues
   data_reviews:
-    # TODO
+    - https://bugzilla.mozilla.org/show_bug.cgi?id=1923967
   expires: never
   include_client_id: false

--- a/glean/pings.yaml
+++ b/glean/pings.yaml
@@ -1,0 +1,4 @@
+## Describes the pings being sent out to Glean.
+
+# Schema
+$schema: moz://mozilla.org/schemas/glean/pings/1-0-0


### PR DESCRIPTION
## Description

Addition of the metrics.yaml and pings.yaml configurations for Glean metrics. This is to measure the Daily Active User metrics internally.

Noting the open questions doc we created with Glean team [here](https://docs.google.com/document/d/1WDnn49eD0lxdcSfZzaeQZsVaKQ2KqG7VhQrP8vZDdyE/edit#heading=h.i4wnylph1d9x).  We may approach this with the following modification:
- A single event metric with the extra_keys metadata section containing the other data (platform, sync id, collection, etc)
- We may exclude the timestamp as Glean has its own internal timestamp we can use

## Testing
N/A


## Issue(s)

Closes [SYNC-4415](https://mozilla-hub.atlassian.net/browse/SYNC-4415).


[SYNC-4415]: https://mozilla-hub.atlassian.net/browse/SYNC-4415?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ