### PR TITLE
feat: user agent parsing

### DIFF
--- a/syncserver/src/server/user_agent.rs
+++ b/syncserver/src/server/user_agent.rs
@@ -97,6 +97,15 @@ impl DeviceInfo {
     }
 }
 
+/// Parses user agents from headers and returns a DeviceInfo struct containing
+/// DeviceFamily, OsFamily, Platform, and Firefox Version.
+///
+/// Intended to handle standard user agent strings but also accomodates the non-standard,
+/// Firefox-specific user agents for iOS and desktop.
+///
+/// Parsing logic for non-standard iOS strings are in the form Firefox-iOS-FxA/24 and
+/// manually modifies WootheeResult to match with correct enums for iOS platform and OS.
+/// FxSync/<...>.desktop result still parses natively with Woothee and doesn't require intervention.
 pub fn get_device_info(user_agent: &str) -> DeviceInfo {
     let mut w_result: WootheeResult<'_> = Parser::new().parse(user_agent).unwrap_or_default();
 

--- a/syncserver/src/server/user_agent.rs
+++ b/syncserver/src/server/user_agent.rs
@@ -1,7 +1,6 @@
 use std::fmt;
 use std::str::FromStr;
 
-use validator::ValidateUrl;
 use woothee::parser::{Parser, WootheeResult};
 
 // List of valid user-agent attributes to keep, anything not in this
@@ -169,7 +168,7 @@ pub fn get_device_info(user_agent: &str) -> DeviceInfo {
     };
 
     let firefox_version =
-        u32::from_str(w_result.version.split(".").collect::<Vec<&str>>()[0]).unwrap_or_default();
+        u32::from_str(w_result.version.split('.').collect::<Vec<&str>>()[0]).unwrap_or_default();
 
     DeviceInfo {
         platform,
@@ -254,36 +253,48 @@ mod tests {
 
     #[test]
     fn test_windows_desktop() {
-        let desktop_user_agent = r#"Firefox/130.0.1 (Windows NT 10.0; Win64; x64) FxSync/1.132.0.20240913135723.desktop"#;
-        let device_info = get_device_info(desktop_user_agent);
+        let user_agent = r#"Firefox/130.0.1 (Windows NT 10.0; Win64; x64) FxSync/1.132.0.20240913135723.desktop"#;
+        let device_info = get_device_info(user_agent);
         assert_eq!(device_info.platform, Platform::FirefoxDesktop);
         assert_eq!(device_info.device_family, DeviceFamily::Desktop);
         assert_eq!(device_info.os_family, OsFamily::Windows);
         assert_eq!(device_info.firefox_version, 130);
     }
+
+    #[test]
     fn test_macos_desktop() {
-        let desktop_user_agent =
+        let user_agent =
             r#"Firefox/130.0.1 (Intel Mac OS X 10.15) FxSync/1.132.0.20240913135723.desktop"#;
-        let device_info = get_device_info(desktop_user_agent);
+        let device_info = get_device_info(user_agent);
         assert_eq!(device_info.platform, Platform::FirefoxDesktop);
         assert_eq!(device_info.device_family, DeviceFamily::Desktop);
         assert_eq!(device_info.os_family, OsFamily::MacOs);
-        assert_eq!(device_info.firefox_version, 132);
+        assert_eq!(device_info.firefox_version, 130);
     }
 
+    #[test]
     fn test_fenix() {
-        let fenix_user_agent =
-            r#"Mozilla/5.0 (Android 13; Mobile; rv:130.0) Gecko/130.0 Firefox/130.0"#;
-        let device_info = get_device_info(desktop_user_agent);
+        let user_agent = r#"Mozilla/5.0 (Android 13; Mobile; rv:130.0) Gecko/130.0 Firefox/130.0"#;
+        let device_info = get_device_info(user_agent);
         assert_eq!(device_info.platform, Platform::Fenix);
         assert_eq!(device_info.device_family, DeviceFamily::Mobile);
         assert_eq!(device_info.os_family, OsFamily::Android);
         assert_eq!(device_info.firefox_version, 130);
     }
 
+    #[test]
     fn test_firefox_ios() {
-        let fenix_user_agent = r#"Firefox-iOS-FxA/24"#;
-        let device_info = get_device_info(desktop_user_agent);
+        let user_agent = r#"Firefox-iOS-FxA/24"#;
+        let device_info = get_device_info(user_agent);
+        assert_eq!(device_info.platform, Platform::FirefoxIOS);
+        assert_eq!(device_info.device_family, DeviceFamily::Mobile);
+        assert_eq!(device_info.os_family, OsFamily::IOS);
+    }
+
+    #[test]
+    fn test_firefox_ios_alternate_user_agent() {
+        let user_agent = r#"Firefox-iOS-Sync/115.0b32242 (iPhone; iPhone OS 17.7) (Firefox)"#;
+        let device_info = get_device_info(user_agent);
         assert_eq!(device_info.platform, Platform::FirefoxIOS);
         assert_eq!(device_info.device_family, DeviceFamily::Mobile);
         assert_eq!(device_info.os_family, OsFamily::IOS);

--- a/syncserver/src/server/user_agent.rs
+++ b/syncserver/src/server/user_agent.rs
@@ -18,8 +18,8 @@ const VALID_UA_OS: &[&str] = &["Firefox OS", "Linux", "Mac OSX"];
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum DeviceFamily {
     Desktop,
-    Phone,
-    Tablet,
+    IOS,
+    Android,
     Other,
 }
 
@@ -69,24 +69,19 @@ impl DeviceInfo {
     pub fn is_mobile(&self) -> bool {
         matches!(
             &self.device_family,
-            DeviceFamily::Phone | DeviceFamily::Tablet
+            DeviceFamily::IOS | DeviceFamily::Android
         ) || matches!(&self.os_family, OsFamily::Android | OsFamily::IOS)
     }
 
     /// Determine if the device is iOS based on either the form factor or OS.
     pub fn is_ios(&self) -> bool {
-        matches!(
-            &self.device_family,
-            DeviceFamily::Phone | DeviceFamily::Tablet
-        ) || matches!(&self.os_family, OsFamily::Android | OsFamily::IOS)
+        matches!(&self.device_family, DeviceFamily::IOS) && matches!(&self.os_family, OsFamily::IOS)
     }
 
     /// Determine if the device is an android (Fenix) device based on either the form factor or OS.
     pub fn is_fenix(&self) -> bool {
-        matches!(
-            &self.device_family,
-            DeviceFamily::Phone | DeviceFamily::Tablet
-        ) || matches!(&self.os_family, OsFamily::Android)
+        matches!(&self.device_family, DeviceFamily::Android)
+            && matches!(&self.os_family, OsFamily::Android)
     }
 }
 
@@ -127,8 +122,8 @@ pub fn get_device_info(user_agent: &str) -> DeviceInfo {
     };
     let device_family = match w_result.category {
         "pc" => DeviceFamily::Desktop,
-        "smartphone" if os.as_str() == "ipad" => DeviceFamily::Tablet,
-        "smartphone" => DeviceFamily::Phone,
+        "smartphone" if os.as_str() == "ipad" => DeviceFamily::IOS,
+        "smartphone" if os.as_str() == "android" => DeviceFamily::Android,
         _ => DeviceFamily::Other,
     };
     DeviceInfo {

--- a/syncserver/src/server/user_agent.rs
+++ b/syncserver/src/server/user_agent.rs
@@ -1,3 +1,6 @@
+use std::fmt;
+use std::str::FromStr;
+
 use woothee::parser::{Parser, WootheeResult};
 
 // List of valid user-agent attributes to keep, anything not in this
@@ -10,6 +13,25 @@ const VALID_UA_BROWSER: &[&str] = &["Chrome", "Firefox", "Safari", "Opera"];
 // full list (WootheeResult's 'os' field may fall back to its 'name'
 // field). Windows has many values and we only care that its Windows
 const VALID_UA_OS: &[&str] = &["Firefox OS", "Linux", "Mac OSX"];
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum DeviceFamily {
+    Desktop,
+    Phone,
+    Tablet,
+    Other,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum OsFamily {
+    Windows,
+    MacOs,
+    Linux,
+    IOs,
+    Android,
+    ChromeOs,
+    Other,
+}
 
 pub fn parse_user_agent(agent: &str) -> (WootheeResult<'_>, &str, &str) {
     let parser = Parser::new();

--- a/syncserver/src/server/user_agent.rs
+++ b/syncserver/src/server/user_agent.rs
@@ -22,6 +22,13 @@ pub enum DeviceFamily {
     Other,
 }
 
+impl fmt::Display for DeviceFamily {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let name = format!("{:?}", self).to_lowercase();
+        write!(fmt, "{}", name)
+    }
+}
+
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum OsFamily {
     Windows,
@@ -31,6 +38,13 @@ pub enum OsFamily {
     Android,
     ChromeOs,
     Other,
+}
+
+impl fmt::Display for OsFamily {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let name = format!("{:?}", self).to_lowercase();
+        write!(fmt, "{}", name)
+    }
 }
 
 pub fn parse_user_agent(agent: &str) -> (WootheeResult<'_>, &str, &str) {

--- a/syncserver/src/server/user_agent.rs
+++ b/syncserver/src/server/user_agent.rs
@@ -157,8 +157,12 @@ pub fn get_device_info(user_agent: &str) -> DeviceInfo {
         DeviceFamily::Other => Platform::Other,
     };
 
-    let firefox_version =
-        u32::from_str(w_result.version.split('.').collect::<Vec<&str>>()[0]).unwrap_or_default();
+    let firefox_version = w_result
+        .version
+        .split('.')
+        .next()
+        .and_then(|v| v.parse::<u32>().ok())
+        .unwrap_or(0);
 
     DeviceInfo {
         platform,
@@ -279,6 +283,7 @@ mod tests {
         assert_eq!(device_info.platform, Platform::FirefoxIOS);
         assert_eq!(device_info.device_family, DeviceFamily::Mobile);
         assert_eq!(device_info.os_family, OsFamily::IOS);
+        assert_eq!(device_info.firefox_version, 0);
     }
 
     #[test]
@@ -288,5 +293,6 @@ mod tests {
         assert_eq!(device_info.platform, Platform::FirefoxIOS);
         assert_eq!(device_info.device_family, DeviceFamily::Mobile);
         assert_eq!(device_info.os_family, OsFamily::IOS);
+        assert_eq!(device_info.firefox_version, 0);
     }
 }

--- a/syncserver/src/server/user_agent.rs
+++ b/syncserver/src/server/user_agent.rs
@@ -13,11 +13,12 @@ const VALID_UA_BROWSER: &[&str] = &["Chrome", "Firefox", "Safari", "Opera"];
 // field). Windows has many values and we only care that its Windows
 const VALID_UA_OS: &[&str] = &["Firefox OS", "Linux", "Mac OSX"];
 
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub enum Platform {
     FirefoxDesktop,
     Fenix,
     FirefoxIOS,
+    #[default]
     Other,
 }
 
@@ -28,17 +29,12 @@ impl fmt::Display for Platform {
     }
 }
 
-impl Default for Platform {
-    fn default() -> Platform {
-        Platform::Other
-    }
-}
-
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub enum DeviceFamily {
     Desktop,
     Mobile,
     Tablet,
+    #[default]
     Other,
 }
 
@@ -49,19 +45,14 @@ impl fmt::Display for DeviceFamily {
     }
 }
 
-impl Default for DeviceFamily {
-    fn default() -> DeviceFamily {
-        DeviceFamily::Other
-    }
-}
-
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub enum OsFamily {
     Windows,
     MacOs,
     Linux,
     IOS,
     Android,
+    #[default]
     Other,
 }
 
@@ -69,12 +60,6 @@ impl fmt::Display for OsFamily {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = format!("{:?}", self).to_lowercase();
         write!(fmt, "{}", name)
-    }
-}
-
-impl Default for OsFamily {
-    fn default() -> OsFamily {
-        OsFamily::Other
     }
 }
 

--- a/syncserver/src/server/user_agent.rs
+++ b/syncserver/src/server/user_agent.rs
@@ -237,12 +237,41 @@ mod tests {
     }
 
     #[test]
-    fn test_desktop() {
+    fn test_windows_desktop() {
         let desktop_user_agent = r#"Firefox/130.0.1 (Windows NT 10.0; Win64; x64) FxSync/1.132.0.20240913135723.desktop"#;
         let device_info = get_device_info(desktop_user_agent);
         assert_eq!(device_info.platform, Platform::FirefoxDesktop);
         assert_eq!(device_info.device_family, DeviceFamily::Desktop);
         assert_eq!(device_info.os_family, OsFamily::Windows);
+        assert_eq!(device_info.firefox_version, 130);
+    }
+    fn test_macos_desktop() {
+        let desktop_user_agent =
+            r#"Firefox/130.0.1 (Intel Mac OS X 10.15) FxSync/1.132.0.20240913135723.desktop"#;
+        let device_info = get_device_info(desktop_user_agent);
+        assert_eq!(device_info.platform, Platform::FirefoxDesktop);
+        assert_eq!(device_info.device_family, DeviceFamily::Desktop);
+        assert_eq!(device_info.os_family, OsFamily::MacOs);
+        assert_eq!(device_info.firefox_version, 132);
+    }
+
+    fn test_fenix() {
+        let fenix_user_agent =
+            r#"Mozilla/5.0 (Android 13; Mobile; rv:130.0) Gecko/130.0 Firefox/130.0"#;
+        let device_info = get_device_info(desktop_user_agent);
+        assert_eq!(device_info.platform, Platform::Fenix);
+        assert_eq!(device_info.device_family, DeviceFamily::Mobile);
+        assert_eq!(device_info.os_family, OsFamily::Android);
+        assert_eq!(device_info.firefox_version, 130);
+    }
+
+    fn test_firefox_ios() {
+        let fenix_user_agent =
+            r#"Mozilla/5.0 (Android 13; Mobile; rv:130.0) Gecko/130.0 Firefox/130.0"#;
+        let device_info = get_device_info(desktop_user_agent);
+        assert_eq!(device_info.platform, Platform::Fenix);
+        assert_eq!(device_info.device_family, DeviceFamily::Mobile);
+        assert_eq!(device_info.os_family, OsFamily::IOS);
         assert_eq!(device_info.firefox_version, 130);
     }
 }

--- a/syncserver/src/server/user_agent.rs
+++ b/syncserver/src/server/user_agent.rs
@@ -116,10 +116,6 @@ impl DeviceInfo {
 pub fn get_device_info(user_agent: &str) -> DeviceInfo {
     let mut w_result: WootheeResult<'_> = Parser::new().parse(user_agent).unwrap_or_default();
 
-    // Check if the user agent is not Firefox and return empty.
-    if !["firefox"].contains(&w_result.name.to_lowercase().as_str()) {
-        return DeviceInfo::default();
-    }
     // Current Firefox-iOS logic outputs the `user_agent` in the following formats:
     // Firefox-iOS-Sync/108.1b24234 (iPad; iPhone OS 16.4.1) (Firefox)
     // OR
@@ -143,6 +139,11 @@ pub fn get_device_info(user_agent: &str) -> DeviceInfo {
         w_result.name = "firefox";
         w_result.category = "smartphone";
         w_result.os = "ipad";
+    }
+
+    // Check if the user agent is not Firefox and return empty.
+    if !["firefox"].contains(&w_result.name.to_lowercase().as_str()) {
+        return DeviceInfo::default();
     }
 
     let os = w_result.os.to_lowercase();

--- a/syncserver/src/server/user_agent.rs
+++ b/syncserver/src/server/user_agent.rs
@@ -47,6 +47,13 @@ impl fmt::Display for OsFamily {
     }
 }
 
+#[derive(Debug, Eq, PartialEq)]
+pub struct DeviceInfo {
+    pub device_family: DeviceFamily,
+    pub os_family: OsFamily,
+    pub firefox_version: u32,
+}
+
 pub fn parse_user_agent(agent: &str) -> (WootheeResult<'_>, &str, &str) {
     let parser = Parser::new();
     let wresult = parser.parse(agent).unwrap_or_else(|| WootheeResult {

--- a/syncserver/src/server/user_agent.rs
+++ b/syncserver/src/server/user_agent.rs
@@ -99,17 +99,7 @@ impl DeviceInfo {
 }
 
 pub fn get_device_info(user_agent: &str) -> DeviceInfo {
-    let mut w_result = Parser::new()
-        .parse(user_agent)
-        .unwrap_or_else(|| WootheeResult {
-            name: "",
-            category: "",
-            os: "",
-            os_version: "".into(),
-            browser_type: "",
-            version: "",
-            vendor: "",
-        });
+    let mut w_result: WootheeResult<'_> = Parser::new().parse(user_agent).unwrap_or_default();
 
     // Current Firefox-iOS logic outputs the `user_agent` in the following formats:
     // Firefox-iOS-Sync/108.1b24234 (iPad; iPhone OS 16.4.1) (Firefox)

--- a/syncserver/src/server/user_agent.rs
+++ b/syncserver/src/server/user_agent.rs
@@ -294,4 +294,14 @@ mod tests {
         assert_eq!(device_info.os_family, OsFamily::IOS);
         assert_eq!(device_info.firefox_version, 0);
     }
+
+    #[test]
+    fn test_platform_other() {
+        let user_agent = r#"Mozilla/5.0 (Linux; Android 9; SM-A920F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4216.0 Mobile Safari/537.36"#;
+        let device_info = get_device_info(user_agent);
+        assert_eq!(device_info.platform, Platform::Other);
+        assert_eq!(device_info.device_family, DeviceFamily::Mobile);
+        assert_eq!(device_info.os_family, OsFamily::Android);
+        assert_eq!(device_info.firefox_version, 86);
+    }
 }

--- a/syncserver/src/server/user_agent.rs
+++ b/syncserver/src/server/user_agent.rs
@@ -1,5 +1,4 @@
 use std::fmt;
-use std::str::FromStr;
 
 use woothee::parser::{Parser, WootheeResult};
 

--- a/syncserver/src/server/user_agent.rs
+++ b/syncserver/src/server/user_agent.rs
@@ -1,7 +1,6 @@
 use std::fmt;
 use std::str::FromStr;
 
-use actix_http::header::ACCESS_CONTROL_REQUEST_HEADERS;
 use woothee::parser::{Parser, WootheeResult};
 
 // List of valid user-agent attributes to keep, anything not in this
@@ -86,16 +85,17 @@ impl DeviceInfo {
 }
 
 pub fn get_device_info(user_agent: &str) -> DeviceInfo {
-    let parser = Parser::new();
-    let mut w_result = parser.parse(user_agent).unwrap_or_else(|| WootheeResult {
-        name: "",
-        category: "",
-        os: "",
-        os_version: "".into(),
-        browser_type: "",
-        version: "",
-        vendor: "",
-    });
+    let mut w_result = Parser::new()
+        .parse(user_agent)
+        .unwrap_or_else(|| WootheeResult {
+            name: "",
+            category: "",
+            os: "",
+            os_version: "".into(),
+            browser_type: "",
+            version: "",
+            vendor: "",
+        });
 
     // NOTE: Firefox on iPads report back the Safari "desktop" UA
     // (e.g. `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/605.1.15

--- a/syncserver/src/server/user_agent.rs
+++ b/syncserver/src/server/user_agent.rs
@@ -34,7 +34,7 @@ pub enum OsFamily {
     Windows,
     MacOs,
     Linux,
-    IOs,
+    IOS,
     Android,
     ChromeOs,
     Other,
@@ -52,6 +52,23 @@ pub struct DeviceInfo {
     pub device_family: DeviceFamily,
     pub os_family: OsFamily,
     pub firefox_version: u32,
+}
+
+impl DeviceInfo {
+    pub fn is_desktop(&self) -> bool {
+        matches!(&self.device_family, DeviceFamily::Desktop)
+            || matches!(
+                &self.os_family,
+                OsFamily::MacOs | OsFamily::Windows | OsFamily::Linux
+            )
+    }
+
+    pub fn is_mobile(&self) -> bool {
+        matches!(
+            &self.device_family,
+            DeviceFamily::Phone | DeviceFamily::Tablet
+        ) || matches!(&self.os_family, OsFamily::Android | OsFamily::IOS)
+    }
 }
 
 pub fn parse_user_agent(agent: &str) -> (WootheeResult<'_>, &str, &str) {

--- a/syncserver/src/server/user_agent.rs
+++ b/syncserver/src/server/user_agent.rs
@@ -15,10 +15,25 @@ const VALID_UA_BROWSER: &[&str] = &["Chrome", "Firefox", "Safari", "Opera"];
 const VALID_UA_OS: &[&str] = &["Firefox OS", "Linux", "Mac OSX"];
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum Platform {
+    FirefoxDesktop,
+    Fenix,
+    FirefoxIOS,
+    Other,
+}
+
+impl fmt::Display for Platform {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let name = format!("{:?}", self).to_lowercase();
+        write!(fmt, "{}", name)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum DeviceFamily {
     Desktop,
-    IOS,
-    Android,
+    Mobile,
+    Tablet,
     Other,
 }
 
@@ -36,7 +51,6 @@ pub enum OsFamily {
     Linux,
     IOS,
     Android,
-    ChromeOs,
     Other,
 }
 
@@ -49,6 +63,7 @@ impl fmt::Display for OsFamily {
 
 #[derive(Debug, Eq, PartialEq)]
 pub struct DeviceInfo {
+    pub platform: Platform,
     pub device_family: DeviceFamily,
     pub os_family: OsFamily,
     pub firefox_version: u32,
@@ -66,20 +81,19 @@ impl DeviceInfo {
 
     /// Determine if the device is a mobile phone based on either the form factor or OS.
     pub fn is_mobile(&self) -> bool {
-        matches!(
-            &self.device_family,
-            DeviceFamily::IOS | DeviceFamily::Android
-        ) || matches!(&self.os_family, OsFamily::Android | OsFamily::IOS)
+        matches!(&self.device_family, DeviceFamily::Mobile)
+            && matches!(&self.os_family, OsFamily::Android | OsFamily::IOS)
     }
 
     /// Determine if the device is iOS based on either the form factor or OS.
     pub fn is_ios(&self) -> bool {
-        matches!(&self.device_family, DeviceFamily::IOS) && matches!(&self.os_family, OsFamily::IOS)
+        matches!(&self.device_family, DeviceFamily::Mobile)
+            && matches!(&self.os_family, OsFamily::IOS)
     }
 
     /// Determine if the device is an android (Fenix) device based on either the form factor or OS.
     pub fn is_fenix(&self) -> bool {
-        matches!(&self.device_family, DeviceFamily::Android)
+        matches!(&self.device_family, DeviceFamily::Mobile)
             && matches!(&self.os_family, OsFamily::Android)
     }
 }
@@ -96,6 +110,8 @@ pub fn get_device_info(user_agent: &str) -> DeviceInfo {
             version: "",
             vendor: "",
         });
+    let firefox_version =
+        u32::from_str(w_result.version.split(".").collect::<Vec<&str>>()[0]).unwrap_or_default();
 
     // NOTE: Firefox on iPads report back the Safari "desktop" UA
     // (e.g. `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/605.1.15
@@ -108,25 +124,39 @@ pub fn get_device_info(user_agent: &str) -> DeviceInfo {
         w_result.os = "ipad";
     }
 
-    let firefox_version =
-        u32::from_str(w_result.version.split(".").collect::<Vec<&str>>()[0]).unwrap_or_default();
     let os = w_result.os.to_lowercase();
     let os_family = match os.as_str() {
         _ if os.starts_with("windows") => OsFamily::Windows,
         "mac osx" => OsFamily::MacOs,
         "linux" => OsFamily::Linux,
-        "iphone" => OsFamily::IOS,
+        "iphone" | "ipad" => OsFamily::IOS,
         "android" => OsFamily::Android,
-        "chromeos" => OsFamily::ChromeOs,
         _ => OsFamily::Other,
     };
+
     let device_family = match w_result.category {
         "pc" => DeviceFamily::Desktop,
-        "smartphone" if os.as_str() == "ipad" => DeviceFamily::IOS,
-        "smartphone" if os.as_str() == "android" => DeviceFamily::Android,
+        "smartphone" if os.as_str() == "ipad" => DeviceFamily::Tablet,
+        "smartphone" => DeviceFamily::Mobile,
         _ => DeviceFamily::Other,
     };
+
+    let platform = match device_family {
+        DeviceFamily::Desktop => Platform::FirefoxDesktop,
+        DeviceFamily::Mobile => match os_family {
+            OsFamily::IOS => Platform::FirefoxIOS,
+            OsFamily::Android => Platform::Fenix,
+            _ => Platform::Other,
+        },
+        DeviceFamily::Tablet => match os_family {
+            OsFamily::IOS => Platform::FirefoxIOS,
+            _ => Platform::Other,
+        },
+        DeviceFamily::Other => Platform::Other,
+    };
+
     DeviceInfo {
+        platform,
         device_family,
         os_family,
         firefox_version,
@@ -163,7 +193,9 @@ pub fn parse_user_agent(agent: &str) -> (WootheeResult<'_>, &str, &str) {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_user_agent;
+    use crate::server::user_agent::{DeviceFamily, OsFamily, Platform};
+
+    use super::{get_device_info, parse_user_agent};
 
     #[test]
     fn test_linux() {
@@ -202,5 +234,15 @@ mod tests {
         assert_eq!(ua_result.os, "BlackBerry");
         assert_eq!(metrics_browser, "Other");
         assert_eq!(ua_result.name, "UNKNOWN");
+    }
+
+    #[test]
+    fn test_desktop() {
+        let desktop_user_agent = r#"Firefox/130.0.1 (Windows NT 10.0; Win64; x64) FxSync/1.132.0.20240913135723.desktop"#;
+        let device_info = get_device_info(desktop_user_agent);
+        assert_eq!(device_info.platform, Platform::FirefoxDesktop);
+        assert_eq!(device_info.device_family, DeviceFamily::Desktop);
+        assert_eq!(device_info.os_family, OsFamily::Windows);
+        assert_eq!(device_info.firefox_version, 130);
     }
 }


### PR DESCRIPTION
## Description

Addition of User Agent parsing, consisting of:
Platform (Firefox Desktop, Firefox iOS, Fenix, Other)
Device family (Desktop, Mobile, Tablet, Other)
 OS family (Mac, Windows, Linux, iOS, Android, other)

Note: User agent emission from iOS clients is non-standard. Two observed variants occur:
`Firefox-iOS-FxA/24` or `Firefox-iOS-Sync/115.0b32242 (iPhone; iPhone OS 17.7) (Firefox)`
See the shared spreadsheet in [SYNC-4413](https://mozilla-hub.atlassian.net/browse/SYNC-4413) for details.

As a result of Woothee being unable to parse this non-standard user agent, custom logic was added to fill in the gaps to so that the association logic can work to fill out all the matching enum values.

Subsequent PR will pull this into metarequest and apply the parsing.

## Testing
Added unit tests within `user_agent` to verify new user_agent strings.


## Issue(s)

Closes [SYNC-4414](https://mozilla-hub.atlassian.net/browse/SYNC-4414).


[SYNC-4414]: https://mozilla-hub.atlassian.net/browse/SYNC-4414?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[SYNC-4413]: https://mozilla-hub.atlassian.net/browse/SYNC-4413?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ