### PR TITLE
docs: sync server side metrics adr

### DIFF
--- a/docs/adr/0001-daily-active-use-server-side-metrics-glean.md
+++ b/docs/adr/0001-daily-active-use-server-side-metrics-glean.md
@@ -17,7 +17,6 @@ The goal is to measure DAU (and subsequently WAU & MAU) by emitting metrics from
 * User identifier (hashed_fxa_uid)
 * Timestamp
 * Platform (from UserAgent: Desktop, Fenix, iOS)
-* Collection updated
  
 In researching possible implementation methods, it became clear that many options did not offer us the ease and flexibility to reconcile the data after emission. This is why Glean is recommended as a clear frontrunner. This is not without some drawbacks, but they are minimal compared to other options that would, for example, require considerable data processing and querying difficulties. There is support for this implementation from the Glean team and active support in the process.
 

--- a/docs/adr/0001-daily-active-use-server-side-metrics-glean.md
+++ b/docs/adr/0001-daily-active-use-server-side-metrics-glean.md
@@ -1,0 +1,102 @@
+# Measuring Server-Side Daily Active Use (DAU) With Glean
+
+* Status: proposed
+* Deciders: Taddes Korris, David Durst, JR Conlin, Phillip Jenvey
+* Date: 2024-10-09
+
+Technical Story: 
+[Jira Epic Url](https://mozilla-hub.atlassian.net/browse/SYNC-4389)
+
+
+## Context and Problem Statement
+
+There is a requiement to move away from measuring Sync Daily Active Use (DAU) via FxA.
+The implementation of Relay and additional authentication paths means the metric will no
+longer be accurate. Furthermore, there is a broad movement towards measuring DAU within the service itself. 
+
+The goal is to measure DAU (and subsequently WAU & MAU) by emitting metrics from syncserver-rs itself. This involves 
+
+
+
+## Decision Drivers <!-- optional -->
+
+1. [primary driver, e.g., a force, facing concern, …]
+2. Glean is an internal tool successfully used by many teams at Mozilla.
+3. The Glean team has extensive experience and can provide considerable support in establishing application metrics.
+
+## Considered Options
+
+* A. Glean for server-side measurement of DAU
+* B. StatsD and Grafana
+* C. Sql/Redash
+
+
+## Decision Outcome
+
+Chosen option:
+
+* A. "Glean for server-side measurement of DAU"
+
+[justification. e.g., only option, which meets primary decision driver | which resolves a force or facing concern | … | comes out best (see below)].
+
+### Positive Consequences <!-- optional -->
+
+* [e.g., improvement of quality attribute satisfaction, follow-up decisions required, …]
+* …
+
+### Negative Consequences <!-- optional -->
+
+* [e.g., compromising quality attribute, follow-up decisions required, …]
+* …
+
+## Pros and Cons of the Options <!-- optional -->
+
+### [option A]
+
+[example | description | pointer to more information | …] <!-- optional -->
+
+#### Pros
+
+* [argument for]
+* [argument for]
+* … <!-- numbers of pros can vary -->
+
+#### Cons
+
+* [argument against]
+* … <!-- numbers of cons can vary -->
+
+### [option B]
+
+[example | description | pointer to more information | …] <!-- optional -->
+
+#### Pros
+
+* [argument for]
+* [argument for]
+* … <!-- numbers of pros can vary -->
+
+#### Cons
+
+* [argument against]
+* … <!-- numbers of cons can vary -->
+
+### [option C]
+
+[example | description | pointer to more information | …] <!-- optional -->
+
+#### Pros
+
+* [argument for]
+* [argument for]
+* … <!-- numbers of pros can vary -->
+
+#### Cons
+
+* [argument against]
+* … <!-- numbers of cons can vary -->
+
+## Links 
+
+* [Discussion Document](https://docs.google.com/document/d/1Tk4VIuQZcn8IG-UI38kziZn5e-FMOI0Z-VrvaYTI1SM/edit#heading=h.b0mqx1fng4wa)
+* [FxA DAU Metric in Redash](https://sql.telemetry.mozilla.org/queries/101007/source?p_end%20date=2024-06-26&p_start%20date=2024-05-01#248905)

--- a/docs/adr/0001-daily-active-use-server-side-metrics-glean.md
+++ b/docs/adr/0001-daily-active-use-server-side-metrics-glean.md
@@ -1,6 +1,6 @@
 # Measuring Server-Side Daily Active Use (DAU) With Glean
 
-* Status: proposed
+* Status: approved
 * Deciders: Taddes Korris, David Durst, JR Conlin, Phillip Jenvey
 * Date: 2024-10-09
 
@@ -10,16 +10,15 @@ Technical Story:
 
 ## Context and Problem Statement
 
-There is a requirement to move away from the current measurement of Sync Daily Active Use (DAU), which measures usage via FxA/Mozilla Accounts.
-The addition of Relay, device backups/migrations, through FxA means the metric will no longer an be accurate reflection of Sync usage. This is due to increased browser sign-ins with the potential of overcounting, or not counting those logging into the browser without Sync enabled. Furthermore, there is a broader organizational movement towards measuring DAU within services themselves. 
+There is an organizational requirement for each service to be able to measure its own DAU (Daily Active Users). Sync historically measured DAU via FxA through browser login. With the addition of Relay, device backups/migrations, etc. this will no longer an be accurate reflection of Sync usage, nor a direct measurement originating within Sync. This is due to increased browser sign-ins with the potential of overcounting, or not counting those logging into the browser without Sync enabled. See [Decision Brief - Server-Side Sync Usage Attribution from Mozilla Accounts](https://docs.google.com/document/d/1zD-ia3fP43o-dYpwavDgH5Hb6Xo_fgQzzoWqTiX_wR8/edit?tab=t.0#heading=h.mdoaoiyvqgfo).
 
-The goal is to measure DAU (and subsequently WAU & MAU) by emitting metrics from syncserver-rs itself. This requires the following data:
+The goal is to measure DAU (and subsequently WAU & MAU) by emitting metrics from syncstorage-rs itself. This requires the following data:
 * User identifier (hashed_fxa_uid)
 * Timestamp
-* Platform (from UserAgent: Desktop, Fenix, iOS)
+* Platform (Desktop, Fenix, iOS, Other)
+* Device Family (Desktop, Mobioe, Tablet, Other)
+* Device ID (hashed_device_id) for opt-out/deletion
  
-In researching possible implementation methods, it became clear that many options did not offer us the ease and flexibility to reconcile the data after emission. This is why Glean is recommended as a clear frontrunner. This is not without some drawbacks, but they are minimal compared to other options that would, for example, require considerable data processing and querying difficulties. There is support for this implementation from the Glean team and active support in the process.
-
 ## Decision Drivers
 
 1. Simplicity of implementation, not only for internal metric emission, but for processing and querying.
@@ -30,31 +29,38 @@ In researching possible implementation methods, it became clear that many option
 
 ## Considered Options
 
-* A. Glean
-* B. StatsD and Grafana
-* C. Sql/Redash
+* A. Glean Parser for Rust - Contribute to glean team repo by implementing Rust server
+* B. Custom Glean Implementation - Our own custom implementation, internal only to Sync
+* C. StatsD and Grafana
 
 ## Decision Outcome
 
 Chosen option:
 
-* A. "Glean for server-side measurement of DAU"
+* A. "Glean Parser for Rust: for server-side measurement of DAU"
 
-The use of Glean appears the best choice for measuring internal DAU metrics.  It meets our requirements and provides us with needed support on the data processing side. It also provides considerable support from the Glean team to implement this in a thoughtful manner.  There are some challenges with this implementation (more below), namely in this being a greenfield attempt at Rust server-side metrics, however the pros outweigh the cons. Other metrics implementations like StatsD and Grafana cannot be easily used to measure and aggregate this data. Additionally, it adds considerable overhead in determining how to query the data and reconcile ping emissions of Sync events. Having dedicated organizational support means we establish best practices.
+In researching possible implementation methods, it became clear that many options did not offer us the ease and flexibility to reconcile the data after emission. This is why Glean is recommended as a clear frontrunner, due to its rich tooling in aggregating, querying, and visualizing data.
+
+However, this left an addition decision to either implement our own custom Glean code to emit "Glean-compliant" output, or to contribute to the Glean team's `glean_parser` repository for server-side metrics. The `glean_parser` is used for all server implementations of Glean, since the SDK is only available for client-side applications. Currently, Rust is not supported.
+
+The Glean team does/did not have capacity to implemented the Rust `glean_parser` feature, so we had to decide what is the best solution not only for this use case, but to consider possible future use cases. In consultation with the Glean team, it became clear avoiding our custom implementation and opting for the general-purpose `glean_parser` for Rust was the ideal solution.
 
 ## Pros and Cons of the Options
 
-### A. Glean
+### A. Glean Parser for Rust
 
-Glean is a widely used tool at Mozilla and provides us with a solution to the given issue and possible extensibility in the future. Not without some challenges in initial implementation, but the potential for positive impact is high.
+Glean is a widely used tool at Mozilla and provides us with a solution to the given issue and possible extensibility in the future. Not without some challenges in initial implementation, related to coordination with Glean team and upfront development effort. However, the potential for positive impact within our team and the organization is significant: all Rust server applications will be able to use Glean with full server support, our possible intention to integrate Glean into Push is made easier, and this is done in partnership with the Glean team.
 
 #### Pros
 
-* Satisfaction of requirement to measure internal DAU metrics.
+* Makes Glean compatible for all Rust server applications going forward.
+* Preferred option of the Glean team.
+* Glean team believes, based on FxA metrics volume, that our volume will not be a problem (180-190K per minute).
+* A collection of metrics, emitted as a single "Ping Event" make querying of related data simpler.
 * Core of Glean's purpose is to measure user interactions and the rich metadata that accompanies it.
-* Capacity for future expansion of application metrics within Sync beyond DAU.
+* Capacity for future expansion of application metrics within Sync, beyond DAU.
 * Prepares for implementation of same measurements in autopush, also using Glean.
-* Easier to query.
+* Easier to query, have data team support to set up queries.
 * Use of standardized Mozilla tooling.
 * Establishment of team knowledge of using Glean.
 * Establishment of server-side Rust best practices, leading to easier development for backend Rust applications.
@@ -64,18 +70,36 @@ Glean is a widely used tool at Mozilla and provides us with a solution to the gi
 
 * The `glean_parser` tool used by other Glean applications is currently not supported for Rust. Furthermore, client applications can use the Glean SDK and this is also not an option for us.
 * Server side metrics have not yet been implemented for a Rust server application of this kind, so this is new territory.
-* There is added complexity of data review process and registration of the application to Glean's probe scraper.
-* Potential delays and challenges in new implementation.
+* There is added complexity of data review process and registration of the application to Glean's probe scraper, PubSub topics, ingestion pipeline etc.
+* May require more uptfront development effort to get up to speed with new code and process.
+* Some concerns exist around volume of data emitted from the service and if it is feasible, but we won't know until we try.
 
-### StatsD and Grafana
+### B. Custom Glean Implementation 
 
-StatsD and Grafana offer us core application metrics and service health. While we use this frequently, it doesn't neatly fit the measurement requirements we have for DAU and would likely be very difficult to process via queries.
+This was originally appearing to be the desired approach to measuring DAU via Glean.  This was predicated on the ease of prototyping a custom implementation that imitated the Glean team's logic to create "Glean-compliant" output that could be configured to be ingested.  However, in consulting with the Glean team and evaluating the pros and cons of this approach, it became clear this approach had considerably more drawbacks than implementing the `glean_parser` for Rust. These drawbacks were a lack of testing, validation, less support from the Glean team, and the potential problems with maintenance and adding Glean metrics in the future.
+
+#### Pros
+* Gives team control over implementation and allows us to customize the Glean logging as we see fit.
+* Does not require contribution to Glean team's repos, which potentially limits the scope understanding a new codebase.
+* Easy to prototype and make changes.
+* Doesn't require understanding the templating logic and libraries in the `glean_parser`
+
+#### Cons
+* There is no built-in testing suite or validation, so this would put a larger development burden on us and require the Glean team's review.
+* Lack of testing and validation means higher likelihood of bugs.
+* If we decide to add new Glean metrics in the future, this may break the custom implementation and impose a greater maintenance overhead.
+* Time required to understand the Glean team's implementations anyways, in order to replicate behavior and data structures.
+* Likely won't have same support from Glean team as it is not related to their implementation.
+
+### C. StatsD, Grafana, InfluxDB
+
+StatsD and Grafana offer us core application metrics and service health. While we use this frequently, it doesn't neatly fit the measurement requirements we have for DAU and would likely be very difficult to process via queries. This is because such application metrics are geared towards increment counters, response codes, and timers. Given DAU is a user-initiated interaction, and we need to query unique events based on the `hashed_fxa_id`, this is not suitable for InfluxDB/StatsD. Figuring out how to query this data poses challenges as it has not been implemented for such a use case. 
 
 #### Pros
 
+* Already utilized for core service metrics (status codes, API endpoint counts, cluster health, etc).
 * Well understood and used.
-* Support for SRE for more complex queries.
-* Already utilized for core metrics.
+* Possible for SRE for more complex queries.
 
 #### Cons
 
@@ -83,29 +107,13 @@ StatsD and Grafana offer us core application metrics and service health. While w
 * Somewhat opaque and complicated query logic required.
 * Significant difficulty in aggregation and reconciliation logic. 
 * May not scale well given number of events.
-* Likely considerable overhead in understanding how to make sense of data.
-* Heavier load for team to manage data processing.
+* Likely a considerable overhead in understanding how to make sense of data.
+* Heavier load for team to manage data processing, as this approach has not been tried.
 
-### SQL/Redash
-
-The current DAU metric used from FxA uses SQL telemetry and provides the ability to query data.  It is then displayed in a redash panel. While convenient, we do not have the infrastructure in place for this option and it might involve considerable effort to establish.
-
-#### Pros
-
-* Used and understood within services already.
-* Simple interface.
-
-#### Cons
-
-* Implemented strictly for accounts at present.
-* Lack of clarity on how to aggregate and process data after emitted.
-* Infrastructure does not exist to emit the metrics to.
-* Likely considerable overhead in understanding how to make sense of data.
-* Heavier load for team to manage data processing.
 
 ## Links 
 
-* [Decision Brief - Server-Side Sync Usage Attribution from Mozilla Accounts](https://docs.google.com/document/d/1zD-ia3fP43o-dYpwavDgH5Hb6Xo_fgQzzoWqTiX_wR8/edit)
+* [Decision Brief - Server-Side Sync Usage Attribution from Mozilla Accounts](https://docs.google.com/document/d/1zD-ia3fP43o-dYpwavDgH5Hb6Xo_fgQzzoWqTiX_wR8/edit?tab=t.0#heading=h.mdoaoiyvqgfo)
 * [FxA DAU Metric in Redash](https://sql.telemetry.mozilla.org/queries/101007/source?p_end%20date=2024-06-26&p_start%20date=2024-05-01#248905)
 * [Working Document](https://docs.google.com/document/d/1Tk4VIuQZcn8IG-UI38kziZn5e-FMOI0Z-VrvaYTI1SM/edit#heading=h.b0mqx1fng4wa)
 * [Sync Ecosystem Infrastructure and Metrics: KPI Metrics](https://mozilla-hub.atlassian.net/wiki/spaces/CLOUDSERVICES/pages/969834589/Establish+KPI+metrics+DAU+Retention)

--- a/docs/adr/0001-daily-active-use-server-side-metrics-glean.md
+++ b/docs/adr/0001-daily-active-use-server-side-metrics-glean.md
@@ -10,8 +10,8 @@ Technical Story:
 
 ## Context and Problem Statement
 
-There is a requirement to move away from the current measurement of Sync Daily Active Use (DAU), which measures usage via FxA.
-The addition of Relay and additional authentication paths through FxA means the metric will no longer an be accurate reflection of Sync usage. Furthermore, there is a broader organizational movement towards measuring DAU within services themselves. 
+There is a requirement to move away from the current measurement of Sync Daily Active Use (DAU), which measures usage via FxA/Mozilla Accounts.
+The addition of Relay, device backups/migrations, through FxA means the metric will no longer an be accurate reflection of Sync usage. This is due to increased browser sign-ins with the potential of overcounting, or not counting those logging into the browser without Sync enabled. Furthermore, there is a broader organizational movement towards measuring DAU within services themselves. 
 
 The goal is to measure DAU (and subsequently WAU & MAU) by emitting metrics from syncserver-rs itself. This requires the following data:
 * User identifier (hashed_fxa_uid)
@@ -24,13 +24,14 @@ In researching possible implementation methods, it became clear that many option
 ## Decision Drivers
 
 1. Simplicity of implementation, not only for internal metric emission, but for processing and querying.
-2. Glean is an internal tool successfully used by many teams at Mozilla.
-3. The Glean team has extensive experience and can provide considerable support in establishing application metrics.
-4. Extensibility: ability to expand scope of metrics to other measurements and apply methodology to other services in Sync ecosystem.
+2. Reduction of complexity and load on team to process and make sense of data. Ideally there is existing infrastructure to reduce the possible significant work to calculate DAU.
+3. Glean is an internal tool successfully used by many teams at Mozilla.
+4. The Glean team has extensive experience and can provide considerable support in establishing application metrics.
+5. Extensibility: ability to expand scope of metrics to other measurements and apply methodology to other services in Sync ecosystem.
 
 ## Considered Options
 
-* A. Glean for server-side measurement of DAU
+* A. Glean
 * B. StatsD and Grafana
 * C. Sql/Redash
 
@@ -42,72 +43,72 @@ Chosen option:
 
 The use of Glean appears the best choice for measuring internal DAU metrics.  It meets our requirements and provides us with needed support on the data processing side. It also provides considerable support from the Glean team to implement this in a thoughtful manner.  There are some challenges with this implementation (more below), namely in this being a greenfield attempt at Rust server-side metrics, however the pros outweigh the cons. Other metrics implementations like StatsD and Grafana cannot be easily used to measure and aggregate this data. Additionally, it adds considerable overhead in determining how to query the data and reconcile ping emissions of Sync events. Having dedicated organizational support means we establish best practices.
 
-### Positive Consequences
+## Pros and Cons of the Options
+
+### A. Glean
+
+Glean is a widely used tool at Mozilla and provides us with a solution to the given issue and possible extensibility in the future. Not without some challenges in initial implementation, but the potential for positive impact is high.
+
+#### Pros
 
 * Satisfaction of requirement to measure internal DAU metrics.
+* Core of Glean's purpose is to measure user interactions and the rich metadata that accompanies it.
 * Capacity for future expansion of application metrics within Sync beyond DAU.
 * Prepares for implementation of same measurements in autopush, also using Glean.
+* Easier to query.
 * Use of standardized Mozilla tooling.
 * Establishment of team knowledge of using Glean.
 * Establishment of server-side Rust best practices, leading to easier development for backend Rust applications.
 * Transparency in data review process with consideration made to minimum collection of data.
 
-### Negative Consequences
+#### Cons
 
 * The `glean_parser` tool used by other Glean applications is currently not supported for Rust. Furthermore, client applications can use the Glean SDK and this is also not an option for us.
 * Server side metrics have not yet been implemented for a Rust server application of this kind, so this is new territory.
 * There is added complexity of data review process and registration of the application to Glean's probe scraper.
 * Potential delays and challenges in new implementation.
 
-## Pros and Cons of the Options
+### StatsD and Grafana
 
-### [option A]
-
-[example | description | pointer to more information | …] <!-- optional -->
+StatsD and Grafana offer us core application metrics and service health. While we use this frequently, it doesn't neatly fit the measurement requirements we have for DAU and would likely be very difficult to process via queries.
 
 #### Pros
 
-* [argument for]
-* [argument for]
-* … <!-- numbers of pros can vary -->
+* Well understood and used.
+* Support for SRE for more complex queries.
+* Already utilized for core metrics.
 
 #### Cons
 
-* [argument against]
-* … <!-- numbers of cons can vary -->
+* StatsD is not a good format for measuring something like user interactions.
+* Somewhat opaque and complicated query logic required.
+* Significant difficulty in aggregation and reconciliation logic. 
+* May not scale well given number of events.
+* Likely considerable overhead in understanding how to make sense of data.
+* Heavier load for team to manage data processing.
 
-### [option B]
+### SQL/Redash
 
-[example | description | pointer to more information | …] <!-- optional -->
+The current DAU metric used from FxA uses SQL telemetry and provides the ability to query data.  It is then displayed in a redash panel. While convenient, we do not have the infrastructure in place for this option and it might involve considerable effort to establish.
 
 #### Pros
 
-* [argument for]
-* [argument for]
-* … <!-- numbers of pros can vary -->
+* Used and understood within services already.
+* Simple interface.
 
 #### Cons
 
-* [argument against]
-* … <!-- numbers of cons can vary -->
-
-### [option C]
-
-[example | description | pointer to more information | …] <!-- optional -->
-
-#### Pros
-
-* [argument for]
-* [argument for]
-* … <!-- numbers of pros can vary -->
-
-#### Cons
-
-* [argument against]
-* … <!-- numbers of cons can vary -->
+* Implemented strictly for accounts at present.
+* Lack of clarity on how to aggregate and process data after emitted.
+* Infrastructure does not exist to emit the metrics to.
+* Likely considerable overhead in understanding how to make sense of data.
+* Heavier load for team to manage data processing.
 
 ## Links 
 
-* [Discussion Document](https://docs.google.com/document/d/1Tk4VIuQZcn8IG-UI38kziZn5e-FMOI0Z-VrvaYTI1SM/edit#heading=h.b0mqx1fng4wa)
+* [Decision Brief - Server-Side Sync Usage Attribution from Mozilla Accounts](https://docs.google.com/document/d/1zD-ia3fP43o-dYpwavDgH5Hb6Xo_fgQzzoWqTiX_wR8/edit)
 * [FxA DAU Metric in Redash](https://sql.telemetry.mozilla.org/queries/101007/source?p_end%20date=2024-06-26&p_start%20date=2024-05-01#248905)
+* [Working Document](https://docs.google.com/document/d/1Tk4VIuQZcn8IG-UI38kziZn5e-FMOI0Z-VrvaYTI1SM/edit#heading=h.b0mqx1fng4wa)
 * [Sync Ecosystem Infrastructure and Metrics: KPI Metrics](https://mozilla-hub.atlassian.net/wiki/spaces/CLOUDSERVICES/pages/969834589/Establish+KPI+metrics+DAU+Retention)
+* [Integrating Glean](https://mozilla.github.io/glean/book/user/adding-glean-to-your-project/rust.html)
+* [Glean Metrics](https://mozilla.github.io/glean/book/reference/metrics/index.html)

--- a/docs/adr/0001-daily-active-use-server-side-metrics-glean.md
+++ b/docs/adr/0001-daily-active-use-server-side-metrics-glean.md
@@ -10,19 +10,23 @@ Technical Story:
 
 ## Context and Problem Statement
 
-There is a requiement to move away from measuring Sync Daily Active Use (DAU) via FxA.
-The implementation of Relay and additional authentication paths means the metric will no
-longer be accurate. Furthermore, there is a broad movement towards measuring DAU within the service itself. 
+There is a requirement to move away from the current measurement of Sync Daily Active Use (DAU), which measures usage via FxA.
+The addition of Relay and additional authentication paths through FxA means the metric will no longer an be accurate reflection of Sync usage. Furthermore, there is a broader organizational movement towards measuring DAU within services themselves. 
 
-The goal is to measure DAU (and subsequently WAU & MAU) by emitting metrics from syncserver-rs itself. This involves 
+The goal is to measure DAU (and subsequently WAU & MAU) by emitting metrics from syncserver-rs itself. This requires the following data:
+* User identifier (hashed_fxa_uid)
+* Timestamp
+* Platform (from UserAgent: Desktop, Fenix, iOS)
+* Collection updated
+ 
+In researching possible implementation methods, it became clear that many options did not offer us the ease and flexibility to reconcile the data after emission. This is why Glean is recommended as a clear frontrunner. This is not without some drawbacks, but they are minimal compared to other options that would, for example, require considerable data processing and querying difficulties. There is support for this implementation from the Glean team and active support in the process.
 
+## Decision Drivers
 
-
-## Decision Drivers <!-- optional -->
-
-1. [primary driver, e.g., a force, facing concern, …]
+1. Simplicity of implementation, not only for internal metric emission, but for processing and querying.
 2. Glean is an internal tool successfully used by many teams at Mozilla.
 3. The Glean team has extensive experience and can provide considerable support in establishing application metrics.
+4. Extensibility: ability to expand scope of metrics to other measurements and apply methodology to other services in Sync ecosystem.
 
 ## Considered Options
 
@@ -30,26 +34,32 @@ The goal is to measure DAU (and subsequently WAU & MAU) by emitting metrics from
 * B. StatsD and Grafana
 * C. Sql/Redash
 
-
 ## Decision Outcome
 
 Chosen option:
 
 * A. "Glean for server-side measurement of DAU"
 
-[justification. e.g., only option, which meets primary decision driver | which resolves a force or facing concern | … | comes out best (see below)].
+The use of Glean appears the best choice for measuring internal DAU metrics.  It meets our requirements and provides us with needed support on the data processing side. It also provides considerable support from the Glean team to implement this in a thoughtful manner.  There are some challenges with this implementation (more below), namely in this being a greenfield attempt at Rust server-side metrics, however the pros outweigh the cons. Other metrics implementations like StatsD and Grafana cannot be easily used to measure and aggregate this data. Additionally, it adds considerable overhead in determining how to query the data and reconcile ping emissions of Sync events. Having dedicated organizational support means we establish best practices.
 
-### Positive Consequences <!-- optional -->
+### Positive Consequences
 
-* [e.g., improvement of quality attribute satisfaction, follow-up decisions required, …]
-* …
+* Satisfaction of requirement to measure internal DAU metrics.
+* Capacity for future expansion of application metrics within Sync beyond DAU.
+* Prepares for implementation of same measurements in autopush, also using Glean.
+* Use of standardized Mozilla tooling.
+* Establishment of team knowledge of using Glean.
+* Establishment of server-side Rust best practices, leading to easier development for backend Rust applications.
+* Transparency in data review process with consideration made to minimum collection of data.
 
-### Negative Consequences <!-- optional -->
+### Negative Consequences
 
-* [e.g., compromising quality attribute, follow-up decisions required, …]
-* …
+* The `glean_parser` tool used by other Glean applications is currently not supported for Rust. Furthermore, client applications can use the Glean SDK and this is also not an option for us.
+* Server side metrics have not yet been implemented for a Rust server application of this kind, so this is new territory.
+* There is added complexity of data review process and registration of the application to Glean's probe scraper.
+* Potential delays and challenges in new implementation.
 
-## Pros and Cons of the Options <!-- optional -->
+## Pros and Cons of the Options
 
 ### [option A]
 
@@ -100,3 +110,4 @@ Chosen option:
 
 * [Discussion Document](https://docs.google.com/document/d/1Tk4VIuQZcn8IG-UI38kziZn5e-FMOI0Z-VrvaYTI1SM/edit#heading=h.b0mqx1fng4wa)
 * [FxA DAU Metric in Redash](https://sql.telemetry.mozilla.org/queries/101007/source?p_end%20date=2024-06-26&p_start%20date=2024-05-01#248905)
+* [Sync Ecosystem Infrastructure and Metrics: KPI Metrics](https://mozilla-hub.atlassian.net/wiki/spaces/CLOUDSERVICES/pages/969834589/Establish+KPI+metrics+DAU+Retention)

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -1,0 +1,3 @@
+# Synsctorage-rs ADRs
+
+This directory archives all the Architectural Decision Records (ADRs) for Syncstorage-rs.

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,0 +1,94 @@
+# [short title of solved problem and solution]
+
+* Status: [proposed | rejected | accepted | deprecated | … | superseded by [ADR-0005](0005-example.md)] <!-- optional -->
+* Deciders: [list everyone involved in the decision] <!-- optional -->
+* Date: [YYYY-MM-DD when the decision was last updated] <!-- optional -->
+
+Technical Story: [description | ticket/issue URL] <!-- optional -->
+
+## Context and Problem Statement
+
+[Describe the context and problem statement, e.g., in free form using two to three sentences. You may want to articulate the problem in form of a question.]
+
+## Decision Drivers <!-- optional -->
+
+1. [primary driver, e.g., a force, facing concern, …]
+2. [secondary driver, e.g., a force, facing concern, …]
+3. … <!-- numbers of drivers can vary, ranked in order of importance -->
+
+## Considered Options
+
+* A. [option A]
+* B. [option B]
+* C. [option C]
+* D. … <!-- numbers of options can vary -->
+
+## Decision Outcome
+
+Chosen option:
+
+* A. "[option A]"
+
+[justification. e.g., only option, which meets primary decision driver | which resolves a force or facing concern | … | comes out best (see below)].
+
+### Positive Consequences <!-- optional -->
+
+* [e.g., improvement of quality attribute satisfaction, follow-up decisions required, …]
+* …
+
+### Negative Consequences <!-- optional -->
+
+* [e.g., compromising quality attribute, follow-up decisions required, …]
+* …
+
+## Pros and Cons of the Options <!-- optional -->
+
+### [option A]
+
+[example | description | pointer to more information | …] <!-- optional -->
+
+#### Pros
+
+* [argument for]
+* [argument for]
+* … <!-- numbers of pros can vary -->
+
+#### Cons
+
+* [argument against]
+* … <!-- numbers of cons can vary -->
+
+### [option B]
+
+[example | description | pointer to more information | …] <!-- optional -->
+
+#### Pros
+
+* [argument for]
+* [argument for]
+* … <!-- numbers of pros can vary -->
+
+#### Cons
+
+* [argument against]
+* … <!-- numbers of cons can vary -->
+
+### [option C]
+
+[example | description | pointer to more information | …] <!-- optional -->
+
+#### Pros
+
+* [argument for]
+* [argument for]
+* … <!-- numbers of pros can vary -->
+
+#### Cons
+
+* [argument against]
+* … <!-- numbers of cons can vary -->
+
+## Links <!-- optional -->
+
+* [Link type] [Link to ADR] <!-- example: Refined by [ADR-0005](0005-example.md) -->
+* … <!-- numbers of links can vary -->


### PR DESCRIPTION
## Description

Required ADR to validate approach of using Glean for server-side metrics to measure DAU.

The ADR will be created and stored in the syncstorage-rs repo and referenced in our service runbooks and documentation.

## Testing

N/A

## Issue(s)

Closes [SYNC-4434](https://mozilla-hub.atlassian.net/browse/SYNC-4434).


[SYNC-4434]: https://mozilla-hub.atlassian.net/browse/SYNC-4434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ