### PR TITLE
feat: wire MysqlError's ReportableError impl into TokenserverError

### DIFF
--- a/syncserver-db-common/src/error.rs
+++ b/syncserver-db-common/src/error.rs
@@ -41,7 +41,11 @@ impl From<MysqlErrorKind> for MysqlError {
 
 impl ReportableError for MysqlError {
     fn is_sentry_event(&self) -> bool {
-        true
+        #[allow(clippy::match_like_matches_macro)]
+        match &self.kind {
+            MysqlErrorKind::Pool(_) => false,
+            _ => true,
+        }
     }
 
     fn metric_label(&self) -> Option<String> {

--- a/syncserver/src/tokenserver/extractors.rs
+++ b/syncserver/src/tokenserver/extractors.rs
@@ -320,6 +320,7 @@ impl FromRequest for DbWrapper {
                 .map(Self)
                 .map_err(|e| TokenserverError {
                     context: format!("Couldn't acquire a database connection: {}", e),
+                    source: Some(Box::new(e)),
                     ..TokenserverError::internal_error()
                 })
         })

--- a/syncserver/src/tokenserver/mod.rs
+++ b/syncserver/src/tokenserver/mod.rs
@@ -1,4 +1,6 @@
+#[allow(clippy::result_large_err)]
 pub mod extractors;
+#[allow(clippy::result_large_err)]
 pub mod handlers;
 pub mod logging;
 

--- a/tokenserver-auth/src/lib.rs
+++ b/tokenserver-auth/src/lib.rs
@@ -3,7 +3,9 @@ mod crypto;
 
 #[cfg(not(feature = "py"))]
 pub use crypto::{JWTVerifier, JWTVerifierImpl};
+#[allow(clippy::result_large_err)]
 pub mod oauth;
+#[allow(clippy::result_large_err)]
 mod token;
 use syncserver_common::Metrics;
 pub use token::Tokenlib;

--- a/tokenserver-db/src/error.rs
+++ b/tokenserver-db/src/error.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use backtrace::Backtrace;
 use http::StatusCode;
-use syncserver_common::{from_error, impl_fmt_display, InternalError};
+use syncserver_common::{from_error, impl_fmt_display, InternalError, ReportableError};
 use syncserver_db_common::error::MysqlError;
 use thiserror::Error;
 use tokenserver_common::TokenserverError;
@@ -22,6 +22,29 @@ pub struct DbError {
 impl DbError {
     pub(crate) fn internal(msg: String) -> Self {
         DbErrorKind::Internal(msg).into()
+    }
+}
+
+impl ReportableError for DbError {
+    fn backtrace(&self) -> Option<&Backtrace> {
+        match &self.kind {
+            DbErrorKind::Mysql(e) => e.backtrace(),
+            _ => Some(&self.backtrace),
+        }
+    }
+
+    fn is_sentry_event(&self) -> bool {
+        match &self.kind {
+            DbErrorKind::Mysql(e) => e.is_sentry_event(),
+            _ => true,
+        }
+    }
+
+    fn metric_label(&self) -> Option<String> {
+        match &self.kind {
+            DbErrorKind::Mysql(e) => e.metric_label(),
+            _ => None,
+        }
     }
 }
 
@@ -56,7 +79,7 @@ impl From<DbError> for TokenserverError {
         TokenserverError {
             description: db_error.to_string(),
             context: db_error.to_string(),
-            backtrace: db_error.backtrace,
+            backtrace: db_error.backtrace.clone(),
             http_status: if db_error.status.is_server_error() {
                 // Use the status code from the DbError if it already suggests an internal error;
                 // it might be more specific than `StatusCode::SERVICE_UNAVAILABLE`
@@ -64,6 +87,7 @@ impl From<DbError> for TokenserverError {
             } else {
                 StatusCode::SERVICE_UNAVAILABLE
             },
+            source: Some(Box::new(db_error)),
             // An unhandled DbError in the Tokenserver code is an internal error
             ..TokenserverError::internal_error()
         }


### PR DESCRIPTION
and quiet Pool errors

## Issue(s)

Closes SYNC-4424

Note this is a quick fix, I think `TokenserverError` could use a cleaner, further overhaul: https://mozilla-hub.atlassian.net/browse/SYNC-4443
