### PR TITLE
feat: revert "feat: Revert "chore: revert back to bullseye (for now) 

### DIFF
--- a/tools/tokenserver/process_account_events.py
+++ b/tools/tokenserver/process_account_events.py
@@ -115,24 +115,22 @@ def process_account_event(database, body, metrics=None):
     else:
         if email is not None:
             record_metric = True
-            match event_type:
-                case "delete":
-                    # Mark the user as retired.
-                    # Actual cleanup is done by a separate process.
-                    logger.info("Processing account delete for %r", email)
-                    database.retire_user(email)
-                case "reset":
-                    logger.info("Processing account reset for %r", email)
-                    update_generation_number(
-                        database, email, generation, metrics=metrics)
-                case "passwordChange":
-                    logger.info("Processing password change for %r", email)
-                    update_generation_number(
-                        database, email, generation, metrics=metrics)
-                case _:
-                    record_metric = False
-                    logger.warning("Dropping unknown event type %r",
-                                   event_type)
+            if event_type == "delete":
+                # Mark the user as retired.
+                # Actual cleanup is done by a separate process.
+                logger.info("Processing account delete for %r", email)
+                database.retire_user(email)
+            elif event_type == "reset":
+                logger.info("Processing account reset for %r", email)
+                update_generation_number(
+                    database, email, generation, metrics=metrics)
+            elif event_type == "passwordChange":
+                logger.info("Processing password change for %r", email)
+                update_generation_number(
+                    database, email, generation, metrics=metrics)
+            else:
+                record_metric = False
+                logger.warning("Dropping unknown event type %r", event_type)
             if record_metric and metrics:
                 metrics.incr(event_type)
 


### PR DESCRIPTION
Just to be 100% on the safe side, let's go back to the old Debian bullseye until tokenserver is fully stabilized on prod.

We know this bookworm/mysql client upgrade did trigger some differences in establishing connections (they took longer to establish the max 100 we use). Tokenserver should be able to handle this difference, but let's ensure the blocking thread pool changes are successful before reattempting this bookworm/client upgrade.

It could also be useful to see the new blocking thread pool metrics before/after the bookworm upgrade, so it makes sense to revert back to the older debian/client for now.

## Issue(s)

Issue SYNC-4363
