### PR TITLE
feat: add hashed_device_id to HawkIdentifier

### DIFF
--- a/syncserver/src/web/extractors.rs
+++ b/syncserver/src/web/extractors.rs
@@ -995,6 +995,7 @@ pub struct HawkIdentifier {
     pub fxa_uid: String,
     pub fxa_kid: String,
     pub hashed_fxa_uid: String,
+    pub hashed_device_id: String,
     pub tokenserver_origin: TokenserverOrigin,
 }
 
@@ -1006,6 +1007,7 @@ impl HawkIdentifier {
             fxa_uid: "cmd".to_owned(),
             fxa_kid: "cmd".to_owned(),
             hashed_fxa_uid: "cmd".to_owned(),
+            hashed_device_id: "cmd".to_owned(),
             tokenserver_origin: TokenserverOrigin::default(),
         }
     }
@@ -1109,6 +1111,7 @@ impl HawkIdentifier {
             fxa_uid: payload.fxa_uid,
             fxa_kid: payload.fxa_kid,
             hashed_fxa_uid: payload.hashed_fxa_uid,
+            hashed_device_id: payload.hashed_device_id,
             tokenserver_origin: payload.tokenserver_origin,
         };
         Ok(user_id)

--- a/syncserver/src/web/extractors.rs
+++ b/syncserver/src/web/extractors.rs
@@ -1125,6 +1125,7 @@ impl From<HawkIdentifier> for UserIdentifier {
             fxa_uid: hawk_id.fxa_uid,
             fxa_kid: hawk_id.fxa_kid,
             hashed_fxa_uid: hawk_id.hashed_fxa_uid,
+            hashed_device_id: hawk_id.hashed_device_id,
         }
     }
 }

--- a/syncstorage-db-common/src/lib.rs
+++ b/syncstorage-db-common/src/lib.rs
@@ -278,4 +278,5 @@ pub struct UserIdentifier {
     pub fxa_uid: String,
     pub fxa_kid: String,
     pub hashed_fxa_uid: String,
+    pub hashed_device_id: String,
 }

--- a/syncstorage-db/src/tests/support.rs
+++ b/syncstorage-db/src/tests/support.rs
@@ -131,5 +131,6 @@ pub fn hid(user_id: u32) -> UserIdentifier {
         fxa_uid: format!("xxx_unit_tests_fxa_uid{}", user_id),
         fxa_kid: format!("xxx_unit_tests_fxa_kid{}", user_id),
         hashed_fxa_uid: format!("xxx_unit_tests_hashed_fxa_uid{}", user_id),
+        hashed_device_id: format!("xxx_unit_tests_hashed_device_id{}", user_id),
     }
 }


### PR DESCRIPTION
## Description

In looking ahead to possible opt-outs, we would want to tether to client logic using the hashed_device_id as a mechanism to delete or exclude records.

See client code : https://searchfox.org/mozilla-central/source/services/sync/modules/telemetry.sys.mjs 

This may in the end not be used, but for now it appears to be the best approach and should be included in the data review and payload of the `UserIdentifier`, passed in from the `HawkPayload`

## Testing
N/A - unit testing in crates


## Issue(s)

Closes [SYNC-4448](https://mozilla-hub.atlassian.net/browse/SYNC-4448).


[SYNC-4448]: https://mozilla-hub.atlassian.net/browse/SYNC-4448?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ