### PR TITLE
fix: upgrade sentry w/ a fix for the blocking curl Transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2458,8 +2458,7 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 [[package]]
 name = "sentry"
 version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5484316556650182f03b43d4c746ce0e3e48074a21e2f51244b648b6542e1066"
+source = "git+https://github.com/getsentry/sentry-rust?rev=1b65b5c#1b65b5c99af975496880e7325218479e0037d097"
 dependencies = [
  "curl",
  "httpdate",
@@ -2473,8 +2472,7 @@ dependencies = [
 [[package]]
 name = "sentry-backtrace"
 version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40aa225bb41e2ec9d7c90886834367f560efc1af028f1c5478a6cce6a59c463a"
+source = "git+https://github.com/getsentry/sentry-rust?rev=1b65b5c#1b65b5c99af975496880e7325218479e0037d097"
 dependencies = [
  "backtrace",
  "once_cell",
@@ -2485,8 +2483,7 @@ dependencies = [
 [[package]]
 name = "sentry-contexts"
 version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a8dd746da3d16cb8c39751619cefd4fcdbd6df9610f3310fd646b55f6e39910"
+source = "git+https://github.com/getsentry/sentry-rust?rev=1b65b5c#1b65b5c99af975496880e7325218479e0037d097"
 dependencies = [
  "hostname",
  "libc",
@@ -2499,8 +2496,7 @@ dependencies = [
 [[package]]
 name = "sentry-core"
 version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "161283cfe8e99c8f6f236a402b9ccf726b201f365988b5bb637ebca0abbd4a30"
+source = "git+https://github.com/getsentry/sentry-rust?rev=1b65b5c#1b65b5c99af975496880e7325218479e0037d097"
 dependencies = [
  "once_cell",
  "rand",
@@ -2512,8 +2508,7 @@ dependencies = [
 [[package]]
 name = "sentry-debug-images"
 version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc6b25e945fcaa5e97c43faee0267eebda9f18d4b09a251775d8fef1086238a"
+source = "git+https://github.com/getsentry/sentry-rust?rev=1b65b5c#1b65b5c99af975496880e7325218479e0037d097"
 dependencies = [
  "findshlibs",
  "once_cell",
@@ -2523,8 +2518,7 @@ dependencies = [
 [[package]]
 name = "sentry-tracing"
 version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd3c5faf2103cd01eeda779ea439b68c4ee15adcdb16600836e97feafab362ec"
+source = "git+https://github.com/getsentry/sentry-rust?rev=1b65b5c#1b65b5c99af975496880e7325218479e0037d097"
 dependencies = [
  "sentry-backtrace",
  "sentry-core",
@@ -2535,8 +2529,7 @@ dependencies = [
 [[package]]
 name = "sentry-types"
 version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d68cdf6bc41b8ff3ae2a9c4671e97426dcdd154cc1d4b6b72813f285d6b163f"
+source = "git+https://github.com/getsentry/sentry-rust?rev=1b65b5c#1b65b5c99af975496880e7325218479e0037d097"
 dependencies = [
  "debugid",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,13 +64,14 @@ regex = "1.4"
 reqwest = { version = "0.12", default-features = false, features = [
   "rustls-tls",
 ] }
-sentry = { version = "0.34", default-features = false, features = [
+# rev 1b65b5c includes https://github.com/getsentry/sentry-rust/pull/701
+sentry = { version = "0.34", git = "https://github.com/getsentry/sentry-rust", rev = "1b65b5c", default-features = false, features = [
   "curl",
   "backtrace",
   "contexts",
   "debug-images",
 ] }
-sentry-backtrace = "0.34"
+sentry-backtrace = { version = "0.34", git = "https://github.com/getsentry/sentry-rust", rev = "1b65b5c" }
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = { version = "1.0", features = ["arbitrary_precision"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ reqwest = { version = "0.12", default-features = false, features = [
   "rustls-tls",
 ] }
 # rev 1b65b5c includes https://github.com/getsentry/sentry-rust/pull/701
+# TODO: bump to 0.35 as soon as it's available
 sentry = { version = "0.34", git = "https://github.com/getsentry/sentry-rust", rev = "1b65b5c", default-features = false, features = [
   "curl",
   "backtrace",


### PR DESCRIPTION
includes the fix: https://github.com/getsentry/sentry-rust/pull/701

Closes SYNC-4460