### PR TITLE
chore: Switch to libmariadb-dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,12 +11,10 @@ ARG DATABASE_BACKEND=spanner
 
 # cmake is required to build grpcio-sys for Spanner builds
 RUN \
-    # Fetch and load the MySQL public key. We need to install libmysqlclient-dev to build syncstorage-rs
+    # We need to install libmariadb-dev to build syncstorage-rs
     # which wants the mariadb
-    wget -qO- https://repo.mysql.com/RPM-GPG-KEY-mysql-2023 > /etc/apt/trusted.gpg.d/mysql.asc && \
-    echo "deb https://repo.mysql.com/apt/debian/ bullseye mysql-8.0" >> /etc/apt/sources.list && \
     apt-get -q update && \
-    apt-get -q install -y --no-install-recommends libmysqlclient-dev cmake
+    apt-get -q install -y --no-install-recommends libmariadb-dev-compat libmariadb-dev cmake
 
 COPY --from=planner /app/recipe.json recipe.json
 RUN cargo chef cook --release --no-default-features --features=syncstorage-db/$DATABASE_BACKEND --features=py_verifier --recipe-path recipe.json
@@ -29,15 +27,8 @@ COPY --from=cacher /app/target /app/target
 COPY --from=cacher $CARGO_HOME /app/$CARGO_HOME
 
 RUN \
-    # Fetch and load the MySQL public key
-    wget -qO- https://repo.mysql.com/RPM-GPG-KEY-mysql-2023 > /etc/apt/trusted.gpg.d/mysql.asc && \
-    echo "deb https://repo.mysql.com/apt/debian/ bullseye mysql-8.0" >> /etc/apt/sources.list && \
-    # mysql_pubkey.asc from:
-    # https://dev.mysql.com/doc/refman/8.0/en/checking-gpg-signature.html
-    # related:
-    # https://dev.mysql.com/doc/mysql-apt-repo-quick-guide/en/#repo-qg-apt-repo-manual-setup
     apt-get -q update && \
-    apt-get -q install -y --no-install-recommends libmysqlclient-dev cmake golang-go python3-dev python3-pip python3-setuptools python3-wheel && \
+    apt-get -q install -y --no-install-recommends libmariadb-dev-compat libmariadb-dev cmake golang-go python3-dev python3-pip python3-setuptools python3-wheel && \
     pip3 install -r requirements.txt && \
     rm -rf /var/lib/apt/lists/*
 
@@ -65,16 +56,9 @@ RUN \
 RUN \
     groupadd --gid 10001 app && \
     useradd --uid 10001 --gid 10001 --home /app --create-home app && \
-    # first, an apt-get update is required for gnupg, which is required for apt-key adv
+    # first, an apt-get update is required for the packages
     apt-get -q update && \
-    # and ca-certificates needed for https://repo.mysql.com
-    apt-get install -y gnupg ca-certificates wget && \
-    # Fetch and load the MySQL public key
-    echo "deb https://repo.mysql.com/apt/debian/ bullseye mysql-8.0" >> /etc/apt/sources.list && \
-    wget -qO- https://repo.mysql.com/RPM-GPG-KEY-mysql-2023 > /etc/apt/trusted.gpg.d/mysql.asc && \
-    # update again now that we trust repo.mysql.com
-    apt-get -q update && \
-    apt-get -q install -y build-essential libmysqlclient-dev libssl-dev libffi-dev libcurl4 python3-dev python3-pip python3-setuptools python3-wheel cargo curl jq && \
+    apt-get -q install -y build-essential libmariadb-dev-compat libmariadb-dev libssl-dev libffi-dev libcurl4 python3-dev python3-pip python3-setuptools python3-wheel cargo curl jq && \
     # The python3-cryptography debian package installs version 2.6.1, but we
     # we want to use the version specified in requirements.txt. To do this,
     # we have to remove the python3-cryptography package here.


### PR DESCRIPTION
## Description

The MySQL repository causes issues when trying to build for other architectures (non-existent MySQL binaries), therefore the MariaDB packages should instead be used. This has been successfully tested on arm64.

## Testing

Build on all relevant architectures (x86, arm64, ...).
