### PR TITLE
feat: move context of glean metrics into statsd get_collections metric

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1142,7 +1142,7 @@ checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 
 [[package]]
 name = "glean"
-version = "0.17.12"
+version = "0.17.15"
 dependencies = [
  "chrono",
  "serde 1.0.203",


### PR DESCRIPTION
## Description

We should ideally emit the glean metrics alongside in the typical place we emit statsd metrics: after acquiring a db connection.

In the face of errors on acquiring db connections (which aren’t totally uncommon, we’re currently having spikes of them) we would emit a few less events that are likely going to be duplicates of clients later retrys anyway. The other benefit (in the case of errors) is our glean events should more closely correlate to our actual statsd metrics.

Moves everything into the `transaction_http` block, so Glean flag can still toggle.

## Testing

## Issue(s)

Closes [SYNC-4548](https://mozilla-hub.atlassian.net/browse/SYNC-4548).


[SYNC-4548]: https://mozilla-hub.atlassian.net/browse/SYNC-4548?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ