### PR TITLE
Feat: add task to release unused db conns 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3006,6 +3006,7 @@ dependencies = [
 name = "syncstorage-spanner"
 version = "0.17.15"
 dependencies = [
+ "actix-web",
  "async-trait",
  "backtrace",
  "cadence",

--- a/syncserver/src/server/mod.rs
+++ b/syncserver/src/server/mod.rs
@@ -273,6 +273,14 @@ impl Server {
             &Metrics::from(&metrics),
             blocking_threadpool.clone(),
         )?;
+        // Spawns sweeper that calls Deadpool `retain` method, clearing unused connections.
+        db_pool.spawn_sweeper(Duration::from_secs(
+            settings
+                .syncstorage
+                .database_pool_sweeper_task_interval
+                .unwrap()
+                .into(),
+        ));
         let glean_logger = Arc::new(GleanEventsLogger {
             // app_id corresponds to probe-scraper entry.
             // https://github.com/mozilla/probe-scraper/blob/main/repositories.yaml

--- a/syncserver/src/server/mod.rs
+++ b/syncserver/src/server/mod.rs
@@ -278,7 +278,6 @@ impl Server {
             settings
                 .syncstorage
                 .database_pool_sweeper_task_interval
-                .unwrap()
                 .into(),
         ));
         let glean_logger = Arc::new(GleanEventsLogger {

--- a/syncstorage-mysql/src/pool.rs
+++ b/syncstorage-mysql/src/pool.rs
@@ -99,6 +99,13 @@ impl MysqlDbPool {
         })
     }
 
+    /// Spawn a task to periodically evict idle connections. Calls wrapper sweeper fn
+    ///  to use pool.retain, retaining objects only if they are shorter in duration than
+    ///  defined max_idle. Noop for mysql impl.
+    pub fn spawn_sweeper(&self, _interval: Duration) {
+        sweeper()
+    }
+
     pub fn get_sync(&self) -> DbResult<MysqlDb> {
         Ok(MysqlDb::new(
             self.pool.get()?,
@@ -109,6 +116,13 @@ impl MysqlDbPool {
         ))
     }
 }
+
+/// Sweeper to retain only the objects specified within the closure.
+/// In this context, if a Spanner connection is unutilized, we want it
+/// to release the given connections.
+/// See: https://docs.rs/deadpool/latest/deadpool/managed/struct.Pool.html#method.retain
+/// Noop for mysql impl
+fn sweeper() {}
 
 #[async_trait]
 impl DbPool for MysqlDbPool {

--- a/syncstorage-settings/src/lib.rs
+++ b/syncstorage-settings/src/lib.rs
@@ -78,6 +78,8 @@ pub struct Settings {
     pub database_pool_connection_lifespan: Option<u32>,
     /// Max time a connection should sit idle before being dropped.
     pub database_pool_connection_max_idle: Option<u32>,
+    /// Interval for sweeper task releasing unused connections.
+    pub database_pool_sweeper_task_interval: Option<u32>,
     #[cfg(debug_assertions)]
     pub database_use_test_transactions: bool,
     #[cfg(debug_assertions)]
@@ -115,6 +117,7 @@ impl Default for Settings {
             database_pool_min_idle: None,
             database_pool_connection_lifespan: None,
             database_pool_connection_max_idle: None,
+            database_pool_sweeper_task_interval: Some(30),
             database_pool_connection_timeout: Some(30),
             #[cfg(debug_assertions)]
             database_use_test_transactions: false,

--- a/syncstorage-settings/src/lib.rs
+++ b/syncstorage-settings/src/lib.rs
@@ -79,7 +79,7 @@ pub struct Settings {
     /// Max time a connection should sit idle before being dropped.
     pub database_pool_connection_max_idle: Option<u32>,
     /// Interval for sweeper task releasing unused connections.
-    pub database_pool_sweeper_task_interval: Option<u32>,
+    pub database_pool_sweeper_task_interval: u32,
     #[cfg(debug_assertions)]
     pub database_use_test_transactions: bool,
     #[cfg(debug_assertions)]
@@ -117,7 +117,7 @@ impl Default for Settings {
             database_pool_min_idle: None,
             database_pool_connection_lifespan: None,
             database_pool_connection_max_idle: None,
-            database_pool_sweeper_task_interval: Some(30),
+            database_pool_sweeper_task_interval: 30,
             database_pool_connection_timeout: Some(30),
             #[cfg(debug_assertions)]
             database_use_test_transactions: false,

--- a/syncstorage-spanner/Cargo.toml
+++ b/syncstorage-spanner/Cargo.toml
@@ -6,6 +6,7 @@ authors.workspace = true
 edition.workspace = true
 
 [dependencies]
+actix-web.workspace = true
 backtrace.workspace = true
 cadence.workspace = true
 deadpool.workspace = true

--- a/syncstorage-spanner/src/manager/deadpool.rs
+++ b/syncstorage-spanner/src/manager/deadpool.rs
@@ -13,7 +13,7 @@ use crate::error::DbError;
 pub(crate) type Conn = deadpool::managed::Object<SpannerSessionManager>;
 
 pub(crate) struct SpannerSessionManager {
-    settings: SpannerSessionSettings,
+    pub settings: SpannerSessionSettings,
     /// The gRPC environment
     env: Arc<Environment>,
     metrics: Metrics,

--- a/syncstorage-spanner/src/manager/session.rs
+++ b/syncstorage-spanner/src/manager/session.rs
@@ -64,8 +64,6 @@ pub struct SpannerSessionSettings {
     pub max_lifespan: Option<u32>,
     /// Max idle time of a Session
     pub max_idle: Option<u32>,
-    /// Interval for sweeper task releasing unused connections.
-    pub pool_max_idle: Option<u32>,
 
     /// For tests: disables transactions from committing
     pub(crate) use_test_transactions: bool,
@@ -96,7 +94,6 @@ impl SpannerSessionSettings {
             route_to_leader: settings.database_spanner_route_to_leader,
             max_lifespan: settings.database_pool_connection_lifespan,
             max_idle: settings.database_pool_connection_max_idle,
-            pool_max_idle: settings.database_pool_connection_max_idle,
             use_test_transactions,
             emulator_host: settings.spanner_emulator_host.clone(),
         })

--- a/syncstorage-spanner/src/manager/session.rs
+++ b/syncstorage-spanner/src/manager/session.rs
@@ -65,7 +65,7 @@ pub struct SpannerSessionSettings {
     /// Max idle time of a Session
     pub max_idle: Option<u32>,
     /// Interval for sweeper task releasing unused connections.
-    pub pool_sweeper_task_interval: Option<u32>,
+    pub pool_max_idle: Option<u32>,
 
     /// For tests: disables transactions from committing
     pub(crate) use_test_transactions: bool,
@@ -96,7 +96,7 @@ impl SpannerSessionSettings {
             route_to_leader: settings.database_spanner_route_to_leader,
             max_lifespan: settings.database_pool_connection_lifespan,
             max_idle: settings.database_pool_connection_max_idle,
-            pool_sweeper_task_interval: settings.database_pool_sweeper_task_interval,
+            pool_max_idle: settings.database_pool_connection_max_idle,
             use_test_transactions,
             emulator_host: settings.spanner_emulator_host.clone(),
         })

--- a/syncstorage-spanner/src/manager/session.rs
+++ b/syncstorage-spanner/src/manager/session.rs
@@ -64,6 +64,8 @@ pub struct SpannerSessionSettings {
     pub max_lifespan: Option<u32>,
     /// Max idle time of a Session
     pub max_idle: Option<u32>,
+    /// Interval for sweeper task releasing unused connections.
+    pub pool_sweeper_task_interval: Option<u32>,
 
     /// For tests: disables transactions from committing
     pub(crate) use_test_transactions: bool,
@@ -94,6 +96,7 @@ impl SpannerSessionSettings {
             route_to_leader: settings.database_spanner_route_to_leader,
             max_lifespan: settings.database_pool_connection_lifespan,
             max_idle: settings.database_pool_connection_max_idle,
+            pool_sweeper_task_interval: settings.database_pool_sweeper_task_interval,
             use_test_transactions,
             emulator_host: settings.spanner_emulator_host.clone(),
         })

--- a/syncstorage-spanner/src/pool.rs
+++ b/syncstorage-spanner/src/pool.rs
@@ -50,7 +50,9 @@ impl SpannerDbPool {
         let config = deadpool::managed::PoolConfig {
             max_size,
             timeouts,
-            ..Default::default()
+            // Prefer LIFO to allow the sweeper task to evict least frequently
+            // used connections.
+            queue_mode: deadpool::managed::QueueMode::Lifo,
         };
         let pool = deadpool::managed::Pool::builder(manager)
             .config(config)

--- a/syncstorage-spanner/src/pool.rs
+++ b/syncstorage-spanner/src/pool.rs
@@ -96,7 +96,7 @@ impl SpannerDbPool {
         let pool = self.pool.clone();
         rt::spawn(async move {
             loop {
-                sweeper(&pool, max_idle);
+                sweeper(&pool, Duration::from_secs(max_idle.into()));
                 rt::time::sleep(interval).await;
             }
         });

--- a/syncstorage-spanner/src/pool.rs
+++ b/syncstorage-spanner/src/pool.rs
@@ -86,6 +86,14 @@ impl SpannerDbPool {
     }
 }
 
+/// Sweeper to retain only the objects specified within the closure.
+/// In this context, if a Spanner connection is unutilized, we want it
+/// to release the given connections.
+/// See: https://docs.rs/deadpool/latest/deadpool/managed/struct.Pool.html#method.retain
+fn sweeper(pool: &deadpool::managed::Pool<SpannerSessionManager>, max_idle: Duration) {
+    pool.retain(|_, metrics| metrics.last_used() < max_idle);
+}
+
 #[async_trait]
 impl DbPool for SpannerDbPool {
     type Error = DbError;

--- a/syncstorage-spanner/src/pool.rs
+++ b/syncstorage-spanner/src/pool.rs
@@ -90,7 +90,7 @@ impl SpannerDbPool {
     ///  to use pool.retain, retaining objects only if they are shorter in duration than
     ///  defined max_idle.
     pub fn spawn_sweeper(&self, interval: Duration) {
-        let Some(max_idle) = self.pool.manager().settings.max_lifespan else {
+        let Some(max_idle) = self.pool.manager().settings.pool_max_idle else {
             return;
         };
         let pool = self.pool.clone();
@@ -105,7 +105,7 @@ impl SpannerDbPool {
 
 /// Sweeper to retain only the objects specified within the closure.
 /// In this context, if a Spanner connection is unutilized, we want it
-/// to release the given connections.
+/// to release the given connection.
 /// See: https://docs.rs/deadpool/latest/deadpool/managed/struct.Pool.html#method.retain
 fn sweeper(pool: &deadpool::managed::Pool<SpannerSessionManager>, max_idle: Duration) {
     pool.retain(|_, metrics| metrics.last_used() < max_idle);

--- a/syncstorage-spanner/src/pool.rs
+++ b/syncstorage-spanner/src/pool.rs
@@ -90,7 +90,7 @@ impl SpannerDbPool {
     ///  to use pool.retain, retaining objects only if they are shorter in duration than
     ///  defined max_idle.
     pub fn spawn_sweeper(&self, interval: Duration) {
-        let Some(max_idle) = self.pool.manager().settings.pool_max_idle else {
+        let Some(max_idle) = self.pool.manager().settings.max_idle else {
             return;
         };
         let pool = self.pool.clone();


### PR DESCRIPTION
## Description

By default, Deadpool releases unused connections pretty lazily, causing connections that may otherwise be available to be tied up unnecessarily. This could be part of what’s causing pods to run out of available connections to Spanner in certain cases. To resolve this, we should pursue a solution like the one described [here](https://github.com/bikeshedder/deadpool/issues/178#issuecomment-1036953054), where we spawn a background task that periodically releases connections that haven’t been used within a given amount of time (this amount of time should be configurable in a setting).

To do this, we’ll need to make use of the [Pool::retain](https://docs.rs/deadpool/latest/deadpool/managed/struct.Pool.html#method.retain) method, which was introduced in deadpool 0.9.3 (we’re currently on version 0.5, so we’ll need to upgrade).

## Testing

How should reviewers test?

## Issue(s)

Closes [SYNC-4542](https://mozilla-hub.atlassian.net/browse/SYNC-4542).


[SYNC-4542]: https://mozilla-hub.atlassian.net/browse/SYNC-4542?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ