### PR TITLE
doc: Update CONTRIBUTING to emphasize commit signing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,11 +24,13 @@ Before submitting a PR:
   your reviewer's responsibility to ensure your patch includes adequate tests.
 
 When submitting a PR:
+- **[Sign all your git commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#ssh-commit-verification)**.
+  We cannot accept any PR that does not have all commits signed. This is a policy
+  put in place by our Security Operations team and is enforced by our CI processes.
 - You agree to license your code under the project's open source license
   ([MPL 2.0](/LICENSE)).
 - Base your branch off the current `master`.
 - Add both your code and new tests if relevant.
-- Sign your git commit.
 - Run the test suite to make sure your code passes linting and tests.
 - Ensure your changes do not reduce code coverage of the test suite.
 - Please do not include merge commits in pull requests; include only commits

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,8 @@
 
 Describe these changes.
 
+> **NOTE:** We can only accept PRS with all commits [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#ssh-commit-verification). PRs that contain _any_ unsigned commits will not be accepted and the PR _must_ be resubmitted. If this is something you cannot provide, please disclose and a team member _may_ duplicate the PR as signed for you (depending on availablity and priority. Thank you for your understanding and cooperation.)
+
 ## Testing
 
 How should reviewers test?


### PR DESCRIPTION
## Description

Update the CONTRIBUTING.md doc to emphasize commit signatures, to help prevent frustration by outside contributors. 

