### PR TITLE
Fix URL Prefix Support

### DIFF
--- a/docs/src/config.md
+++ b/docs/src/config.md
@@ -34,6 +34,7 @@ The following configuration options are available.
 | --- | --- | --- |
 | <span id="SYNC_HOST"></span>SYNC_HOST | 127.0.0.1 | Host address to bind the server to |
 | <span id="SYNC_PORT"></span>SYNC_PORT | 8000 | Server port to bind to |
+| <span id="SYNC_PUBLIC_URL"></span>SYNC_PUBLIC_URL | _None_ | public url for performing request validation |
 | <span id="SYNC_MASTER_SECRET"></span>SYNC_MASTER_SECRET | None, required | Secret used to derive auth secrets |
 | <span id="SYNC_ENVIRONMENT"></span>SYNC_ENVIRONMENT | dev | Environment name ("dev", "stage", "prod") |
 | <span id="SYNC_HUMAN_LOGS"></span>SYNC_HUMAN_LOGS | false | Enable human-readable logs |

--- a/syncserver-settings/src/lib.rs
+++ b/syncserver-settings/src/lib.rs
@@ -18,6 +18,8 @@ static PREFIX: &str = "sync";
 pub struct Settings {
     pub port: u16,
     pub host: String,
+    /// public facing URL of the server
+    pub public_url: Option<String>,
     /// Keep-alive header value (seconds)
     pub actix_keep_alive: Option<u32>,
     /// The master secret, from which are derived
@@ -210,6 +212,7 @@ impl Default for Settings {
         Settings {
             port: 8000,
             host: "127.0.0.1".to_string(),
+            public_url: None,
             actix_keep_alive: None,
             master_secret: Secrets::default(),
             statsd_host: Some("localhost".to_owned()),

--- a/syncserver/src/server/mod.rs
+++ b/syncserver/src/server/mod.rs
@@ -69,6 +69,21 @@ pub struct ServerState {
     pub glean_enabled: bool,
 }
 
+/// This is a state holding data about the reverse proxy configuration.
+/// This state object will be made available to all HTTP API calls.
+pub struct ReverseProxyState {
+    /// public facing URL of the server
+    pub public_url: Option<String>,
+}
+
+impl ReverseProxyState {
+    pub fn from_settings(settings: &Settings) -> ReverseProxyState {
+        ReverseProxyState {
+            public_url: settings.public_url.clone(),
+        }
+    }
+}
+
 pub fn cfg_path(path: &str) -> String {
     let path = path
         .replace(
@@ -130,7 +145,7 @@ pub struct Server;
 
 #[macro_export]
 macro_rules! build_app {
-    ($syncstorage_state: expr, $tokenserver_state: expr, $secrets: expr, $limits: expr, $cors: expr, $metrics: expr) => {
+    ($reverse_proxy_state: expr, $syncstorage_state: expr, $tokenserver_state: expr, $secrets: expr, $limits: expr, $cors: expr, $metrics: expr) => {
         App::new()
             .configure(|cfg| {
                 cfg.app_data(Data::new($syncstorage_state));
@@ -141,6 +156,7 @@ macro_rules! build_app {
                 }
             })
             .app_data(Data::new($secrets))
+            .app_data(Data::new($reverse_proxy_state))
             // Middleware is applied LIFO
             // These will wrap all outbound responses with matching status codes.
             .wrap(ErrorHandlers::new().handler(StatusCode::NOT_FOUND, ApiError::render_404))
@@ -264,11 +280,12 @@ macro_rules! build_app {
 
 #[macro_export]
 macro_rules! build_app_without_syncstorage {
-    ($state: expr, $secrets: expr, $cors: expr, $metrics: expr) => {{
+    ($reverse_proxy_state: expr, $state: expr, $secrets: expr, $cors: expr, $metrics: expr) => {{
         let fxa_webhook_enabled = $state.fxa_webhook_enabled;
         App::new()
             .app_data(Data::new($state))
             .app_data(Data::new($secrets))
+            .app_data(Data::new($reverse_proxy_state))
             // Middleware is applied LIFO
             // These will wrap all outbound responses with matching status codes.
             .wrap(ErrorHandlers::new().handler(StatusCode::NOT_FOUND, ApiError::render_404))
@@ -427,6 +444,7 @@ impl Server {
             };
 
             build_app!(
+                ReverseProxyState::from_settings(&settings_copy),
                 syncstorage_state,
                 tokenserver_state.clone(),
                 Arc::clone(&secrets),
@@ -485,6 +503,7 @@ impl Server {
 
         let server = HttpServer::new(move || {
             build_app_without_syncstorage!(
+                ReverseProxyState::from_settings(&settings_copy),
                 tokenserver_state.clone(),
                 Arc::clone(&secrets),
                 build_cors(&settings_copy),

--- a/syncserver/src/server/mod.rs
+++ b/syncserver/src/server/mod.rs
@@ -15,6 +15,7 @@ use actix_web::{
 use cadence::{Gauged, StatsdClient};
 use futures::future::{self, Ready};
 use glean::server_events::GleanEventsLogger;
+use http::Uri;
 use syncserver_common::{
     BlockingThreadpool, BlockingThreadpoolMetrics, Metrics, Taggable,
     middleware::sentry::SentryWrapper,
@@ -80,6 +81,16 @@ impl ReverseProxyState {
     pub fn from_settings(settings: &Settings) -> ReverseProxyState {
         ReverseProxyState {
             public_url: settings.public_url.clone(),
+        }
+    }
+
+    pub fn get_webroot(&self) -> String {
+        match &self.public_url {
+            None => "".to_owned(),
+            Some(url) => match url.parse::<Uri>() {
+                Err(_) => "".to_owned(),
+                Ok(uri) => uri.path().to_owned(),
+            },
         }
     }
 }

--- a/syncserver/src/server/test.rs
+++ b/syncserver/src/server/test.rs
@@ -130,6 +130,7 @@ macro_rules! init_app {
             let state = get_test_state(&$settings).await;
             let metrics = state.metrics.clone();
             test::init_service(build_app!(
+                ReverseProxyState::from_settings(&$settings),
                 state,
                 None::<tokenserver::ServerState>,
                 Arc::clone(&SECRETS),
@@ -251,6 +252,7 @@ where
     let state = get_test_state(&settings).await;
     let metrics = state.metrics.clone();
     let app = test::init_service(build_app!(
+        ReverseProxyState::from_settings(&settings),
         state,
         None::<tokenserver::ServerState>,
         Arc::clone(&SECRETS),
@@ -295,6 +297,7 @@ async fn test_endpoint_with_body(
     let state = get_test_state(&settings).await;
     let metrics = state.metrics.clone();
     let app = test::init_service(build_app!(
+        ReverseProxyState::from_settings(&settings),
         state,
         None::<tokenserver::ServerState>,
         Arc::clone(&SECRETS),

--- a/syncserver/src/server/test.rs
+++ b/syncserver/src/server/test.rs
@@ -144,17 +144,23 @@ macro_rules! init_app {
 }
 
 fn create_request(
-    method: http::Method,
+    method: &http::Method,
     path: &str,
     headers: Option<HashMap<&'static str, String>>,
     payload: Option<serde_json::Value>,
+    settings: Option<&Settings>,
 ) -> test::TestRequest {
-    let settings = get_test_settings();
+    let test_settings = get_test_settings();
+    let settings = settings.unwrap_or(&test_settings);
     let mut req = test::TestRequest::with_uri(path)
         .method(method.clone())
         .insert_header((
             "Authorization",
-            create_hawk_header(method.as_str(), settings.port, path),
+            create_hawk_header(
+                method.as_str(),
+                settings.port,
+                &(ReverseProxyState::from_settings(settings).get_webroot() + path),
+            ),
         ))
         .insert_header(("Accept", "application/json"))
         .insert_header((
@@ -226,20 +232,34 @@ async fn test_endpoint(
     status: Option<StatusCode>,
     expected_body: Option<&str>,
 ) {
-    let app = init_app!().await;
+    for prefix in [None, Some("/firefox-sync")] {
+        let settings = match prefix {
+            None => None,
+            Some(prefix) => {
+                let mut settings = get_test_settings();
+                settings.public_url = Some(format!("https://example.com{}", prefix).to_owned());
+                Some(settings)
+            }
+        };
 
-    let req = create_request(method, path, None, None).to_request();
-    let sresp = app
-        .call(req)
-        .await
-        .expect("Could not get sresp in test_endpoint");
-    match status {
-        None => assert!(sresp.response().status().is_success()),
-        Some(status) => assert!(sresp.response().status() == status),
-    };
-    if let Some(x_body) = expected_body {
-        let body = test::read_body(sresp).await;
-        assert_eq!(body, x_body.as_bytes());
+        let app = match settings.clone() {
+            None => init_app!().await,
+            Some(settings) => init_app!(settings).await,
+        };
+
+        let req = create_request(&method, path, None, None, settings.as_ref()).to_request();
+        let sresp = app
+            .call(req)
+            .await
+            .expect("Could not get sresp in test_endpoint");
+        match status {
+            None => assert!(sresp.response().status().is_success()),
+            Some(status) => assert!(sresp.response().status() == status),
+        };
+        if let Some(x_body) = expected_body {
+            let body = test::read_body(sresp).await;
+            assert_eq!(body, x_body.as_bytes());
+        }
     }
 }
 
@@ -262,7 +282,7 @@ where
     ))
     .await;
 
-    let req = create_request(method, path, None, None).to_request();
+    let req = create_request(&method, path, None, None, Some(&settings)).to_request();
     let sresponse = match app.call(req).await {
         Ok(v) => v,
         Err(e) => {
@@ -306,11 +326,12 @@ async fn test_endpoint_with_body(
         metrics
     ))
     .await;
-    let req = create_request(method, path, None, Some(body)).to_request();
+    let req = create_request(&method, path, None, Some(body), Some(&settings)).to_request();
     let sresponse = app
         .call(req)
         .await
         .expect("Could not get sresponse in test_endpoint_with_body");
+    println!("{sresponse:#?}");
     assert!(sresponse.response().status().is_success());
     test::read_body(sresponse).await
 }
@@ -527,7 +548,7 @@ async fn invalid_content_type() {
     let mut headers = HashMap::new();
     headers.insert("Content-Type", "application/javascript".to_owned());
     let req = create_request(
-        http::Method::PUT,
+        &http::Method::PUT,
         path,
         Some(headers.clone()),
         Some(json!(BsoBody {
@@ -537,6 +558,7 @@ async fn invalid_content_type() {
             ttl: Some(31_536_000),
             ..Default::default()
         })),
+        None,
     )
     .to_request();
 
@@ -550,7 +572,7 @@ async fn invalid_content_type() {
     let path = "/1.5/42/storage/bookmarks";
 
     let req = create_request(
-        http::Method::POST,
+        &http::Method::POST,
         path,
         Some(headers.clone()),
         Some(json!([BsoBody {
@@ -560,6 +582,7 @@ async fn invalid_content_type() {
             ttl: Some(31_536_000),
             ..Default::default()
         }])),
+        None,
     )
     .to_request();
 
@@ -577,13 +600,14 @@ async fn invalid_batch_post() {
     let mut headers = HashMap::new();
     headers.insert("accept", "application/json".to_owned());
     let req = create_request(
-        http::Method::POST,
+        &http::Method::POST,
         "/1.5/42/storage/tabs?batch=sammich",
         Some(headers),
         Some(json!([
             {"id": "123", "payload": "xxx", "sortindex": 23},
             {"id": "456", "payload": "xxxasdf", "sortindex": 23}
         ])),
+        None,
     )
     .to_request();
 
@@ -607,9 +631,10 @@ async fn accept_new_or_dev_ios() {
     );
 
     let req = create_request(
-        http::Method::GET,
+        &http::Method::GET,
         "/1.5/42/info/collections",
         Some(headers),
+        None,
         None,
     )
     .to_request();
@@ -623,9 +648,10 @@ async fn accept_new_or_dev_ios() {
     );
 
     let req = create_request(
-        http::Method::GET,
+        &http::Method::GET,
         "/1.5/42/info/collections",
         Some(headers),
+        None,
         None,
     )
     .to_request();
@@ -639,9 +665,10 @@ async fn accept_new_or_dev_ios() {
     );
 
     let req = create_request(
-        http::Method::GET,
+        &http::Method::GET,
         "/1.5/42/info/collections",
         Some(headers),
+        None,
         None,
     )
     .to_request();
@@ -659,9 +686,10 @@ async fn reject_old_ios() {
     );
 
     let req = create_request(
-        http::Method::GET,
+        &http::Method::GET,
         "/1.5/42/info/collections",
         Some(headers.clone()),
+        None,
         None,
     )
     .to_request();
@@ -669,12 +697,13 @@ async fn reject_old_ios() {
     assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
 
     let req = create_request(
-        http::Method::POST,
+        &http::Method::POST,
         "/1.5/42/storage/tabs?batch=sammich",
         Some(headers),
         Some(json!([
             {"id": "123", "payload": "xxx", "sortindex": 23},
         ])),
+        None,
     )
     .to_request();
     let response = app.call(req).await.unwrap();
@@ -686,8 +715,14 @@ async fn reject_old_ios() {
 #[actix_rt::test]
 async fn info_configuration_xlm() {
     let app = init_app!().await;
-    let req =
-        create_request(http::Method::GET, "/1.5/42/info/configuration", None, None).to_request();
+    let req = create_request(
+        &http::Method::GET,
+        "/1.5/42/info/configuration",
+        None,
+        None,
+        None,
+    )
+    .to_request();
     let response = app.call(req).await.unwrap();
     assert_eq!(response.status(), StatusCode::OK);
     let xlm = response.headers().get(X_LAST_MODIFIED);
@@ -711,18 +746,26 @@ async fn overquota() {
     let app = init_app!(settings).await;
 
     // Clear out any data that's already in the store.
-    let req = create_request(http::Method::DELETE, "/1.5/42/storage", None, None).to_request();
+    let req = create_request(
+        &http::Method::DELETE,
+        "/1.5/42/storage",
+        None,
+        None,
+        Some(&settings),
+    )
+    .to_request();
     let resp = app.call(req).await.unwrap();
     assert!(resp.response().status().is_success());
 
     // Quota is enforced before the write, allowing one write to go over
     let req = create_request(
-        http::Method::PUT,
+        &http::Method::PUT,
         "/1.5/42/storage/xxx_col2/12345",
         None,
         Some(json!(
             {"payload": "*".repeat(500)}
         )),
+        Some(&settings),
     )
     .to_request();
     let response = app.call(req).await.unwrap();
@@ -733,12 +776,13 @@ async fn overquota() {
     actix_rt::time::sleep(Duration::from_millis(10)).await;
 
     let req = create_request(
-        http::Method::PUT,
+        &http::Method::PUT,
         "/1.5/42/storage/xxx_col2/12345",
         None,
         Some(json!(
             {"payload": "*".repeat(500)}
         )),
+        Some(&settings),
     )
     .to_request();
     let response = app.call(req).await.unwrap();
@@ -760,7 +804,14 @@ async fn overquota() {
 
     // XXX: this should run as cleanup regardless of test failure but it's
     // difficult. e.g. FutureExt::catch_unwind isn't compatible w/ actix-web
-    let req = create_request(http::Method::DELETE, "/1.5/42/storage", None, None).to_request();
+    let req = create_request(
+        &http::Method::DELETE,
+        "/1.5/42/storage",
+        None,
+        None,
+        Some(&settings),
+    )
+    .to_request();
     let resp = app.call(req).await.unwrap();
     assert!(resp.response().status().is_success());
 }
@@ -773,7 +824,14 @@ async fn lbheartbeat_max_pool_size_check() {
     let app = init_app!(settings).await;
 
     // Test all is well.
-    let lb_req = create_request(http::Method::GET, "/__lbheartbeat__", None, None).to_request();
+    let lb_req = create_request(
+        &http::Method::GET,
+        "/__lbheartbeat__",
+        None,
+        None,
+        Some(&settings),
+    )
+    .to_request();
     let sresp = app.call(lb_req).await.unwrap();
     let status = sresp.status();
     // Uncomment only for debugging purposes:
@@ -785,10 +843,11 @@ async fn lbheartbeat_max_pool_size_check() {
     headers.insert("TEST_CONNECTIONS", "10".to_owned());
     headers.insert("TEST_IDLES", "0".to_owned());
     let req = create_request(
-        http::Method::GET,
+        &http::Method::GET,
         "/__lbheartbeat__",
         Some(headers.clone()),
         None,
+        Some(&settings),
     )
     .to_request();
     let sresp = app.call(req).await.unwrap();
@@ -799,8 +858,14 @@ async fn lbheartbeat_max_pool_size_check() {
 
     // check duration for exhausted connections
     actix_rt::time::sleep(Duration::from_secs(1)).await;
-    let req =
-        create_request(http::Method::GET, "/__lbheartbeat__", Some(headers), None).to_request();
+    let req = create_request(
+        &http::Method::GET,
+        "/__lbheartbeat__",
+        Some(headers),
+        None,
+        Some(&settings),
+    )
+    .to_request();
     let sresp = app.call(req).await.unwrap();
     let status = sresp.status();
     let body = test::read_body(sresp).await;
@@ -815,8 +880,14 @@ async fn lbheartbeat_max_pool_size_check() {
     let mut headers: HashMap<&str, String> = HashMap::new();
     headers.insert("TEST_CONNECTIONS", "5".to_owned());
     headers.insert("TEST_IDLES", "5".to_owned());
-    let req =
-        create_request(http::Method::GET, "/__lbheartbeat__", Some(headers), None).to_request();
+    let req = create_request(
+        &http::Method::GET,
+        "/__lbheartbeat__",
+        Some(headers),
+        None,
+        Some(&settings),
+    )
+    .to_request();
     let sresp = app.call(req).await.unwrap();
     let status = sresp.status();
     // Uncomment only for debugging purposes:
@@ -832,13 +903,27 @@ async fn lbheartbeat_ttl_check() {
 
     let app = init_app!(settings).await;
 
-    let lb_req = create_request(http::Method::GET, "/__lbheartbeat__", None, None).to_request();
+    let lb_req = create_request(
+        &http::Method::GET,
+        "/__lbheartbeat__",
+        None,
+        None,
+        Some(&settings),
+    )
+    .to_request();
     let sresp = app.call(lb_req).await.unwrap();
     assert!(sresp.status().is_success());
 
     actix_rt::time::sleep(Duration::from_secs(3)).await;
 
-    let lb_req = create_request(http::Method::GET, "/__lbheartbeat__", None, None).to_request();
+    let lb_req = create_request(
+        &http::Method::GET,
+        "/__lbheartbeat__",
+        None,
+        None,
+        Some(&settings),
+    )
+    .to_request();
     let sresp = app.call(lb_req).await.unwrap();
     assert_eq!(sresp.status(), StatusCode::INTERNAL_SERVER_ERROR);
 }

--- a/syncserver/src/web/auth.rs
+++ b/syncserver/src/web/auth.rs
@@ -19,11 +19,15 @@ use tokenserver_auth::TokenserverOrigin;
 use actix_web::dev::ConnectionInfo;
 use actix_web::http::Uri;
 
+use crate::{
+    error::{ApiErrorKind, ApiResult},
+    server::ReverseProxyState,
+};
+
 use super::{
     error::{HawkErrorKind, ValidationErrorKind},
     extractors::RequestErrorLocation,
 };
-use crate::error::{ApiErrorKind, ApiResult};
 
 /// A parsed and authenticated JSON payload
 /// extracted from the signed `id` property
@@ -166,6 +170,7 @@ impl HawkPayload {
     pub fn extrude(
         header: &str,
         method: &str,
+        reverse_proxy_state: &ReverseProxyState,
         secrets: &Secrets,
         ci: &ConnectionInfo,
         uri: &Uri,
@@ -193,7 +198,15 @@ impl HawkPayload {
             Utc::now().timestamp() as u64
         };
 
-        HawkPayload::new(header, method, path.as_str(), host, port, secrets, expiry)
+        HawkPayload::new(
+            header,
+            method,
+            (reverse_proxy_state.get_webroot() + path.as_str()).as_str(),
+            host,
+            port,
+            secrets,
+            expiry,
+        )
     }
 }
 

--- a/syncserver/src/web/extractors/bso_put_request.rs
+++ b/syncserver/src/web/extractors/bso_put_request.rs
@@ -89,7 +89,7 @@ mod tests {
         auth::HawkPayload,
         extractors::test_utils::{
             SECRETS, TEST_HOST, TEST_PORT, USER_ID, USER_ID_STR, create_valid_hawk_header,
-            extract_body_as_str, make_db, make_state,
+            extract_body_as_str, make_db, make_reverse_proxy_state, make_state,
         },
     };
 
@@ -100,6 +100,7 @@ mod tests {
         let payload = HawkPayload::test_default(*USER_ID);
         let state = make_state();
         let secrets = Arc::clone(&SECRETS);
+        let reverse_proxy_state = make_reverse_proxy_state();
         let uri = format!("/1.5/{}/storage/tabs/asdf", *USER_ID);
         let header =
             create_valid_hawk_header(&payload, &secrets, "POST", &uri, TEST_HOST, TEST_PORT);
@@ -109,6 +110,7 @@ mod tests {
         let req = TestRequest::with_uri(&uri)
             .data(state)
             .data(secrets)
+            .data(reverse_proxy_state)
             .insert_header(("authorization", header))
             .insert_header(("content-type", "application/json"))
             .method(Method::POST)
@@ -133,6 +135,7 @@ mod tests {
         let payload = HawkPayload::test_default(*USER_ID);
         let state = make_state();
         let secrets = Arc::clone(&SECRETS);
+        let reverse_proxy_state = make_reverse_proxy_state();
         let uri = format!("/1.5/{}/storage/tabs/asdf", *USER_ID);
         let header =
             create_valid_hawk_header(&payload, &secrets, "POST", &uri, TEST_HOST, TEST_PORT);
@@ -142,6 +145,7 @@ mod tests {
         let req = TestRequest::with_uri(&uri)
             .data(state)
             .data(secrets)
+            .data(reverse_proxy_state)
             .insert_header(("authorization", header))
             .insert_header(("content-type", "application/json"))
             .method(Method::POST)

--- a/syncserver/src/web/extractors/bso_request.rs
+++ b/syncserver/src/web/extractors/bso_request.rs
@@ -64,7 +64,8 @@ mod tests {
         auth::HawkPayload,
         extractors::test_utils::{
             INVALID_BSO_NAME, SECRETS, TEST_HOST, TEST_PORT, USER_ID, USER_ID_STR,
-            create_valid_hawk_header, extract_body_as_str, make_db, make_state,
+            create_valid_hawk_header, extract_body_as_str, make_db, make_reverse_proxy_state,
+            make_state,
         },
     };
 
@@ -73,12 +74,14 @@ mod tests {
         let payload = HawkPayload::test_default(*USER_ID);
         let state = make_state();
         let secrets = Arc::clone(&SECRETS);
+        let reverse_proxy_state = make_reverse_proxy_state();
         let uri = format!("/1.5/{}/storage/tabs/asdf", *USER_ID);
         let header =
             create_valid_hawk_header(&payload, &secrets, "GET", &uri, TEST_HOST, TEST_PORT);
         let req = TestRequest::with_uri(&uri)
             .data(state)
             .data(secrets)
+            .data(reverse_proxy_state)
             .insert_header(("authorization", header))
             .method(Method::GET)
             .param("uid", USER_ID_STR.as_str())
@@ -98,12 +101,14 @@ mod tests {
         let payload = HawkPayload::test_default(*USER_ID);
         let state = make_state();
         let secrets = Arc::clone(&SECRETS);
+        let reverse_proxy_state = make_reverse_proxy_state();
         let uri = format!("/1.5/{}/storage/tabs/{}", *USER_ID, INVALID_BSO_NAME);
         let header =
             create_valid_hawk_header(&payload, &secrets, "GET", &uri, TEST_HOST, TEST_PORT);
         let req = TestRequest::with_uri(&uri)
             .data(state)
             .data(secrets)
+            .data(reverse_proxy_state)
             .insert_header(("authorization", header))
             .method(Method::GET)
             // `param` sets the value that would be extracted from the tokenized URI, as if the router did it.
@@ -136,6 +141,7 @@ mod tests {
         let altered_bso = format!("\"{{{}}}\"", *USER_ID);
         let state = make_state();
         let secrets = Arc::clone(&SECRETS);
+        let reverse_proxy_state = make_reverse_proxy_state();
         let uri = format!(
             "/1.5/{}/storage/tabs/{}",
             *USER_ID,
@@ -146,6 +152,7 @@ mod tests {
         let req = TestRequest::with_uri(&uri)
             .data(state)
             .data(secrets)
+            .data(reverse_proxy_state)
             .insert_header(("authorization", header))
             .insert_header(("accept", "application/json,text/plain:q=0.5"))
             .method(Method::GET)

--- a/syncserver/src/web/extractors/collection_request.rs
+++ b/syncserver/src/web/extractors/collection_request.rs
@@ -89,7 +89,8 @@ mod tests {
         auth::HawkPayload,
         extractors::test_utils::{
             INVALID_COLLECTION_NAME, SECRETS, TEST_HOST, TEST_PORT, USER_ID, USER_ID_STR,
-            create_valid_hawk_header, extract_body_as_str, make_db, make_state,
+            create_valid_hawk_header, extract_body_as_str, make_db, make_reverse_proxy_state,
+            make_state,
         },
     };
 
@@ -98,12 +99,14 @@ mod tests {
         let payload = HawkPayload::test_default(*USER_ID);
         let state = make_state();
         let secrets = Arc::clone(&SECRETS);
+        let reverse_proxy_state = make_reverse_proxy_state();
         let uri = format!("/1.5/{}/storage/tabs", *USER_ID);
         let header =
             create_valid_hawk_header(&payload, &secrets, "GET", &uri, TEST_HOST, TEST_PORT);
         let req = TestRequest::with_uri(&uri)
             .data(state)
             .data(secrets)
+            .data(reverse_proxy_state)
             .insert_header(("authorization", header))
             .insert_header(("accept", "application/json,text/plain:q=0.5"))
             .method(Method::GET)
@@ -122,6 +125,7 @@ mod tests {
         let hawk_payload = HawkPayload::test_default(*USER_ID);
         let state = make_state();
         let secrets = Arc::clone(&SECRETS);
+        let reverse_proxy_state = make_reverse_proxy_state();
         let uri = format!("/1.5/{}/storage/{}", *USER_ID, INVALID_COLLECTION_NAME);
         let header =
             create_valid_hawk_header(&hawk_payload, &secrets, "GET", &uri, TEST_HOST, TEST_PORT);
@@ -130,6 +134,7 @@ mod tests {
             .method(Method::GET)
             .data(state)
             .data(secrets)
+            .data(reverse_proxy_state)
             .param("uid", USER_ID_STR.as_str())
             .param("collection", INVALID_COLLECTION_NAME)
             .to_http_request();

--- a/syncserver/src/web/extractors/hawk_identifier.rs
+++ b/syncserver/src/web/extractors/hawk_identifier.rs
@@ -17,6 +17,7 @@ use tokenserver_auth::TokenserverOrigin;
 use super::{RequestErrorLocation, urldecode};
 use crate::{
     error::{ApiError, ApiErrorKind},
+    server::ReverseProxyState,
     web::{
         DOCKER_FLOW_ENDPOINTS,
         auth::HawkPayload,
@@ -97,6 +98,7 @@ impl HawkIdentifier {
         method: &str,
         uri: &Uri,
         ci: &ConnectionInfo,
+        reverse_proxy_state: &ReverseProxyState,
         secrets: &Secrets,
     ) -> Result<Self, Error>
     where
@@ -113,6 +115,7 @@ impl HawkIdentifier {
             .to_str()
             .map_err(|e| -> ApiError { HawkErrorKind::Header(e).into() })?;
         let identifier = Self::generate(
+            reverse_proxy_state,
             secrets,
             method,
             auth_header,
@@ -125,6 +128,7 @@ impl HawkIdentifier {
     }
 
     pub fn generate(
+        reverse_proxy_state: &ReverseProxyState,
         secrets: &Secrets,
         method: &str,
         header: &str,
@@ -132,7 +136,14 @@ impl HawkIdentifier {
         uri: &Uri,
         exts: &mut Extensions,
     ) -> Result<Self, Error> {
-        let payload = HawkPayload::extrude(header, method, secrets, connection_info, uri)?;
+        let payload = HawkPayload::extrude(
+            header,
+            method,
+            reverse_proxy_state,
+            secrets,
+            connection_info,
+            uri,
+        )?;
         let puid = Self::uid_from_path(uri)?;
         if payload.user_id != puid {
             warn!("⚠️ Hawk UID not in URI: {:?} {:?}", payload.user_id, uri);
@@ -186,6 +197,17 @@ impl FromRequest for HawkIdentifier {
         // NOTE: `connection_info()` will get a mutable reference lock on `extensions()`
         let connection_info = req.connection_info().clone();
         let method = req.method().clone();
+
+        let reverse_proxy_state: &ReverseProxyState =
+            match &req.app_data::<Data<ReverseProxyState>>() {
+                Some(data) => data,
+                None => {
+                    let err: ApiError =
+                        ApiErrorKind::Internal("No app_data ReverseProxyState".to_owned()).into();
+                    return future::ready(Err(err.into()));
+                }
+            };
+
         // Tried collapsing this to a `.or_else` and hit problems with the return resolving
         // to an appropriate error state. Can't use `?` since the function does not return a result.
         let secrets = match req.app_data::<Data<Arc<Secrets>>>() {
@@ -196,7 +218,14 @@ impl FromRequest for HawkIdentifier {
             }
         };
 
-        let result = Self::extrude(&req, method.as_str(), uri, &connection_info, secrets);
+        let result = Self::extrude(
+            &req,
+            method.as_str(),
+            uri,
+            &connection_info,
+            reverse_proxy_state,
+            secrets,
+        );
 
         if let Ok(ref hawk_id) = result {
             // Store the origin of the token as an extra to be included when emitting a Sentry error

--- a/syncserver/src/web/extractors/hawk_identifier.rs
+++ b/syncserver/src/web/extractors/hawk_identifier.rs
@@ -256,7 +256,7 @@ mod tests {
         auth::HawkPayload,
         extractors::test_utils::{
             SECRETS, TEST_HOST, TEST_PORT, USER_ID, USER_ID_STR, create_valid_hawk_header,
-            extract_body_as_str, make_state,
+            extract_body_as_str, make_reverse_proxy_state, make_state,
         },
     };
 
@@ -265,6 +265,7 @@ mod tests {
         let hawk_payload = HawkPayload::test_default(*USER_ID);
         let state = make_state();
         let secrets = Arc::clone(&SECRETS);
+        let reverse_proxy_state = make_reverse_proxy_state();
         let uri = format!("/1.5/{}/storage/col2", *USER_ID);
         let header =
             create_valid_hawk_header(&hawk_payload, &secrets, "GET", &uri, TEST_HOST, TEST_PORT);
@@ -273,6 +274,7 @@ mod tests {
             .method(Method::GET)
             .data(state)
             .data(secrets)
+            .data(reverse_proxy_state)
             .param("uid", USER_ID_STR.as_str())
             .to_http_request();
         let mut payload = Payload::None;
@@ -288,12 +290,14 @@ mod tests {
         let mismatch_uid = "5";
         let state = make_state();
         let secrets = Arc::clone(&SECRETS);
+        let reverse_proxy_state = make_reverse_proxy_state();
         let uri = format!("/1.5/{}/storage/col2", mismatch_uid);
         let header =
             create_valid_hawk_header(&hawk_payload, &secrets, "GET", &uri, TEST_HOST, TEST_PORT);
         let req = TestRequest::with_uri(&uri)
             .data(state)
             .data(secrets)
+            .data(reverse_proxy_state)
             .insert_header(("authorization", header))
             .method(Method::GET)
             .param("uid", mismatch_uid)

--- a/syncserver/src/web/extractors/test_utils.rs
+++ b/syncserver/src/web/extractors/test_utils.rs
@@ -23,7 +23,10 @@ use syncstorage_db::mock::{MockDb, MockDbPool};
 use syncstorage_settings::{Deadman, ServerLimits, Settings as SyncstorageSettings};
 
 use super::CollectionPostRequest;
-use crate::{server::ServerState, web::auth::HawkPayload};
+use crate::{
+    server::{ReverseProxyState, ServerState},
+    web::auth::HawkPayload,
+};
 
 lazy_static! {
     static ref SERVER_LIMITS: Arc<ServerLimits> = Arc::new(ServerLimits::default());
@@ -71,6 +74,10 @@ pub fn make_state() -> ServerState {
     }
 }
 
+pub fn make_reverse_proxy_state() -> ReverseProxyState {
+    ReverseProxyState { public_url: None }
+}
+
 pub fn extract_body_as_str(sresponse: ServiceResponse) -> String {
     String::from_utf8(block_on(test::read_body(sresponse)).to_vec()).unwrap()
 }
@@ -115,6 +122,7 @@ pub async fn post_collection(
     let payload = HawkPayload::test_default(*USER_ID);
     let state = make_state();
     let secrets = Arc::clone(&SECRETS);
+    let reverse_proxy_state = make_reverse_proxy_state();
     let path = format!(
         "/1.5/{}/storage/tabs{}{}",
         *USER_ID,
@@ -126,6 +134,7 @@ pub async fn post_collection(
     let req = TestRequest::with_uri(&format!("http://{}:{}{}", TEST_HOST, TEST_PORT, path))
         .data(state)
         .data(secrets)
+        .data(reverse_proxy_state)
         .method(Method::POST)
         .insert_header(("authorization", header))
         .insert_header(("content-type", "application/json; charset=UTF-8"))


### PR DESCRIPTION
## Description
Currently, hosting the SyncStorage service under any root URL other than `/` like, say, `/firefox-sync`, causes 401 HTTP error codes caused by mismatching Message Authentication Codes (or MACs for short) as pointed out by @ethowitz [here](https://github.com/mozilla-services/syncstorage-rs/issues/1217#issuecomment-1032845053).

Changes made in this PR add a new option `public_url` allowing users to specify the public facing URL to the root of the `syncserver`s services.

This `public_url` option is used for determining the original request uri and perform the MAC authentication properly.

## Things to Note
As explained by @kyz [here](https://github.com/mozilla-services/syncstorage-rs/issues/1649#issuecomment-2704651360), the host and port for performing the MAC authentication are taken from the `Forwarded` or the `X-Forwarded-For` and `X-Forwarded-Scheme` etc. headers:

https://github.com/mozilla-services/syncstorage-rs/blob/8c56cae8905325345972a4abe99c12c1fc1b012c/syncserver/src/web/auth.rs#L177-L193

It might be a good idea to swap this to perform the authentication based on `public_url` if specified, instead. However, I **did not** include this in this PR and I would love to hear what other people think about this.

## Testing

1. Spin up a `syncserver` which is hosted under a root other than `/`, for example: `http://localhost:8080/firefox-sync`:
   ```yml
   services:
     web:
       image: nginxproxy/nginx-proxy
       restart: unless-stopped
       ports:
         - 127.0.0.1:8080:80
       environment:
         DEFAULT_HOST: sync.example.com
       volumes:
         - /var/run/docker.sock:/tmp/docker.sock:ro
     sync-server:
       build:
         context: .
         dockerfile_inline: |
           FROM rust AS build
           ARG SYNC_STORAGE_VERSION=0.18.2
           RUN git clone https://github.com/mozilla-services/syncstorage-rs -b $${SYNC_STORAGE_VERSION} /app
           WORKDIR /app
   
           RUN \
             apt-get update \
             && apt-get install -y libpython3-dev \
             && cargo install --path ./syncserver --features mysql --locked \
             && cargo clean \
             && apt-get remove -y libpython3-dev \
             && rm -rf /var/lib/apt/lists \
             && bash -O extglob -c 'rm -rf /usr/local/cargo/!(bin)' \
             && bash -O extglob -c 'rm -rf /usr/local/cargo/bin/!(syncserver)'
   
           FROM python:3.11 AS sync
           COPY --from=build /usr/local/cargo/bin/syncserver /usr/local/bin
           COPY --from=build /app/requirements.txt .
           RUN pip install -r requirements.txt
           CMD [ "/usr/local/bin/syncserver" ]
         target: sync
       restart: unless-stopped
       environment:
         VIRTUAL_PORT: 80
         VIRTUAL_PATH: "/firefox-sync/"
         VIRTUAL_DEST: "/"
         VIRTUAL_HOST: sync.example.com
         RUST_LOG: warn
         SYNC_HUMAN_LOGS: 1
         SYNC_HOST: "0.0.0.0"
         SYNC_PORT: 80
         SYNC_MASTER_SECRET: secret
         SYNC_SYNCSTORAGE__ENABLED: "true"
         SYNC_SYNCSTORAGE__DATABASE_URL: mysql://sync:password@sync-db/SyncStorage
         SYNC_SYNCSTORAGE__ENABLE_QUOTA: 0
         SYNC_TOKENSERVER__ENABLED: "true"
         SYNC_TOKENSERVER__DATABASE_URL: mysql://token:password@token-db/TokenServer
         SYNC_TOKENSERVER__RUN_MIGRATIONS: "true"
         SYNC_TOKENSERVER__FXA_METRICS_HASH_SECRET: secret
         SYNC_TOKENSERVER__FXA_EMAIL_DOMAIN: api.accounts.firefox.com
         SYNC_TOKENSERVER__FXA_OAUTH_SERVER_URL: https://oauth.accounts.firefox.com
         SYNC_TOKENSERVER__FXA_BROWSERID_AUDIENCE: https://token.services.mozilla.com
         SYNC_TOKENSERVER__FXA_BROWSERID_ISSUER: https://api.accounts.firefox.com
         SYNC_TOKENSERVER__FXA_BROWSERID_SERVER_URL: https://verifier.accounts.firefox.com/v2
       expose:
         - 80
     sync-db:
       image: mariadb
       restart: unless-stopped
       environment:
         MARIADB_RANDOM_ROOT_PASSWORD: "yes"
         MARIADB_USER: sync
         MARIADB_PASSWORD: password
         MARIADB_DATABASE: SyncStorage
     token-db:
       build:
         context: .
         dockerfile_inline: |
           FROM rust AS build
           ARG SYNC_STORAGE_VERSION=0.18.2
           RUN git clone https://github.com/mozilla-services/syncstorage-rs -b $${SYNC_STORAGE_VERSION} /app
   
           RUN \
             cargo install diesel_cli --no-default-features --features mysql --locked \
             && bash -O extglob -c 'rm -rf /usr/local/cargo/!(bin)' \
             && bash -O extglob -c 'rm -rf /usr/local/cargo/bin/!(diesel)'
   
           FROM mariadb AS db
           RUN mkdir -p /app/tokenserver-db
           COPY --from=build /app/tokenserver-db/migrations /app/tokenserver-db/migrations
           COPY --from=build /usr/local/cargo/bin/diesel /usr/local/bin
   
           RUN { \
               echo '#!/bin/bash'; \
               echo 'diesel --database-url "mysql://$${MARIADB_USER}:$${MARIADB_PASSWORD}@localhost/$${MARIADB_DATABASE}" migration --migration-dir /app/tokenserver-db/migrations run'; \
               echo 'mariadb -u$$MARIADB_USER -p$$MARIADB_PASSWORD -D $$MARIADB_DATABASE <<EOF'; \
               echo 'INSERT INTO services (service, pattern)'; \
               echo "SELECT 'sync-1.5', '{node}/1.5/{uid}'"; \
               echo "WHERE NOT EXISTS (SELECT 1 FROM services);"; \
               echo ""; \
               echo 'INSERT INTO nodes (\`service\`, node, capacity, available, current_load, downed, backoff)'; \
               echo "SELECT LAST_INSERT_ID(), 'http://localhost:8080/firefox-sync', 1, 1, 0, 0, 0"; \
               echo "WHERE LAST_INSERT_ID() > 0;"; \
               echo "EOF"; \
             } > /docker-entrypoint-initdb.d/tokenserver-db.sh
       restart: unless-stopped
       environment:
         MARIADB_RANDOM_ROOT_PASSWORD: "yes"
         MARIADB_USER: token
         MARIADB_PASSWORD: password
         MARIADB_DATABASE: TokenServer
   ```
2. Try to sync your browser against `http://localhost:8080/firefox-sync/1.0/sync/1.5`
3. Take note that any request pointing to `http://localhost:8080/firefox-sync/1.5/*` fail with a 401 HTTP code

## Issue(s)

Closes #1217 and closes #1649.