### PR TITLE
chore: audit ignore RUSTSEC-2024-0437

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -2,4 +2,5 @@
 ignore = [
        "RUSTSEC-2024-0365", # Bound by diesel 1.4 (4GB limit n/a to tokenserver)
        "RUSTSEC-2024-0421", # Bound by diesel 1.4, `idna`  < 0.1.5, Upgrade to >=1.0.0
+       "RUSTSEC-2024-0437", # Bound by grpcio 0.13
 ]


### PR DESCRIPTION
## Description

Describe these changes.

> **NOTE:** We can only accept PRS with all commits [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#ssh-commit-verification). PRs that contain _any_ unsigned commits will not be accepted and the PR _must_ be resubmitted. If this is something you cannot provide, please disclose and a team member _may_ duplicate the PR as signed for you (depending on availablity and priority. Thank you for your understanding and cooperation.)

When I merged in my last pr for [adding nextest](https://github.com/mozilla-services/syncstorage-rs/pull/1651), a break from `cargo audit` snuck in, but it can't be resolved with an upgrade.

## Testing

How should reviewers test?

## Issue(s)

Closes [link](link).
