### PR TITLE
chore: switch back to libmariadb-dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
+ARG DATABASE_BACKEND=spanner
+# Alternatively MYSQLCLIENT_PKG=libmysqlclient-dev for the Oracle/MySQL official client
+ARG MYSQLCLIENT_PKG=libmariadb-dev-compat
+
 # NOTE: Ensure builder's Rust version matches CI's in .circleci/config.yml
-FROM docker.io/lukemathwalker/cargo-chef:0.1.67-rust-1.81-bullseye as chef
+FROM docker.io/lukemathwalker/cargo-chef:0.1.67-rust-1.81-bullseye AS chef
 WORKDIR /app
 
 FROM chef AS planner
@@ -7,37 +11,42 @@ COPY . .
 RUN cargo chef prepare --recipe-path recipe.json
 
 FROM chef AS cacher
-ARG DATABASE_BACKEND=spanner
+ARG DATABASE_BACKEND
+ARG MYSQLCLIENT_PKG
 
 # cmake is required to build grpcio-sys for Spanner builds
 RUN \
-    # Fetch and load the MySQL public key. We need to install libmysqlclient-dev to build syncstorage-rs
-    # which wants the mariadb
-    wget -qO- https://repo.mysql.com/RPM-GPG-KEY-mysql-2023 > /etc/apt/trusted.gpg.d/mysql.asc && \
-    echo "deb https://repo.mysql.com/apt/debian/ bullseye mysql-8.0" >> /etc/apt/sources.list && \
+    if [ "$MYSQLCLIENT_PKG" = libmysqlclient-dev ] ; then \
+        # Fetch and load the MySQL public key.
+        wget -qO- https://repo.mysql.com/RPM-GPG-KEY-mysql-2023 > /etc/apt/trusted.gpg.d/mysql.asc && \
+        echo "deb https://repo.mysql.com/apt/debian/ bullseye mysql-8.0" >> /etc/apt/sources.list ; \
+    fi && \
     apt-get -q update && \
-    apt-get -q install -y --no-install-recommends libmysqlclient-dev cmake
+    apt-get -q install -y --no-install-recommends $MYSQLCLIENT_PKG cmake
 
 COPY --from=planner /app/recipe.json recipe.json
 RUN cargo chef cook --release --no-default-features --features=syncstorage-db/$DATABASE_BACKEND --features=py_verifier --recipe-path recipe.json
 
-FROM chef as builder
-ARG DATABASE_BACKEND=spanner
+FROM chef AS builder
+ARG DATABASE_BACKEND
+ARG MYSQLCLIENT_PKG
 
 COPY . /app
 COPY --from=cacher /app/target /app/target
 COPY --from=cacher $CARGO_HOME /app/$CARGO_HOME
 
 RUN \
-    # Fetch and load the MySQL public key
-    wget -qO- https://repo.mysql.com/RPM-GPG-KEY-mysql-2023 > /etc/apt/trusted.gpg.d/mysql.asc && \
-    echo "deb https://repo.mysql.com/apt/debian/ bullseye mysql-8.0" >> /etc/apt/sources.list && \
-    # mysql_pubkey.asc from:
-    # https://dev.mysql.com/doc/refman/8.0/en/checking-gpg-signature.html
-    # related:
-    # https://dev.mysql.com/doc/mysql-apt-repo-quick-guide/en/#repo-qg-apt-repo-manual-setup
+    if [ "$MYSQLCLIENT_PKG" = libmysqlclient-dev ] ; then \
+        # Fetch and load the MySQL public key.
+        # mysql_pubkey.asc from:
+        # https://dev.mysql.com/doc/refman/8.0/en/checking-gpg-signature.html
+        # related:
+        # https://dev.mysql.com/doc/mysql-apt-repo-quick-guide/en/#repo-qg-apt-repo-manual-setup
+        wget -qO- https://repo.mysql.com/RPM-GPG-KEY-mysql-2023 > /etc/apt/trusted.gpg.d/mysql.asc && \
+        echo "deb https://repo.mysql.com/apt/debian/ bullseye mysql-8.0" >> /etc/apt/sources.list ; \
+    fi && \
     apt-get -q update && \
-    apt-get -q install -y --no-install-recommends libmysqlclient-dev cmake golang-go python3-dev python3-pip python3-setuptools python3-wheel && \
+    apt-get -q install -y --no-install-recommends $MYSQLCLIENT_PKG cmake golang-go python3-dev python3-pip python3-setuptools python3-wheel && \
     pip3 install -r requirements.txt && \
     rm -rf /var/lib/apt/lists/*
 
@@ -50,6 +59,8 @@ RUN \
     if [ "$DATABASE_BACKEND" = "spanner" ] ; then cargo install --path ./syncstorage-spanner --locked --root /app --bin purge_ttl ; fi
 
 FROM docker.io/library/debian:bullseye-slim
+ARG MYSQLCLIENT_PKG
+
 WORKDIR /app
 COPY --from=builder /app/requirements.txt /app
 # Due to a build error that occurs with the Python cryptography package, we
@@ -65,16 +76,18 @@ RUN \
 RUN \
     groupadd --gid 10001 app && \
     useradd --uid 10001 --gid 10001 --home /app --create-home app && \
-    # first, an apt-get update is required for gnupg, which is required for apt-key adv
-    apt-get -q update && \
-    # and ca-certificates needed for https://repo.mysql.com
-    apt-get install -y gnupg ca-certificates wget && \
-    # Fetch and load the MySQL public key
-    echo "deb https://repo.mysql.com/apt/debian/ bullseye mysql-8.0" >> /etc/apt/sources.list && \
-    wget -qO- https://repo.mysql.com/RPM-GPG-KEY-mysql-2023 > /etc/apt/trusted.gpg.d/mysql.asc && \
+    if [ "$MYSQLCLIENT_PKG" = libmysqlclient-dev ] ; then \
+        # first, an apt-get update is required for gnupg, which is required for apt-key adv
+        apt-get -q update && \
+        # and ca-certificates needed for https://repo.mysql.com
+        apt-get install -y gnupg ca-certificates wget && \
+        # Fetch and load the MySQL public key
+        echo "deb https://repo.mysql.com/apt/debian/ bullseye mysql-8.0" >> /etc/apt/sources.list && \
+        wget -qO- https://repo.mysql.com/RPM-GPG-KEY-mysql-2023 > /etc/apt/trusted.gpg.d/mysql.asc ; \
+    fi && \
     # update again now that we trust repo.mysql.com
     apt-get -q update && \
-    apt-get -q install -y build-essential libmysqlclient-dev libssl-dev libffi-dev libcurl4 python3-dev python3-pip python3-setuptools python3-wheel cargo curl jq && \
+    apt-get -q install -y build-essential $MYSQLCLIENT_PKG libssl-dev libffi-dev libcurl4 python3-dev python3-pip python3-setuptools python3-wheel cargo curl jq && \
     # The python3-cryptography debian package installs version 2.6.1, but we
     # we want to use the version specified in requirements.txt. To do this,
     # we have to remove the python3-cryptography package here.


### PR DESCRIPTION
as it builds on more architectures (such as arm64) and we no longer require its TLS support

derived from ghagl's and tommie's PRs (thanks!)
https://github.com/mozilla-services/syncstorage-rs/pull/1635 https://github.com/mozilla-services/syncstorage-rs/pull/1644

Closes SYNC-4690