### PR TITLE
Bump Version in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 default-members = ["syncserver"]
 
 [workspace.package]
-version = "0.17.15"
+version = "0.18.2"
 authors = [
   "Ben Bangert <ben@groovie.org>",
   "Phil Jenvey <pjenvey@underboss.org>",


### PR DESCRIPTION
Bumps Cargo.toml version from 0.17.15 to 0.18.2 to match the github release version, as heartbeat still shows version as "0.17.15" even when you are on latest version

![image](https://github.com/user-attachments/assets/40b6a7e0-651a-4790-8d68-b00e3417a9d4)
