### PR TITLE
fix(infra): configure gcp utils before upload

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,7 +158,7 @@ commands:
           environment:
             SYNCSTORAGE_RS_IMAGE: app:build
 
-  upload-to-gcs:
+  gcs-configure-and-upload:
     parameters:
       source:
         type: string
@@ -168,6 +168,10 @@ commands:
         type: enum
         enum: ["xml", "json"]
     steps:
+      - gcp-cli/setup:
+          google_project_id: ETE_GOOGLE_PROJECT_ID
+          gcloud_service_key: ETE_GCLOUD_SERVICE_KEY
+          google_project_number: ETE_GOOGLE_PROJECT_NUMBER
       - run:
           name: Upload << parameters.source >> << parameters.extension >> Files to GCS
           when: always  # Ensure the step runs even if previous steps, like test runs, fail
@@ -247,10 +251,6 @@ jobs:
             MYSQL_DATABASE: syncstorage
     resource_class: large
     steps:
-      - gcp-cli/setup:
-          google_project_id: ETE_GOOGLE_PROJECT_ID
-          gcloud_service_key: ETE_GCLOUD_SERVICE_KEY
-          google_project_number: ETE_GOOGLE_PROJECT_NUMBER
       - checkout
       - display-versions
       - setup-python
@@ -268,11 +268,11 @@ jobs:
       # then run-tokenserver-scripts-tests will fail. These tests expect the db to be
       # configured already, and it appears unit-tests modify the db to the expected state
       - store-test-results
-      - upload-to-gcs:
+      - gcs-configure-and-upload:
           source: workflow/test-results
           destination: gs://ecosystem-test-eng-metrics/syncstorage-rs/junit
           extension: xml
-      - upload-to-gcs:
+      - gcs-configure-and-upload:
           source: workflow/test-results
           destination: gs://ecosystem-test-eng-metrics/syncstorage-rs/coverage
           extension: json
@@ -432,7 +432,7 @@ jobs:
       - run-e2e-tests:
           db: mysql
       - store-test-results
-      - upload-to-gcs:
+      - gcs-configure-and-upload:
           source: workflow/test-results
           destination: gs://ecosystem-test-eng-metrics/syncstorage-rs/junit
           extension: xml
@@ -461,7 +461,7 @@ jobs:
       - run-e2e-tests:
           db: spanner
       - store-test-results
-      - upload-to-gcs:
+      - gcs-configure-and-upload:
           source: workflow/test-results
           destination: gs://ecosystem-test-eng-metrics/syncstorage-rs/junit
           extension: xml


### PR DESCRIPTION
## Description

I broke the build on master because the final step for e2e tests tries to upload to GCS without being authenticated with GCP first. This just moves the authentication into the same command so we don't have to remember to add the auth step. It also cleans up other references to the step

- Move authentication setup for GCP into upload command
- Update name to be more descriptive for gcs upload
- Update references to use new name and remove redundant GCP authentication setup

Closes STOR-255

> **NOTE:** We can only accept PRS with all commits [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#ssh-commit-verification). PRs that contain _any_ unsigned commits will not be accepted and the PR _must_ be resubmitted. If this is something you cannot provide, please disclose and a team member _may_ duplicate the PR as signed for you (depending on availablity and priority. Thank you for your understanding and cooperation.)

## Testing

[Here](https://app.circleci.com/pipelines/github/mozilla-services/syncstorage-rs/5761/workflows/a35d04fe-65db-41ad-a3b1-a9ee7b2d1da8/jobs/23402) is a run where I tested with my branch name to see it work. The interesting caveat with this change is that we now see duplicate steps for configuring if upload needs to happen multiple times, here's an example: 

<img width="1704" alt="image" src="https://github.com/user-attachments/assets/366a5782-07c9-4839-967b-6b5f9c645535" />


If we don't like this I can revert it and make sure the configure step is explicitly called everywhere it's needed!

## Issue(s)

Closes [STOR-255](https://mozilla-hub.atlassian.net/browse/STOR-255).


[STOR-255]: https://mozilla-hub.atlassian.net/browse/STOR-255?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ