### PR TITLE
refactor: quiet dbg calls

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,14 +63,12 @@ commands:
     steps:
       - run:
           name: Rust Clippy MySQL
-          command: |
-            cargo clippy --workspace --all-targets --no-default-features --features=syncstorage-db/mysql --features=py_verifier -- -D clippy::dbg_macro -D warnings
+          command: make clippy_mysql
   rust-clippy-spanner:
     steps:
       - run:
           name: Rust Clippy Spanner
-          command: |
-            cargo clippy --workspace --all-targets --no-default-features --features=syncstorage-db/spanner --features=py_verifier -- -D clippy::dbg_macro -D warnings
+          command: make clippy_spanner
   setup-mysql:
     steps:
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@
 # To avoid collision with other GCP connections we create specific vars for
 # the ETE Test Pipeline.
 # ETE_GOOGLE_PROJECT_ID     - GCP Project ID for ecosystem-test-eng
-# ETE_GCLOUD_SERVICE_KEY    - GCP syncstorage specific Service Account JSON Key 
+# ETE_GCLOUD_SERVICE_KEY    - GCP syncstorage specific Service Account JSON Key
 # ETE_GOOGLE_PROJECT_NUMBER - GCP Project Number for ecosystem-test-eng
 #
 version: 2.1
@@ -64,13 +64,13 @@ commands:
       - run:
           name: Rust Clippy MySQL
           command: |
-            cargo clippy --workspace --all-targets --no-default-features --features=syncstorage-db/mysql --features=py_verifier -- -D warnings
+            cargo clippy --workspace --all-targets --no-default-features --features=syncstorage-db/mysql --features=py_verifier -- -D clippy::dbg_macro -D warnings
   rust-clippy-spanner:
     steps:
       - run:
           name: Rust Clippy Spanner
           command: |
-            cargo clippy --workspace --all-targets --no-default-features --features=syncstorage-db/spanner --features=py_verifier -- -D warnings
+            cargo clippy --workspace --all-targets --no-default-features --features=syncstorage-db/spanner --features=py_verifier -- -D clippy::dbg_macro -D warnings
   setup-mysql:
     steps:
       - run:
@@ -99,7 +99,7 @@ commands:
 
   install-test-deps:
     steps:
-      - run: 
+      - run:
           name: Install test dependencies
           command: cargo install --locked cargo-nextest cargo-llvm-cov
 
@@ -118,7 +118,7 @@ commands:
           name: nextest with code coverage (quota enforced)
           command: make test_with_coverage
           environment:
-              SYNC_SYNCSTORAGE__ENFORCE_QUOTA: 1
+            SYNC_SYNCSTORAGE__ENFORCE_QUOTA: 1
 
   merge-unit-test-coverage:
     steps:
@@ -140,11 +140,11 @@ commands:
           when: always
           name: Tokenserver integration tests
           command: |
-              # NOTE: Python3.12 requires `--break-system-packages`.
-              # This command is run on the circleci/rust image, which is running python 3.10
-               make run_token_server_integration_tests
+            # NOTE: Python3.12 requires `--break-system-packages`.
+            # This command is run on the circleci/rust image, which is running python 3.10
+             make run_token_server_integration_tests
           environment:
-              SYNCSTORAGE_RS_IMAGE: app:build
+            SYNCSTORAGE_RS_IMAGE: app:build
   run-e2e-tests:
     parameters:
       db:
@@ -174,7 +174,7 @@ commands:
           google_project_number: ETE_GOOGLE_PROJECT_NUMBER
       - run:
           name: Upload << parameters.source >> << parameters.extension >> Files to GCS
-          when: always  # Ensure the step runs even if previous steps, like test runs, fail
+          when: always # Ensure the step runs even if previous steps, like test runs, fail
           command: |
             if [ "$CIRCLE_BRANCH" = "master" ]; then
               FILES=$(ls -1 << parameters.source>>/*.<< parameters.extension>> )
@@ -213,7 +213,7 @@ commands:
 jobs:
   checks:
     docker:
-      - image: cimg/rust:1.86  # RUST_VER
+      - image: cimg/rust:1.86 # RUST_VER
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
@@ -230,25 +230,25 @@ jobs:
 
   build-and-test:
     docker:
-      - image: cimg/rust:1.86  # RUST_VER
+      - image: cimg/rust:1.86 # RUST_VER
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
         environment:
-            SYNC_SYNCSTORAGE__DATABASE_URL: mysql://test:test@127.0.0.1/syncstorage
-            SYNC_TOKENSERVER__DATABASE_URL: mysql://test:test@127.0.0.1/tokenserver
-            RUST_BACKTRACE: 1
-            # XXX: begin_test_transaction doesn't play nice over threaded tests
-            RUST_TEST_THREADS: 1
+          SYNC_SYNCSTORAGE__DATABASE_URL: mysql://test:test@127.0.0.1/syncstorage
+          SYNC_TOKENSERVER__DATABASE_URL: mysql://test:test@127.0.0.1/tokenserver
+          RUST_BACKTRACE: 1
+          # XXX: begin_test_transaction doesn't play nice over threaded tests
+          RUST_TEST_THREADS: 1
       - image: cimg/mysql:5.7
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
         environment:
-            MYSQL_ROOT_PASSWORD: password
-            MYSQL_USER: test
-            MYSQL_PASSWORD: test
-            MYSQL_DATABASE: syncstorage
+          MYSQL_ROOT_PASSWORD: password
+          MYSQL_USER: test
+          MYSQL_PASSWORD: test
+          MYSQL_DATABASE: syncstorage
     resource_class: large
     steps:
       - checkout
@@ -279,7 +279,7 @@ jobs:
       #- save-sccache-cache
   build-mysql-image:
     docker:
-      - image: cimg/rust:1.86  # RUST_VER
+      - image: cimg/rust:1.86 # RUST_VER
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
@@ -293,9 +293,9 @@ jobs:
       - run:
           name: Build MySQL Docker image
           command: >
-              docker build -t app:build
-              --build-arg DATABASE_BACKEND=mysql
-              .
+            docker build -t app:build
+            --build-arg DATABASE_BACKEND=mysql
+            .
           no_output_timeout: 30m
       # save the built docker container into CircleCI's cache. This is
       # required since Workflows do not have the same remote docker instance.
@@ -316,7 +316,7 @@ jobs:
             - /home/circleci/cache
   build-spanner-image:
     docker:
-      - image: cimg/rust:1.86  # RUST_VER
+      - image: cimg/rust:1.86 # RUST_VER
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
@@ -331,10 +331,10 @@ jobs:
           name: Build Spanner Docker image
           # Build w/ the Oracle libmysqlclient-dev for TLS support
           command: >
-              docker build -t app:build
-              --build-arg DATABASE_BACKEND=spanner
-              --build-arg MYSQLCLIENT_PKG=libmysqlclient-dev
-              .
+            docker build -t app:build
+            --build-arg DATABASE_BACKEND=spanner
+            --build-arg MYSQLCLIENT_PKG=libmysqlclient-dev
+            .
           no_output_timeout: 30m
       # save the built docker container into CircleCI's cache. This is
       # required since Workflows do not have the same remote docker instance.

--- a/Makefile
+++ b/Makefile
@@ -35,11 +35,11 @@ PYTHON_SITE_PACKGES = $(shell $(SRC_ROOT)/venv/bin/python -c "from distutils.sys
 
 clippy_mysql:
 	# Matches what's run in circleci
-	cargo clippy --workspace --all-targets --no-default-features --features=syncstorage-db/mysql --features=py_verifier -- -D warnings
+	cargo clippy --workspace --all-targets --no-default-features --features=syncstorage-db/mysql --features=py_verifier -- -D clippy::dbg_macro -D warnings
 
 clippy_spanner:
 	# Matches what's run in circleci
-	cargo clippy --workspace --all-targets --no-default-features --features=syncstorage-db/spanner --features=py_verifier -- -D warnings
+	cargo clippy --workspace --all-targets --no-default-features --features=syncstorage-db/spanner --features=py_verifier -- -D clippy::dbg_macro -D warnings
 
 clean:
 	cargo clean

--- a/syncserver/src/server/test.rs
+++ b/syncserver/src/server/test.rs
@@ -267,7 +267,7 @@ where
 
     if !sresponse.response().status().is_success() {
         trace!(
-            "⚠️ Warning: Returned error",
+            "⚠️ Warning: Returned error with status: {} and response: {:?}",
             sresponse.response().status(),
             sresponse.response()
         );

--- a/syncserver/src/server/test.rs
+++ b/syncserver/src/server/test.rs
@@ -266,7 +266,7 @@ where
     };
 
     if !sresponse.response().status().is_success() {
-        dbg!(
+        trace!(
             "⚠️ Warning: Returned error",
             sresponse.response().status(),
             sresponse.response()
@@ -770,6 +770,7 @@ async fn lbheartbeat_max_pool_size_check() {
     let lb_req = create_request(http::Method::GET, "/__lbheartbeat__", None, None).to_request();
     let sresp = app.call(lb_req).await.unwrap();
     let status = sresp.status();
+    // Uncomment only for debugging purposes:
     // dbg!(status, test::read_body(sresp).await);
     assert!(status.is_success());
 
@@ -786,6 +787,7 @@ async fn lbheartbeat_max_pool_size_check() {
     .to_request();
     let sresp = app.call(req).await.unwrap();
     let status = sresp.status();
+    // Uncomment only for debugging purposes:
     // dbg!(status, test::read_body(sresp).await);
     assert!(status == StatusCode::INTERNAL_SERVER_ERROR);
 
@@ -798,6 +800,7 @@ async fn lbheartbeat_max_pool_size_check() {
     let body = test::read_body(sresp).await;
     let resp: HashMap<String, serde_json::value::Value> =
         serde_json::de::from_str(std::str::from_utf8(body.as_ref()).unwrap()).unwrap();
+    // Uncomment only for debugging purposes:
     // dbg!(status, body, &resp);
     assert!(status == StatusCode::INTERNAL_SERVER_ERROR);
     assert!(resp.get("duration_ms").unwrap().as_u64().unwrap() > 1000);
@@ -810,6 +813,7 @@ async fn lbheartbeat_max_pool_size_check() {
         create_request(http::Method::GET, "/__lbheartbeat__", Some(headers), None).to_request();
     let sresp = app.call(req).await.unwrap();
     let status = sresp.status();
+    // Uncomment only for debugging purposes:
     // dbg!(status, test::read_body(sresp).await);
     assert!(status == StatusCode::OK);
 }

--- a/syncserver/src/web/handlers.rs
+++ b/syncserver/src/web/handlers.rs
@@ -645,7 +645,6 @@ pub async fn lbheartbeat(req: HttpRequest) -> Result<HttpResponse, ApiError> {
             )
             .unwrap_or_default(),
         };
-        // dbg!(&test_pool, deadman.max_size);
         test_pool
     } else {
         state.db_pool.clone().state()


### PR DESCRIPTION
## Description
Removed `dbg!` call and annotated some commented out calls in testing that indicate it should only be used in testing.

Added a command in the two clippy commands, in the Makefile and CI, to deny the use of `dbg!` macro calls.

See clippy docs here for [dbg_macro](https://rust-lang.github.io/rust-clippy/master/index.html#dbg_macro)

## Testing

Run clippy

## Issue(s)

Closes [STOR-79](https://mozilla-hub.atlassian.net/browse/STOR-79).


[STOR-79]: https://mozilla-hub.atlassian.net/browse/STOR-79?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ