### PR TITLE
bug : fix stream one or none

### DIFF
--- a/syncstorage-spanner/src/batch.rs
+++ b/syncstorage-spanner/src/batch.rs
@@ -319,7 +319,7 @@ pub async fn do_append_async(
         .params(sqlparams)
         .param_types(sqlparam_types)
         .execute_async(&db.conn)?;
-    while let Some(row) = existing_stream.next_async().await? {
+    while let Some(row) = existing_stream.try_next().await? {
         existing.insert(exist_idx(
             &collection_id.to_string(),
             &batch.id,

--- a/syncstorage-spanner/src/batch.rs
+++ b/syncstorage-spanner/src/batch.rs
@@ -319,8 +319,7 @@ pub async fn do_append_async(
         .params(sqlparams)
         .param_types(sqlparam_types)
         .execute_async(&db.conn)?;
-    while let Some(row) = existing_stream.next_async().await {
-        let row = row?;
+    while let Some(row) = existing_stream.next_async().await? {
         existing.insert(exist_idx(
             &collection_id.to_string(),
             &batch.id,

--- a/syncstorage-spanner/src/models.rs
+++ b/syncstorage-spanner/src/models.rs
@@ -1412,8 +1412,7 @@ impl SpannerDb {
 
         let mut ids = vec![];
         let mut modifieds = vec![];
-        while let Some(row) = stream.try_next().await? {
-            let mut row = row;
+        while let Some(mut row) = stream.try_next().await? {
             ids.push(row[0].take_string_value());
             modifieds.push(sync_timestamp_from_rfc3339(row[1].get_string_value())?.as_i64());
         }
@@ -1589,8 +1588,7 @@ impl SpannerDb {
             .param_types(sqlparam_types)
             .execute_async(&self.conn)?;
         let mut existing = HashSet::new();
-        while let Some(row) = streaming.try_next().await? {
-            let mut row = row;
+        while let Some(mut row) = streaming.try_next().await? {
             existing.insert(row[0].take_string_value());
         }
         let mut inserts = vec![];

--- a/syncstorage-spanner/src/models.rs
+++ b/syncstorage-spanner/src/models.rs
@@ -604,7 +604,7 @@ impl SpannerDb {
             .param_types(sqlparam_types)
             .execute_async(&self.conn)?;
         let mut results = HashMap::new();
-        while let Some(row) = streaming.next_async().await? {
+        while let Some(row) = streaming.try_next().await? {
             let collection_id = row[0]
                 .get_string_value()
                 .parse::<i32>()
@@ -658,8 +658,7 @@ impl SpannerDb {
                 )?
                 .params(params)
                 .execute_async(&self.conn)?;
-            while let Some(row) = rs.next_async().await? {
-                let mut row = row;
+            while let Some(mut row) = rs.try_next().await? {
                 let id = row[0]
                     .get_string_value()
                     .parse::<i32>()
@@ -696,7 +695,7 @@ impl SpannerDb {
             .param_types(sqlparam_types)
             .execute_async(&self.conn)?;
         let mut counts = HashMap::new();
-        while let Some(row) = streaming.next_async().await? {
+        while let Some(row) = streaming.try_next().await? {
             let collection_id = row[0]
                 .get_string_value()
                 .parse::<i32>()
@@ -731,7 +730,7 @@ impl SpannerDb {
             .param_types(sqlparam_types)
             .execute_async(&self.conn)?;
         let mut usages = HashMap::new();
-        while let Some(row) = streaming.next_async().await? {
+        while let Some(row) = streaming.try_next().await? {
             let collection_id = row[0]
                 .get_string_value()
                 .parse::<i32>()
@@ -1372,7 +1371,7 @@ impl SpannerDb {
 
         let mut streaming = self.bsos_query_async(query, params).await?;
         let mut bsos = vec![];
-        while let Some(row) = streaming.next_async().await? {
+        while let Some(row) = streaming.try_next().await? {
             bsos.push(bso_from_row(row)?);
         }
 
@@ -1413,7 +1412,7 @@ impl SpannerDb {
 
         let mut ids = vec![];
         let mut modifieds = vec![];
-        while let Some(row) = stream.next_async().await? {
+        while let Some(row) = stream.try_next().await? {
             let mut row = row;
             ids.push(row[0].take_string_value());
             modifieds.push(sync_timestamp_from_rfc3339(row[1].get_string_value())?.as_i64());
@@ -1590,7 +1589,7 @@ impl SpannerDb {
             .param_types(sqlparam_types)
             .execute_async(&self.conn)?;
         let mut existing = HashSet::new();
-        while let Some(row) = streaming.next_async().await? {
+        while let Some(row) = streaming.try_next().await? {
             let mut row = row;
             existing.insert(row[0].take_string_value());
         }

--- a/syncstorage-spanner/src/models.rs
+++ b/syncstorage-spanner/src/models.rs
@@ -604,8 +604,7 @@ impl SpannerDb {
             .param_types(sqlparam_types)
             .execute_async(&self.conn)?;
         let mut results = HashMap::new();
-        while let Some(row) = streaming.next_async().await {
-            let row = row?;
+        while let Some(row) = streaming.next_async().await? {
             let collection_id = row[0]
                 .get_string_value()
                 .parse::<i32>()
@@ -659,8 +658,8 @@ impl SpannerDb {
                 )?
                 .params(params)
                 .execute_async(&self.conn)?;
-            while let Some(row) = rs.next_async().await {
-                let mut row = row?;
+            while let Some(row) = rs.next_async().await? {
+                let mut row = row;
                 let id = row[0]
                     .get_string_value()
                     .parse::<i32>()
@@ -697,8 +696,7 @@ impl SpannerDb {
             .param_types(sqlparam_types)
             .execute_async(&self.conn)?;
         let mut counts = HashMap::new();
-        while let Some(row) = streaming.next_async().await {
-            let row = row?;
+        while let Some(row) = streaming.next_async().await? {
             let collection_id = row[0]
                 .get_string_value()
                 .parse::<i32>()
@@ -733,8 +731,7 @@ impl SpannerDb {
             .param_types(sqlparam_types)
             .execute_async(&self.conn)?;
         let mut usages = HashMap::new();
-        while let Some(row) = streaming.next_async().await {
-            let row = row?;
+        while let Some(row) = streaming.next_async().await? {
             let collection_id = row[0]
                 .get_string_value()
                 .parse::<i32>()
@@ -1375,8 +1372,7 @@ impl SpannerDb {
 
         let mut streaming = self.bsos_query_async(query, params).await?;
         let mut bsos = vec![];
-        while let Some(row) = streaming.next_async().await {
-            let row = row?;
+        while let Some(row) = streaming.next_async().await? {
             bsos.push(bso_from_row(row)?);
         }
 
@@ -1417,8 +1413,8 @@ impl SpannerDb {
 
         let mut ids = vec![];
         let mut modifieds = vec![];
-        while let Some(row) = stream.next_async().await {
-            let mut row = row?;
+        while let Some(row) = stream.next_async().await? {
+            let mut row = row;
             ids.push(row[0].take_string_value());
             modifieds.push(sync_timestamp_from_rfc3339(row[1].get_string_value())?.as_i64());
         }
@@ -1594,8 +1590,8 @@ impl SpannerDb {
             .param_types(sqlparam_types)
             .execute_async(&self.conn)?;
         let mut existing = HashSet::new();
-        while let Some(row) = streaming.next_async().await {
-            let mut row = row?;
+        while let Some(row) = streaming.next_async().await? {
+            let mut row = row;
             existing.insert(row[0].take_string_value());
         }
         let mut inserts = vec![];

--- a/syncstorage-spanner/src/stream.rs
+++ b/syncstorage-spanner/src/stream.rs
@@ -68,10 +68,10 @@ where
     }
 
     pub async fn one_or_none(&mut self) -> DbResult<Option<Vec<Value>>> {
-        let result = self.next_async().await?;
+        let result = self.try_next().await?;
         if result.is_none() {
             Ok(None)
-        } else if self.next_async().await?.is_some() {
+        } else if self.try_next().await?.is_some() {
             Err(DbError::internal(
                 "Expected one result; got more.".to_owned(),
             ))
@@ -145,15 +145,13 @@ where
 
     // We could implement Stream::poll_next instead of this, but
     // this is easier for now and we can refactor into the trait later.
-    pub async fn next_async(&mut self) -> DbResult<Option<Vec<Value>>> {
+    pub async fn try_next(&mut self) -> DbResult<Option<Vec<Value>>> {
         while self.rows.is_empty() {
-            match self.consume_next().await {
-                Ok(true) => {}
-                Ok(false) => return Ok(None),
-                // Note: Iteration may continue after an error. We may want to
-                // stop afterwards instead for safety sake (it's not really
-                // recoverable)
-                Err(e) => return Err(e),
+            // Note: Iteration may continue after an error. We may want to
+            // stop afterwards instead for safety sake (it's not really
+            // recoverable)
+            if !self.consume_next().await? {
+                return Ok(None);
             }
         }
         Ok(self.rows.pop_front())
@@ -251,11 +249,12 @@ mod tests {
             Err(GoogleAuthenticationFailed),
         ]));
         let _err = s.one_or_none().await.unwrap_err();
-        // XXX: https://github.com/mozilla-services/syncstorage-rs/issues/1384
+        // Note:resolves historic Sentry error. Uncomment dbg! for debugging only.
+        // See: https://github.com/mozilla-services/syncstorage-rs/issues/1384
         //dbg!(&err);
-        //assert!(matches!(
-        //    err.kind,
-        //    DbErrorKind::Grpc(GoogleAuthenticationFailed)
-        //));
+        assert!(matches!(
+            err.kind,
+            DbErrorKind::Grpc(GoogleAuthenticationFailed)
+        ));
     }
 }

--- a/syncstorage-spanner/src/stream.rs
+++ b/syncstorage-spanner/src/stream.rs
@@ -248,7 +248,7 @@ mod tests {
             Ok(simple_part()),
             Err(GoogleAuthenticationFailed),
         ]));
-        let _err = s.one_or_none().await.unwrap_err();
+        let err = s.one_or_none().await.unwrap_err();
         // Note:resolves historic Sentry error. Uncomment dbg! for debugging only.
         // See: https://github.com/mozilla-services/syncstorage-rs/issues/1384
         //dbg!(&err);


### PR DESCRIPTION
## Description

The one_or_none method occasionally emits errors on SQL that can only produce at most one result.

Seeing this occur from update_user_collection_quotas, get_storage_timestamp and lock_for_write_async

https://sentry.io/organizations/mozilla/issues/3517020595/?environment=prod&project=6316464&query=is%3Aunresolved

https://sentry.io/organizations/mozilla/issues/3514687669/?environment=prod&project=6316464&query=is%3Aunresolved

https://sentry.io/organizations/mozilla/issues/3516548273/?environment=prod&project=6316464&query=is%3Aunresolved

We surmise the issue here is a bug in one_or_none: it doesn’t notice its second call to next_async could potentially be an Error. It should always propagate errors from next_async before validating its result (always call next_async().transpose()?). 

This was easy to miss because next_async returns Option<Result> (vs Result<Option>) to match poll_next (which it may rewritten into at some point).

[TryStream::try_next](https://docs.rs/futures/latest/futures/stream/trait.TryStreamExt.html#method.try_next) as the model for changing the implementation of `next_async`
## Issue(s)

Closes [STOR-212](https://mozilla-hub.atlassian.net/browse/STOR-212).


[STOR-212]: https://mozilla-hub.atlassian.net/browse/STOR-212?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ