### PR TITLE
feat: spanner scripts parse gcp project

### DIFF
--- a/tools/spanner/count_expired_rows.py
+++ b/tools/spanner/count_expired_rows.py
@@ -50,7 +50,7 @@ def from_env():
         print(f"Exception {e}")
         instance_id = os.environ.get("INSTANCE_ID", "spanner-test")
         database_id = os.environ.get("DATABASE_ID", "sync_stage")
-        project_id = os.environ.get("PROJECT_ID", "test-project")
+        project_id = os.environ.get("GOOGLE_CLOUD_PROJECT", "test-project")
     return (instance_id, database_id, project_id)
 
 

--- a/tools/spanner/count_expired_rows.py
+++ b/tools/spanner/count_expired_rows.py
@@ -22,7 +22,7 @@ logging.basicConfig(
 
 # Change these to match your install.
 client = spanner.Client()
-
+DSN_URL = "SYNC_SYNCSTORAGE__DATABASE_URL"
 
 def from_env():
     """
@@ -35,10 +35,14 @@ def from_env():
     `spanner://projects/moz-fx-sync-prod-xxxx/instances/sync/databases/syncdb`
     database_id = `syncdb`, instance_id = `sync`, project_id = `moz-fx-sync-prod-xxxx`
     """
+    instance_id = None
+    database_id = None
+    project_id = None
+
     try:
-        url = os.environ.get("SYNC_SYNCSTORAGE__DATABASE_URL")
+        url = os.environ.get(DSN_URL)
         if not url:
-            raise Exception("no url")
+            raise Exception(f"No URL DSN for provided URL: {DSN_URL}")
         parsed_url = parse.urlparse(url)
         if parsed_url.scheme == "spanner":
             path = parsed_url.path.split("/")
@@ -47,10 +51,15 @@ def from_env():
             database_id = path[-1]
     except Exception as e:
         # Change these to reflect your Spanner instance install
-        print(f"Exception {e}")
+        print(f"Exception parsing url: {e}")
+    # Fallbacks if not set
+    if not instance_id:
         instance_id = os.environ.get("INSTANCE_ID", "spanner-test")
+    if not database_id:
         database_id = os.environ.get("DATABASE_ID", "sync_stage")
+    if not project_id:
         project_id = os.environ.get("GOOGLE_CLOUD_PROJECT", "test-project")
+
     return (instance_id, database_id, project_id)
 
 

--- a/tools/spanner/count_expired_rows.py
+++ b/tools/spanner/count_expired_rows.py
@@ -29,25 +29,27 @@ def from_env():
         url = os.environ.get("SYNC_SYNCSTORAGE__DATABASE_URL")
         if not url:
             raise Exception("no url")
-        purl = parse.urlparse(url)
-        if purl.scheme == "spanner":
-            path = purl.path.split("/")
+        parsed_url = parse.urlparse(url)
+        if parsed_url.scheme == "spanner":
+            path = parsed_url.path.split("/")
             instance_id = path[-3]
+            project_id = path[-5]
             database_id = path[-1]
     except Exception as e:
         # Change these to reflect your Spanner instance install
         print("Exception {}".format(e))
         instance_id = os.environ.get("INSTANCE_ID", "spanner-test")
         database_id = os.environ.get("DATABASE_ID", "sync_stage")
-    return (instance_id, database_id)
+        project_id = os.environ.get("PROJECT_ID", "sync_stage")
+    return (instance_id, database_id, project_id)
 
 
 def spanner_read_data(query, table):
-    (instance_id, database_id) = from_env()
+    (instance_id, database_id, project_id) = from_env()
     instance = client.instance(instance_id)
     database = instance.database(database_id)
 
-    logging.info("For {}:{}".format(instance_id, database_id))
+    logging.info("For {}:{} {}".format(instance_id, database_id, project_id))
 
     # Count bsos expired rows
     with statsd.timer(f"syncstorage.count_expired_{table}_rows.duration"):

--- a/tools/spanner/count_expired_rows.py
+++ b/tools/spanner/count_expired_rows.py
@@ -40,7 +40,7 @@ def from_env():
         print("Exception {}".format(e))
         instance_id = os.environ.get("INSTANCE_ID", "spanner-test")
         database_id = os.environ.get("DATABASE_ID", "sync_stage")
-        project_id = os.environ.get("PROJECT_ID", "sync_stage")
+        project_id = os.environ.get("PROJECT_ID", "test-project")
     return (instance_id, database_id, project_id)
 
 

--- a/tools/spanner/count_expired_rows.py
+++ b/tools/spanner/count_expired_rows.py
@@ -25,6 +25,16 @@ client = spanner.Client()
 
 
 def from_env():
+    """
+    Function that extracts the instance, project, and database ids from the DSN url.
+    It is defined as the SYNC_SYNCSTORAGE__DATABASE_URL environment variable.
+    The defined defaults are in webservices-infra/sync and can be configured there for
+    production runs. 
+
+    For reference, an example spanner url passed in is in the following format:
+    `spanner://projects/moz-fx-sync-prod-xxxx/instances/sync/databases/syncdb`
+    database_id = `syncdb`, instance_id = `sync`, project_id = `moz-fx-sync-prod-xxxx`
+    """
     try:
         url = os.environ.get("SYNC_SYNCSTORAGE__DATABASE_URL")
         if not url:
@@ -37,7 +47,7 @@ def from_env():
             database_id = path[-1]
     except Exception as e:
         # Change these to reflect your Spanner instance install
-        print("Exception {}".format(e))
+        print(f"Exception {e}")
         instance_id = os.environ.get("INSTANCE_ID", "spanner-test")
         database_id = os.environ.get("DATABASE_ID", "sync_stage")
         project_id = os.environ.get("PROJECT_ID", "test-project")
@@ -49,7 +59,7 @@ def spanner_read_data(query, table):
     instance = client.instance(instance_id)
     database = instance.database(database_id)
 
-    logging.info("For {}:{} {}".format(instance_id, database_id, project_id))
+    logging.info(f"For {instance_id}:{database_id} {project_id}")
 
     # Count bsos expired rows
     with statsd.timer(f"syncstorage.count_expired_{table}_rows.duration"):

--- a/tools/spanner/count_expired_rows.py
+++ b/tools/spanner/count_expired_rows.py
@@ -54,14 +54,24 @@ def from_env():
     return (instance_id, database_id, project_id)
 
 
-def spanner_read_data(query, table):
+def spanner_read_data(query: str, table: str) -> None:
+    """
+    Executes a query on the specified Spanner table to count expired rows,
+    logs the result, and sends metrics to statsd.
+
+    Args:
+        query (str): The SQL query to execute.
+        table (str): The name of the table being queried.
+    Returns:
+        None
+    """
     (instance_id, database_id, project_id) = from_env()
     instance = client.instance(instance_id)
     database = instance.database(database_id)
 
     logging.info(f"For {instance_id}:{database_id} {project_id}")
 
-    # Count bsos expired rows
+    # Count expired rows in the specified table
     with statsd.timer(f"syncstorage.count_expired_{table}_rows.duration"):
         with database.snapshot() as snapshot:
             result = snapshot.execute_sql(query)

--- a/tools/spanner/count_users.py
+++ b/tools/spanner/count_users.py
@@ -50,7 +50,7 @@ def from_env():
         print(f"Exception {e}")
         instance_id = os.environ.get("INSTANCE_ID", "spanner-test")
         database_id = os.environ.get("DATABASE_ID", "sync_stage")
-        project_id = os.environ.get("PROJECT_ID", "test-project")
+        project_id = os.environ.get("GOOGLE_CLOUD_PROJECT", "test-project")
     return (instance_id, database_id, project_id)
 
 

--- a/tools/spanner/count_users.py
+++ b/tools/spanner/count_users.py
@@ -23,7 +23,7 @@ logging.basicConfig(
 
 # Change these to match your install.
 client = spanner.Client()
-
+DSN_URL = "SYNC_SYNCSTORAGE__DATABASE_URL"
 
 def from_env() -> Tuple[str, str, str]:
     """
@@ -37,7 +37,7 @@ def from_env() -> Tuple[str, str, str]:
     database_id = `syncdb`, instance_id = `sync`, project_id = `moz-fx-sync-prod-xxxx`
     """
     try:
-        url = os.environ.get("SYNC_SYNCSTORAGE__DATABASE_URL")
+        url = os.environ.get(DSN_URL)
         if not url:
             raise Exception("no url")
         parsed_url = parse.urlparse(url)

--- a/tools/spanner/count_users.py
+++ b/tools/spanner/count_users.py
@@ -29,25 +29,28 @@ def from_env():
         url = os.environ.get("SYNC_SYNCSTORAGE__DATABASE_URL")
         if not url:
             raise Exception("no url")
-        purl = parse.urlparse(url)
-        if purl.scheme == "spanner":
-            path = purl.path.split("/")
+        parsed_url = parse.urlparse(url)
+        if parsed_url.scheme == "spanner":
+            path = parsed_url.path.split("/")
             instance_id = path[-3]
+            project_id = path[-5]
             database_id = path[-1]
     except Exception as e:
         # Change these to reflect your Spanner instance install
         print("Exception {}".format(e))
         instance_id = os.environ.get("INSTANCE_ID", "spanner-test")
         database_id = os.environ.get("DATABASE_ID", "sync_stage")
-    return (instance_id, database_id)
+        project_id = os.environ.get("PROJECT_ID", "test-project")
+    return (instance_id, database_id, project_id)
 
 
 def spanner_read_data(request=None):
-    (instance_id, database_id) = from_env()
+    (instance_id, database_id, project_id) = from_env()
     instance = client.instance(instance_id)
     database = instance.database(database_id)
+    project = instance.database(database_id)
 
-    logging.info("For {}:{}".format(instance_id, database_id))
+    logging.info("For {}:{} {}".format(instance_id, database_id, project))
 
     # Count users
     with statsd.timer("syncstorage.count_users.duration"):

--- a/tools/spanner/count_users.py
+++ b/tools/spanner/count_users.py
@@ -14,6 +14,7 @@ from urllib import parse
 
 from google.cloud import spanner
 from typing import Tuple
+from utils import ids_from_env
 
 # set up logger
 logging.basicConfig(
@@ -23,37 +24,6 @@ logging.basicConfig(
 
 # Change these to match your install.
 client = spanner.Client()
-DSN_URL = "SYNC_SYNCSTORAGE__DATABASE_URL"
-
-def from_env() -> Tuple[str, str, str]:
-    """
-    Function that extracts the instance, project, and database ids from the DSN url.
-    It is defined as the SYNC_SYNCSTORAGE__DATABASE_URL environment variable.
-    The defined defaults are in webservices-infra/sync and can be configured there for
-    production runs. 
-
-    For reference, an example spanner url passed in is in the following format:
-    `spanner://projects/moz-fx-sync-prod-xxxx/instances/sync/databases/syncdb`
-    database_id = `syncdb`, instance_id = `sync`, project_id = `moz-fx-sync-prod-xxxx`
-    """
-    try:
-        url = os.environ.get(DSN_URL)
-        if not url:
-            raise Exception("no url")
-        parsed_url = parse.urlparse(url)
-        if parsed_url.scheme == "spanner":
-            path = parsed_url.path.split("/")
-            instance_id = path[-3]
-            project_id = path[-5]
-            database_id = path[-1]
-    except Exception as e:
-        # Change these to reflect your Spanner instance install
-        print(f"Exception {e}")
-        instance_id = os.environ.get("INSTANCE_ID", "spanner-test")
-        database_id = os.environ.get("DATABASE_ID", "sync_stage")
-        project_id = os.environ.get("GOOGLE_CLOUD_PROJECT", "test-project")
-    return (instance_id, database_id, project_id)
-
 
 def spanner_read_data() -> None:
     """
@@ -69,7 +39,7 @@ def spanner_read_data() -> None:
     Returns:
         None
     """
-    (instance_id, database_id, project_id) = from_env()
+    (instance_id, database_id, project_id) = ids_from_env()
     instance = client.instance(instance_id)
     database = instance.database(database_id)
     project = instance.database(database_id)

--- a/tools/spanner/count_users.py
+++ b/tools/spanner/count_users.py
@@ -13,6 +13,7 @@ from statsd.defaults.env import statsd
 from urllib import parse
 
 from google.cloud import spanner
+from typing import Tuple
 
 # set up logger
 logging.basicConfig(
@@ -24,7 +25,7 @@ logging.basicConfig(
 client = spanner.Client()
 
 
-def from_env():
+def from_env() -> Tuple[str, str, str]:
     """
     Function that extracts the instance, project, and database ids from the DSN url.
     It is defined as the SYNC_SYNCSTORAGE__DATABASE_URL environment variable.
@@ -54,7 +55,20 @@ def from_env():
     return (instance_id, database_id, project_id)
 
 
-def spanner_read_data(request=None):
+def spanner_read_data() -> None:
+    """
+    Reads data from a Google Cloud Spanner database to count the number of distinct users.
+
+    This function connects to a Spanner instance and database using environment variables,
+    executes a SQL query to count the number of distinct `fxa_uid` entries in the `user_collections` table,
+    and logs the result. It also records the duration of the operation and the user count using statsd metrics.
+
+    Args:
+        None
+
+    Returns:
+        None
+    """
     (instance_id, database_id, project_id) = from_env()
     instance = client.instance(instance_id)
     database = instance.database(database_id)

--- a/tools/spanner/count_users.py
+++ b/tools/spanner/count_users.py
@@ -25,6 +25,16 @@ client = spanner.Client()
 
 
 def from_env():
+    """
+    Function that extracts the instance, project, and database ids from the DSN url.
+    It is defined as the SYNC_SYNCSTORAGE__DATABASE_URL environment variable.
+    The defined defaults are in webservices-infra/sync and can be configured there for
+    production runs. 
+
+    For reference, an example spanner url passed in is in the following format:
+    `spanner://projects/moz-fx-sync-prod-xxxx/instances/sync/databases/syncdb`
+    database_id = `syncdb`, instance_id = `sync`, project_id = `moz-fx-sync-prod-xxxx`
+    """
     try:
         url = os.environ.get("SYNC_SYNCSTORAGE__DATABASE_URL")
         if not url:
@@ -37,7 +47,7 @@ def from_env():
             database_id = path[-1]
     except Exception as e:
         # Change these to reflect your Spanner instance install
-        print("Exception {}".format(e))
+        print(f"Exception {e}")
         instance_id = os.environ.get("INSTANCE_ID", "spanner-test")
         database_id = os.environ.get("DATABASE_ID", "sync_stage")
         project_id = os.environ.get("PROJECT_ID", "test-project")
@@ -50,7 +60,7 @@ def spanner_read_data(request=None):
     database = instance.database(database_id)
     project = instance.database(database_id)
 
-    logging.info("For {}:{} {}".format(instance_id, database_id, project))
+    logging.info(f"For {instance_id}:{database_id} {project}")
 
     # Count users
     with statsd.timer("syncstorage.count_users.duration"):
@@ -59,7 +69,7 @@ def spanner_read_data(request=None):
             result = snapshot.execute_sql(query)
             user_count = result.one()[0]
             statsd.gauge("syncstorage.distinct_fxa_uid", user_count)
-            logging.info("Count found {} distinct users".format(user_count))
+            logging.info(f"Count found {user_count} distinct users")
 
 
 if __name__ == "__main__":

--- a/tools/spanner/purge_ttl.py
+++ b/tools/spanner/purge_ttl.py
@@ -17,6 +17,8 @@ from google.cloud.spanner_v1.database import Database
 from google.cloud.spanner_v1 import param_types
 from statsd.defaults.env import statsd
 
+from utils import ids_from_env
+
 # set up logger
 logging.basicConfig(
     format='{"datetime": "%(asctime)s", "message": "%(message)s"}',
@@ -25,32 +27,32 @@ logging.basicConfig(
 
 # Change these to match your install.
 client = spanner.Client()
-DSN_URL = "SYNC_SYNCSTORAGE__DATABASE_URL"
+# DSN_URL = "SYNC_SYNCSTORAGE__DATABASE_URL"
 
-def use_dsn(args):
-    """
-    Function that extracts the instance, project, and database ids from the DSN url.
-    It is defined as the SYNC_SYNCSTORAGE__DATABASE_URL environment variable.
-    The defined defaults are in webservices-infra/sync and can be configured there for
-    production runs. 
+# def use_dsn(args):
+#     """
+#     Function that extracts the instance, project, and database ids from the DSN url.
+#     It is defined as the SYNC_SYNCSTORAGE__DATABASE_URL environment variable.
+#     The defined defaults are in webservices-infra/sync and can be configured there for
+#     production runs. 
 
-    For reference, an example spanner url passed in is in the following format:
-    `spanner://projects/moz-fx-sync-prod-xxxx/instances/sync/databases/syncdb`
-    database_id = `syncdb`, instance_id = `sync`, project_id = `moz-fx-sync-prod-xxxx`
-    """
-    try:
-        if not args.sync_database_url:
-            raise Exception("no url")
-        url = args.sync_database_url
-        parsed_url = parse.urlparse(url)
-        if parsed_url.scheme == "spanner":
-            path = parsed_url.path.split("/")
-            args.instance_id = path[-3]
-            args.project_id = path[-5]
-            args.database_id = path[-1]
-    except Exception as e:
-        print(f"Exception {e}")
-    return args
+#     For reference, an example spanner url passed in is in the following format:
+#     `spanner://projects/moz-fx-sync-prod-xxxx/instances/sync/databases/syncdb`
+#     database_id = `syncdb`, instance_id = `sync`, project_id = `moz-fx-sync-prod-xxxx`
+#     """
+#     try:
+#         if not args.sync_database_url:
+#             raise Exception("no url")
+#         url = args.sync_database_url
+#         parsed_url = parse.urlparse(url)
+#         if parsed_url.scheme == "spanner":
+#             path = parsed_url.path.split("/")
+#             args.instance_id = path[-3]
+#             args.project_id = path[-5]
+#             args.database_id = path[-1]
+#     except Exception as e:
+#         print(f"Exception {e}")
+#     return args
 
 
 def deleter(database: Database,
@@ -271,7 +273,12 @@ def get_args():
 
     # override using the DSN URL:
     if args.sync_database_url:
-        args = use_dsn(args)
+        (instance_id, database_id, project_id) = ids_from_env(args.sync_database_url)
+        args.instance_id = instance_id
+        args.database_id = database_id
+        args.project_id = project_id
+        import pdb
+        pdb.set_trace()
 
     return args
 

--- a/tools/spanner/purge_ttl.py
+++ b/tools/spanner/purge_ttl.py
@@ -25,7 +25,7 @@ logging.basicConfig(
 
 # Change these to match your install.
 client = spanner.Client()
-
+DSN_URL = "SYNC_SYNCSTORAGE__DATABASE_URL"
 
 def use_dsn(args):
     """
@@ -49,7 +49,6 @@ def use_dsn(args):
             args.project_id = path[-5]
             args.database_id = path[-1]
     except Exception as e:
-        # Change these to reflect your Spanner instance install
         print(f"Exception {e}")
     return args
 

--- a/tools/spanner/purge_ttl.py
+++ b/tools/spanner/purge_ttl.py
@@ -17,7 +17,7 @@ from google.cloud.spanner_v1.database import Database
 from google.cloud.spanner_v1 import param_types
 from statsd.defaults.env import statsd
 
-from utils import ids_from_env
+from utils import ids_from_env, Mode
 
 # set up logger
 logging.basicConfig(
@@ -27,33 +27,6 @@ logging.basicConfig(
 
 # Change these to match your install.
 client = spanner.Client()
-# DSN_URL = "SYNC_SYNCSTORAGE__DATABASE_URL"
-
-# def use_dsn(args):
-#     """
-#     Function that extracts the instance, project, and database ids from the DSN url.
-#     It is defined as the SYNC_SYNCSTORAGE__DATABASE_URL environment variable.
-#     The defined defaults are in webservices-infra/sync and can be configured there for
-#     production runs. 
-
-#     For reference, an example spanner url passed in is in the following format:
-#     `spanner://projects/moz-fx-sync-prod-xxxx/instances/sync/databases/syncdb`
-#     database_id = `syncdb`, instance_id = `sync`, project_id = `moz-fx-sync-prod-xxxx`
-#     """
-#     try:
-#         if not args.sync_database_url:
-#             raise Exception("no url")
-#         url = args.sync_database_url
-#         parsed_url = parse.urlparse(url)
-#         if parsed_url.scheme == "spanner":
-#             path = parsed_url.path.split("/")
-#             args.instance_id = path[-3]
-#             args.project_id = path[-5]
-#             args.database_id = path[-1]
-#     except Exception as e:
-#         print(f"Exception {e}")
-#     return args
-
 
 def deleter(database: Database,
         name: str,
@@ -273,13 +246,10 @@ def get_args():
 
     # override using the DSN URL:
     if args.sync_database_url:
-        (instance_id, database_id, project_id) = ids_from_env(args.sync_database_url)
+        (instance_id, database_id, project_id) = ids_from_env(args.sync_database_url, mode=Mode.URL)
         args.instance_id = instance_id
         args.database_id = database_id
         args.project_id = project_id
-        import pdb
-        pdb.set_trace()
-
     return args
 
 

--- a/tools/spanner/purge_ttl.py
+++ b/tools/spanner/purge_ttl.py
@@ -32,10 +32,11 @@ def use_dsn(args):
         if not args.sync_database_url:
             raise Exception("no url")
         url = args.sync_database_url
-        purl = parse.urlparse(url)
-        if purl.scheme == "spanner":
-            path = purl.path.split("/")
+        parsed_url = parse.urlparse(url)
+        if parsed_url.scheme == "spanner":
+            path = parsed_url.path.split("/")
             args.instance_id = path[-3]
+            args.project_id = path[-5]
             args.database_id = path[-1]
     except Exception as e:
         # Change these to reflect your Spanner instance install
@@ -172,6 +173,12 @@ def get_args():
         "--database_id",
         default=os.environ.get("DATABASE_ID", "sync_schema3"),
         help="Spanner Database ID"
+    )
+    parser.add_argument(
+        "-p",
+        "--project_id",
+        default=os.environ.get("PROJECT_ID", "spanner-test"),
+        help="Spanner Project ID"
     )
     parser.add_argument(
         "-u",

--- a/tools/spanner/purge_ttl.py
+++ b/tools/spanner/purge_ttl.py
@@ -185,7 +185,7 @@ def get_args():
     parser.add_argument(
         "-p",
         "--project_id",
-        default=os.environ.get("PROJECT_ID", "spanner-test"),
+        default=os.environ.get("GOOGLE_CLOUD_PROJECT", "spanner-test"),
         help="Spanner Project ID"
     )
     parser.add_argument(

--- a/tools/spanner/test_count_expired_rows.py
+++ b/tools/spanner/test_count_expired_rows.py
@@ -1,0 +1,85 @@
+import os
+import types
+from unittest.mock import MagicMock
+import pytest
+import logging
+
+import count_expired_rows
+
+@pytest.fixture(autouse=True)
+def reset_env(monkeypatch):
+    # Reset environment variables before each test
+    for var in [
+        "SYNC_SYNCSTORAGE__DATABASE_URL",
+        "INSTANCE_ID",
+        "DATABASE_ID",
+        "GOOGLE_CLOUD_PROJECT"
+    ]:
+        monkeypatch.delenv(var, raising=False)
+
+def test_from_env_with_valid_url(monkeypatch):
+    url = "spanner://projects/test-project/instances/test-instance/databases/test-db"
+    monkeypatch.setenv("SYNC_SYNCSTORAGE__DATABASE_URL", url)
+    instance_id, database_id, project_id = count_expired_rows.from_env()
+    assert instance_id == "test-instance"
+    assert database_id == "test-db"
+    assert project_id == "test-project"
+
+def test_from_env_with_missing_url(monkeypatch):
+    monkeypatch.setenv("INSTANCE_ID", "foo")
+    monkeypatch.setenv("DATABASE_ID", "bar")
+    monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "baz")
+    instance_id, database_id, project_id = count_expired_rows.from_env()
+    assert instance_id == "foo"
+    assert database_id == "bar"
+    assert project_id == "baz"
+
+def test_from_env_with_invalid_url(monkeypatch):
+    monkeypatch.setenv("SYNC_SYNCSTORAGE__DATABASE_URL", "notaspanner://foo")
+    monkeypatch.setenv("INSTANCE_ID", "default")
+    monkeypatch.setenv("DATABASE_ID", "default-db")
+    monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "default-proj")
+
+    instance_id, database_id, project_id = count_expired_rows.from_env()
+    assert instance_id == "default"
+    assert database_id == "default-db"
+    assert project_id == "default-proj"
+
+def test_spanner_read_data_counts_and_logs(monkeypatch, caplog):
+    # Prepare mocks
+    mock_instance = MagicMock()
+    mock_database = MagicMock()
+    mock_snapshot_ctx = MagicMock()
+    mock_snapshot = MagicMock()
+    mock_result = MagicMock()
+    mock_result.one.return_value = [42]
+    mock_snapshot.execute_sql.return_value = mock_result
+    mock_snapshot_ctx.__enter__.return_value = mock_snapshot
+    mock_database.snapshot.return_value = mock_snapshot_ctx
+
+    # Patch spanner client and statsd
+    monkeypatch.setattr(count_expired_rows, "client", MagicMock())
+    count_expired_rows.client.instance.return_value = mock_instance
+    mock_instance.database.return_value = mock_database
+
+    mock_statsd = MagicMock()
+    monkeypatch.setattr(count_expired_rows, "statsd", mock_statsd)
+    mock_statsd.timer.return_value.__enter__.return_value = None
+    mock_statsd.timer.return_value.__exit__.return_value = None
+
+    # Patch from_env to return fixed values
+    monkeypatch.setattr(count_expired_rows, "from_env", lambda: ("inst", "db", "proj"))
+
+    # Run function
+    with caplog.at_level(logging.INFO):
+        count_expired_rows.spanner_read_data("SELECT COUNT(*) FROM foo", "foo")
+
+    # Check logs
+    assert any("For inst:db proj" in m for m in caplog.messages)
+    assert any("Found 42 expired rows in foo" in m for m in caplog.messages)
+
+    # Check statsd calls
+    mock_statsd.gauge.assert_called_with("syncstorage.expired_foo_rows", 42)
+    mock_statsd.timer.assert_called_with("syncstorage.count_expired_foo_rows.duration")
+    mock_database.snapshot.assert_called_once()
+    mock_snapshot.execute_sql.assert_called_with("SELECT COUNT(*) FROM foo")

--- a/tools/spanner/test_purge_ttl.py
+++ b/tools/spanner/test_purge_ttl.py
@@ -1,0 +1,159 @@
+import pytest
+from unittest import mock
+from types import SimpleNamespace
+
+import sys
+
+# Import the functions to test from purge_ttl.py
+import purge_ttl
+
+def test_parse_args_list_single_item():
+    assert purge_ttl.parse_args_list("foo") == ["foo"]
+
+def test_parse_args_list_multiple_items():
+    assert purge_ttl.parse_args_list("[a,b,c]") == ["a", "b", "c"]
+
+def test_use_dsn_parses_url():
+    args = SimpleNamespace(sync_database_url="spanner://projects/proj/instances/inst/databases/db")
+    args = purge_ttl.use_dsn(args)
+    assert args.project_id == "proj"
+    assert args.instance_id == "inst"
+    assert args.database_id == "db"
+
+def test_use_dsn_no_url():
+    args = SimpleNamespace(sync_database_url=None)
+    # Should not raise
+    result = purge_ttl.use_dsn(args)
+    assert result is args
+
+def test_get_expiry_condition_now():
+    args = SimpleNamespace(expiry_mode="now")
+    assert purge_ttl.get_expiry_condition(args) == 'expiry < CURRENT_TIMESTAMP()'
+
+def test_get_expiry_condition_midnight():
+    args = SimpleNamespace(expiry_mode="midnight")
+    assert purge_ttl.get_expiry_condition(args) == 'expiry < TIMESTAMP_TRUNC(CURRENT_TIMESTAMP(), DAY, "UTC")'
+
+def test_get_expiry_condition_invalid():
+    args = SimpleNamespace(expiry_mode="invalid")
+    with pytest.raises(Exception):
+        purge_ttl.get_expiry_condition(args)
+
+def test_add_conditions_no_collections_no_prefix():
+    args = SimpleNamespace(collection_ids=[], uid_prefixes=None)
+    query, params, types = purge_ttl.add_conditions(args, "SELECT * FROM foo WHERE 1=1", None)
+    assert query == "SELECT * FROM foo WHERE 1=1"
+    assert params == {}
+    assert types == {}
+
+def test_add_conditions_with_collections_single():
+    args = SimpleNamespace(collection_ids=["123"])
+    query, params, types = purge_ttl.add_conditions(args, "SELECT * FROM foo WHERE 1=1", None)
+    assert "collection_id = @collection_id" in query
+    assert params["collection_id"] == "123"
+    assert types["collection_id"] == purge_ttl.param_types.INT64
+
+def test_add_conditions_with_collections_multiple():
+    args = SimpleNamespace(collection_ids=["1", "2"])
+    query, params, types = purge_ttl.add_conditions(args, "SELECT * FROM foo WHERE 1=1", None)
+    assert "collection_id in" in query
+    assert params["collection_id_0"] == "1"
+    assert params["collection_id_1"] == "2"
+    assert types["collection_id_0"] == purge_ttl.param_types.INT64
+
+def test_add_conditions_with_prefix():
+    args = SimpleNamespace(collection_ids=[])
+    query, params, types = purge_ttl.add_conditions(args, "SELECT * FROM foo WHERE 1=1", "abc")
+    assert "STARTS_WITH(fxa_uid, @prefix)" in query
+    assert params["prefix"] == "abc"
+    assert types["prefix"] == purge_ttl.param_types.STRING
+
+@mock.patch("purge_ttl.statsd")
+def test_deleter_dryrun(statsd_mock):
+    database = mock.Mock()
+    statsd_mock.timer.return_value.__enter__.return_value = None
+    statsd_mock.timer.return_value.__exit__.return_value = None
+    purge_ttl.deleter(database, "batches", "DELETE FROM batches", dryrun=True)
+    database.execute_partitioned_dml.assert_not_called()
+
+@mock.patch("purge_ttl.statsd")
+def test_deleter_executes(statsd_mock):
+    database = mock.Mock()
+    statsd_mock.timer.return_value.__enter__.return_value = None
+    statsd_mock.timer.return_value.__exit__.return_value = None
+    database.execute_partitioned_dml.return_value = 42
+    
+    purge_ttl.deleter(database, "batches", "DELETE FROM batches", dryrun=False)
+    database.execute_partitioned_dml.assert_called_once()
+
+@mock.patch("purge_ttl.deleter")
+@mock.patch("purge_ttl.add_conditions")
+@mock.patch("purge_ttl.get_expiry_condition")
+@mock.patch("purge_ttl.client")
+def test_spanner_purge_both(client_mock, get_expiry_condition_mock, add_conditions_mock, deleter_mock):
+    # Setup
+    args = SimpleNamespace(
+        instance_id="inst",
+        database_id="db",
+        expiry_mode="now",
+        auto_split=None,
+        uid_prefixes=None,
+        mode="both",
+        dryrun=True,
+        collection_ids=[]
+    )
+
+    instance = mock.Mock()
+    database = mock.Mock()
+    client_mock.instance.return_value = instance
+    instance.database.return_value = database
+
+    get_expiry_condition_mock.return_value = "expiry < CURRENT_TIMESTAMP()"
+    add_conditions_mock.side_effect = [
+        ("batch_query", {"a": 1}, {"a": 2}),
+        ("bso_query", {"b": 3}, {"b": 4}),
+    ]
+    purge_ttl.spanner_purge(args)
+
+    assert deleter_mock.call_count == 2
+
+    deleter_mock.assert_any_call(
+        database=database,
+        name="batches",
+        query="batch_query",
+        params={"a": 1},
+        param_types={"a": 2},
+        prefix=None,
+        dryrun=True,
+    )
+
+    deleter_mock.assert_any_call(
+        database=database,
+        name="bso",
+        query="bso_query",
+        params={"b": 3},
+        param_types={"b": 4},
+        prefix=None,
+        dryrun=True,
+    )
+
+@mock.patch("argparse.ArgumentParser.parse_args")
+def test_get_args_env_and_dsn(parse_args_mock):
+    # Simulate args with DSN
+    args = SimpleNamespace(
+        instance_id="foo",
+        database_id="bar",
+        project_id="baz",
+        sync_database_url="spanner://projects/proj/instances/inst/databases/db",
+        collection_ids=[],
+        uid_prefixes=[],
+        auto_split=None,
+        mode="both",
+        expiry_mode="midnight",
+        dryrun=False,
+    )
+    parse_args_mock.return_value = args
+    result = purge_ttl.get_args()
+    assert result.project_id == "proj"
+    assert result.instance_id == "inst"
+    assert result.database_id == "db"

--- a/tools/spanner/test_utils.py
+++ b/tools/spanner/test_utils.py
@@ -1,0 +1,46 @@
+import pytest
+
+import utils
+from unittest.mock import MagicMock
+
+@pytest.fixture(autouse=True)
+def reset_env(monkeypatch):
+    # Reset environment variables before each test
+    for var in [
+        "SYNC_SYNCSTORAGE__DATABASE_URL",
+        "INSTANCE_ID",
+        "DATABASE_ID",
+        "GOOGLE_CLOUD_PROJECT"
+    ]:
+        monkeypatch.delenv(var, raising=False)
+
+def test_ids_from_env_parses_url(monkeypatch):
+    """Test with passed in DSN"""
+    monkeypatch.setenv("SYNC_SYNCSTORAGE__DATABASE_URL", "spanner://projects/proj/instances/inst/databases/db")
+    dsn = "SYNC_SYNCSTORAGE__DATABASE_URL"
+    instance_id, database_id, project_id = utils.ids_from_env(dsn)
+    assert project_id == "proj"
+    assert instance_id == "inst"
+    assert database_id == "db"
+
+def test_ids_from_env_with_missing_url(monkeypatch):
+    """Test ensures that default env vars set id values."""
+    monkeypatch.setenv("INSTANCE_ID", "foo")
+    monkeypatch.setenv("DATABASE_ID", "bar")
+    monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "baz")
+    instance_id, database_id, project_id = utils.ids_from_env()
+    assert instance_id == "foo"
+    assert database_id == "bar"
+    assert project_id == "baz"
+
+
+def test_from_env_with_invalid_url(monkeypatch):
+    monkeypatch.setenv("SYNC_SYNCSTORAGE__DATABASE_URL", "notaspanner://foo")
+    monkeypatch.setenv("INSTANCE_ID", "default")
+    monkeypatch.setenv("DATABASE_ID", "default-db")
+    monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "default-proj")
+
+    instance_id, database_id, project_id = utils.ids_from_env()
+    assert instance_id == "default"
+    assert database_id == "default-db"
+    assert project_id == "default-proj"

--- a/tools/spanner/utils.py
+++ b/tools/spanner/utils.py
@@ -1,0 +1,59 @@
+# Utility Module for spanner CLI scripts
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+
+import os
+from urllib import parse
+from typing import Tuple
+
+
+DSN_URL = "SYNC_SYNCSTORAGE__DATABASE_URL"
+"""
+Environment variable that stores Sync database URL
+Depending on deployment, can be MySQL or Spanner.
+In this context, should always point to spanner for these scripts.
+"""
+
+def ids_from_env(dsn=DSN_URL) -> Tuple[str, str, str]:
+    """
+    Function that extracts the instance, project, and database ids from the DSN url.
+    It is defined as the SYNC_SYNCSTORAGE__DATABASE_URL environment variable.
+    The defined defaults are in webservices-infra/sync and can be configured there for
+    production runs.
+
+    `dsn` argument is set to default to the `DSN_URL` constant.
+
+    For reference, an example spanner url passed in is in the following format:
+
+    `spanner://projects/moz-fx-sync-prod-xxxx/instances/sync/databases/syncdb`
+    database_id = `syncdb`, instance_id = `sync`, project_id = `moz-fx-sync-prod-xxxx`
+    """
+    instance_id = None
+    database_id = None
+    project_id = None
+
+    try:
+        url = os.environ.get(dsn)
+        if not url:
+            raise Exception(f"No URL DSN for provided URL: {DSN_URL}")
+        parsed_url = parse.urlparse(url)
+        if parsed_url.scheme == "spanner":
+            path = parsed_url.path.split("/")
+            instance_id = path[-3]
+            project_id = path[-5]
+            database_id = path[-1]
+    except Exception as e:
+        # Change these to reflect your Spanner instance install
+        print(f"Exception parsing url: {e}")
+    # Fallbacks if not set
+    if not instance_id:
+        instance_id = os.environ.get("INSTANCE_ID", "spanner-test")
+    if not database_id:
+        database_id = os.environ.get("DATABASE_ID", "sync_stage")
+    if not project_id:
+        project_id = os.environ.get("GOOGLE_CLOUD_PROJECT", "test-project")
+
+    return (instance_id, database_id, project_id)

--- a/tools/spanner/utils.py
+++ b/tools/spanner/utils.py
@@ -8,7 +8,7 @@
 import os
 from urllib import parse
 from typing import Tuple
-
+from unittest.mock import MagicMock
 
 DSN_URL = "SYNC_SYNCSTORAGE__DATABASE_URL"
 """

--- a/tools/spanner/write_batch.py
+++ b/tools/spanner/write_batch.py
@@ -200,7 +200,7 @@ def from_env():
         print(f"Exception {e}")
         instance_id = os.environ.get("INSTANCE_ID", "spanner-test")
         database_id = os.environ.get("DATABASE_ID", "sync_stage")
-        project_id = os.environ.get("PROJECT_ID", "test-project")
+        project_id = os.environ.get("GOOGLE_CLOUD_PROJECT", "test-project")
     return (instance_id, database_id, project_id)
 
 

--- a/tools/spanner/write_batch.py
+++ b/tools/spanner/write_batch.py
@@ -181,24 +181,26 @@ def from_env():
         url = os.environ.get("SYNC_SYNCSTORAGE__DATABASE_URL")
         if not url:
             raise Exception("no url")
-        purl = parse.urlparse(url)
-        if purl.scheme == "spanner":
-            path = purl.path.split("/")
+        parsed_url = parse.urlparse(url)
+        if parsed_url.scheme == "spanner":
+            path = parsed_url.path.split("/")
             instance_id = path[-3]
+            project_id = path[-5]
             database_id = path[-1]
     except Exception as e:
         # Change these to reflect your Spanner instance install
         print("Exception {}".format(e))
         instance_id = os.environ.get("INSTANCE_ID", "spanner-test")
         database_id = os.environ.get("DATABASE_ID", "sync_stage")
-    return (instance_id, database_id)
+        project_id = os.environ.get("PROJECT_ID", "test-project")
+    return (instance_id, database_id, project_id)
 
 
 def loader():
     # Prefix uaids for easy filtering later
     # Each loader thread gets it's own fake user to prevent some hotspot
     # issues.
-    (instance_id, database_id) = from_env()
+    (instance_id, database_id, project_id) = from_env()
     # switching uid/kid to per load because of weird google trimming
     name = threading.current_thread().getName()
     load(instance_id, database_id, COLL_ID, name)

--- a/tools/spanner/write_batch.py
+++ b/tools/spanner/write_batch.py
@@ -46,6 +46,7 @@ Spanner. Please reduce the size or number of the writes, or use fewer
 indexes. (Maximum size: 104857600)
 
 """
+DSN_URL = "SYNC_SYNCSTORAGE__DATABASE_URL"
 # 1 Batch of 2K records with payload of 25K = 201_168_000B
 # so, ~300G would need 2_982_582 batches
 BATCH_SIZE = 2000
@@ -186,9 +187,13 @@ def from_env():
     database_id = `syncdb`, instance_id = `sync`, project_id = `moz-fx-sync-prod-xxxx`
     """
     try:
-        url = os.environ.get("SYNC_SYNCSTORAGE__DATABASE_URL")
+        instance_id = None
+        database_id = None
+        project_id = None
+
+        url = os.environ.get(DSN_URL)
         if not url:
-            raise Exception("no url")
+            raise Exception(f"No URL DSN for provided URL: {DSN_URL}")
         parsed_url = parse.urlparse(url)
         if parsed_url.scheme == "spanner":
             path = parsed_url.path.split("/")
@@ -196,10 +201,14 @@ def from_env():
             project_id = path[-5]
             database_id = path[-1]
     except Exception as e:
+        print(f"Exception parsing url: {e}")
         # Change these to reflect your Spanner instance install
-        print(f"Exception {e}")
+    # Fallbacks if not set
+    if not instance_id:
         instance_id = os.environ.get("INSTANCE_ID", "spanner-test")
+    if not database_id:
         database_id = os.environ.get("DATABASE_ID", "sync_stage")
+    if not project_id:
         project_id = os.environ.get("GOOGLE_CLOUD_PROJECT", "test-project")
     return (instance_id, database_id, project_id)
 


### PR DESCRIPTION
## Description
The `SYNC_SYNCSTORAGE__DATABASE_URL` environment variable defines a spanner DSN URL that is used for parsing out the instance_id & database_id from. However, it was not parsing GCP project, which defaults to the project determined from the environment when not specified. These are defined within webservices-infra in the sync project.

This PR adds the parsing logic to pull out the project_id. Several modernizations and improvements are made to the scripts. It also adds unit tests for better maintainability. 

We’re currently working around this by specifying a GOOGLE_CLOUD_PROJECT env var, which the Spanner client recognizes, but the script should really do it itself since the project is always included in the database url setting.

## Testing

Visit webservices-infra configurations and Kubernetes workflow runs to verify.

New unit tests have been added to validate logic and several bugs were found and now fixed from the addition of tests.

## Issue(s)

Closes [STOR-290](https://mozilla-hub.atlassian.net/browse/STOR-290).


[STOR-290]: https://mozilla-hub.atlassian.net/browse/STOR-290?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ