### PR TITLE
fix: make pyo3 usage optional per the feature flag

### DIFF
--- a/syncserver/Cargo.toml
+++ b/syncserver/Cargo.toml
@@ -47,7 +47,7 @@ syncserver-settings = { path = "../syncserver-settings" }
 syncstorage-db = { path = "../syncstorage-db" }
 syncstorage-settings = { path = "../syncstorage-settings" }
 time = "^0.3"
-tokenserver-auth = { path = "../tokenserver-auth", default-features = false }
+tokenserver-auth = { path = "../tokenserver-auth" }
 tokenserver-common = { path = "../tokenserver-common" }
 tokenserver-db = { path = "../tokenserver-db" }
 tokenserver-settings = { path = "../tokenserver-settings" }
@@ -60,7 +60,7 @@ woothee = "0.13"
 [features]
 default = ["mysql", "py_verifier"]
 no_auth = []
-py_verifier = ["tokenserver-auth/py"]
+py_verifier = ["tokenserver-auth/py", "tokenserver-common/py"]
 mysql = ["syncstorage-db/mysql"]
 spanner = ["syncstorage-db/spanner"]
 actix-compress = ["actix-web/compress-brotli", "actix-web/compress-gzip", "actix-web/compress-zstd"]

--- a/tokenserver-auth/Cargo.toml
+++ b/tokenserver-auth/Cargo.toml
@@ -36,5 +36,4 @@ mockito = "1.4.0"
 tokio = { workspace = true, features = ["macros"] }
 
 [features]
-default = ["py"]
-py = ["pyo3"]
+py = ["pyo3", "tokenserver-common/py"]

--- a/tokenserver-common/Cargo.toml
+++ b/tokenserver-common/Cargo.toml
@@ -15,5 +15,4 @@ pyo3 = { version = "0.24", features = ["auto-initialize"], optional = true }
 syncserver-common = { path = "../syncserver-common" }
 
 [features]
-default = ["py"]
 py = ["pyo3"]

--- a/tokenserver-common/src/error.rs
+++ b/tokenserver-common/src/error.rs
@@ -3,7 +3,6 @@ use std::{cmp::PartialEq, error::Error, fmt};
 use actix_web::{HttpResponse, ResponseError};
 use backtrace::Backtrace;
 use http::StatusCode;
-use pyo3::prelude::PyErr;
 use serde::{
     ser::{SerializeMap, Serializer},
     Serialize,
@@ -326,8 +325,9 @@ impl InternalError for TokenserverError {
     }
 }
 
-impl From<PyErr> for TokenserverError {
-    fn from(err: PyErr) -> Self {
+#[cfg(feature = "py")]
+impl From<pyo3::prelude::PyErr> for TokenserverError {
+    fn from(err: pyo3::prelude::PyErr) -> Self {
         InternalError::internal_error(err.to_string())
     }
 }


### PR DESCRIPTION
## Description

and cleanup feature flag usage (only specifying defaults in syncserver's Cargo.toml)

## Issue(s)

Closes STOR-295 / https://github.com/mozilla-services/syncstorage-rs/issues/1704
