### PR TITLE
test: collect and report spanner tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,6 +119,40 @@ commands:
           environment:
             SYNC_SYNCSTORAGE__ENFORCE_QUOTA: 1
 
+  run-spanner-tests:
+    steps:
+      - run:
+          name: cargo spanner build
+          command: cargo build --workspace --no-default-features --features=syncstorage-db/spanner --features=py_verifier
+      - run:
+          name: Wait for Spanner Emulator
+          command: |-
+            for i in {1..10}; do
+              if nc -z 127.0.0.1 9020; then
+                echo "Spanner emulator running on port 9020."
+                break
+              fi
+              echo "Waiting for Spanner emulator..."
+              sleep 2
+            done
+            if ! nc -z 127.0.0.1 9020; then
+              echo "ERROR: Cannot connect to Spanner emulator at 127.0.0.1:9020. Terminating."
+              exit 1
+            fi
+      - run:
+          name: setup spanner
+          environment:
+            SYNC_SYNCSTORAGE__DATABASE_URL: spanner://projects/test-project/instances/test-instance/databases/test-database
+            SYNC_SYNCSTORAGE__SPANNER_EMULATOR_HOST: 127.0.0.1:9020
+          command: scripts/prepare-spanner.sh
+      - run:
+          name: cargo test spanner
+          environment:
+            SYNC_SYNCSTORAGE__DATABASE_URL: spanner://projects/test-project/instances/test-instance/databases/test-database
+            SYNC_SYNCSTORAGE__SPANNER_EMULATOR_HOST: 127.0.0.1:9010
+            RUST_TEST_THREADS: 1
+          command: make spanner_test_with_coverage
+
   merge-unit-test-coverage:
     steps:
       - run:
@@ -156,39 +190,6 @@ commands:
             make docker_run_<< parameters.db >>_e2e_tests
           environment:
             SYNCSTORAGE_RS_IMAGE: app:build
-
-  run-spanner-tests:
-    steps:
-      - run:
-          name: cargo spanner build
-          command: cargo build --workspace --no-default-features --features=syncstorage-db/spanner --features=py_verifier
-      - run:
-          name: Wait for Spanner Emulator
-          command: |-
-            for i in {1..10}; do
-              if nc -z 127.0.0.1 9020; then
-                echo "Spanner emulator running on port 9020."
-                break
-              fi
-              echo "Waiting for Spanner emulator..."
-              sleep 2
-            done
-            if ! nc -z 127.0.0.1 9020; then
-              echo "ERROR: Cannot connect to Spanner emulator at 127.0.0.1:9020. Terminating."
-              exit 1
-            fi
-      - run:
-          name: setup spanner
-          environment:
-            SYNC_SYNCSTORAGE__DATABASE_URL: spanner://projects/test-project/instances/test-instance/databases/test-database
-            SYNC_SYNCSTORAGE__SPANNER_EMULATOR_HOST: 127.0.0.1:9020
-          command: scripts/prepare-spanner.sh
-      - run:
-          name: cargo test spanner
-          environment:
-            SYNC_SYNCSTORAGE__DATABASE_URL: spanner://projects/test-project/instances/test-instance/databases/test-database
-            SYNC_SYNCSTORAGE__SPANNER_EMULATOR_HOST: 127.0.0.1:9010
-          command: cargo test --workspace --no-default-features --features=syncstorage-db/spanner --features=py_verifier || true
 
   gcs-configure-and-upload:
     parameters:

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ TEST_RESULTS_DIR ?= workflow/test-results
 TEST_PROFILE := $(if $(CIRCLECI),ci,default)
 TEST_FILE_PREFIX := $(if $(CIRCLECI),$(CIRCLE_BUILD_NUM)__$(EPOCH_TIME)__$(CIRCLE_PROJECT_REPONAME)__$(WORKFLOW)__)
 UNIT_JUNIT_XML := $(TEST_RESULTS_DIR)/$(TEST_FILE_PREFIX)unit__results.xml
+SPANNER_UNIT_JUNIT_XML := $(TEST_RESULTS_DIR)/$(TEST_FILE_PREFIX)spanner_unit__results.xml
 UNIT_COVERAGE_JSON := $(TEST_RESULTS_DIR)/$(TEST_FILE_PREFIX)unit__coverage.json
 
 SPANNER_INT_JUNIT_XML := $(TEST_RESULTS_DIR)/$(TEST_FILE_PREFIX)spanner_integration__results.xml
@@ -146,7 +147,7 @@ test_with_coverage:
 spanner_test_with_coverage:
 	cargo llvm-cov --no-report --summary-only \
 		nextest --workspace --no-default-features --features=syncstorage-db/spanner --features=py_verifier --profile ${TEST_PROFILE}|| true; exit_code=$$?
-	mv target/nextest/${TEST_PROFILE}/junit.xml ${UNIT_JUNIT_XML}
+	mv target/nextest/${TEST_PROFILE}/junit.xml ${SPANNER_UNIT_JUNIT_XML}
 	exit $$exit_code
 
 merge_coverage_results:

--- a/Makefile
+++ b/Makefile
@@ -142,6 +142,13 @@ test_with_coverage:
 	mv target/nextest/${TEST_PROFILE}/junit.xml ${UNIT_JUNIT_XML}
 	exit $$exit_code
 
+.ONESHELL:
+spanner_test_with_coverage:
+	cargo llvm-cov --no-report --summary-only \
+		nextest --workspace --no-default-features --features=syncstorage-db/spanner --features=py_verifier --profile ${TEST_PROFILE}|| true; exit_code=$$?
+	mv target/nextest/${TEST_PROFILE}/junit.xml ${UNIT_JUNIT_XML}
+	exit $$exit_code
+
 merge_coverage_results:
 	cargo llvm-cov report --summary-only --json --output-path ${UNIT_COVERAGE_JSON}
 


### PR DESCRIPTION
## Description

After adding Spanner Unit tests as a part of our CI flow, we want to report on these tests in the same way as our other Rust-based unit tests.

Create a scoped makefile command, and move the tests to run after unit tests.

Add commands to run with nexttest and output results.

## Testing
CI results

Can also check `artifacts` section in CI to review test output results.

## Issue(s)

Closes [STOR-293](https://mozilla-hub.atlassian.net/browse/STOR-293).


[STOR-293]: https://mozilla-hub.atlassian.net/browse/STOR-293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ