### PR TITLE
feat: bump max payload to 2.5

### DIFF
--- a/syncstorage-settings/src/lib.rs
+++ b/syncstorage-settings/src/lib.rs
@@ -12,9 +12,11 @@ use syncserver_common::{self, MAX_SPANNER_LOAD_SIZE};
 static KILOBYTE: u32 = 1024;
 static MEGABYTE: u32 = KILOBYTE * KILOBYTE;
 static GIGABYTE: u32 = MEGABYTE * 1_000;
-static DEFAULT_MAX_POST_BYTES: u32 = 2 * MEGABYTE;
+// Current limit of 2.5 MB
+static DEFAULT_MAX_POST_BYTES: u32 = (2.5 * MEGABYTE as f32) as u32;
 static DEFAULT_MAX_POST_RECORDS: u32 = 100;
-static DEFAULT_MAX_RECORD_PAYLOAD_BYTES: u32 = 2 * MEGABYTE;
+// Current limit of 2.5 MB
+static DEFAULT_MAX_RECORD_PAYLOAD_BYTES: u32 = (2.5 * MEGABYTE as f32) as u32;
 static DEFAULT_MAX_REQUEST_BYTES: u32 = DEFAULT_MAX_POST_BYTES + 4 * KILOBYTE;
 static DEFAULT_MAX_TOTAL_BYTES: u32 = 100 * DEFAULT_MAX_POST_BYTES;
 // also used to determine the max number of records to return for MySQL.
@@ -175,6 +177,7 @@ pub struct ServerLimits {
     pub max_post_records: u32,
 
     /// Maximum size of an individual BSO payload, in bytes.
+    /// At present is limited to 2.5MB
     pub max_record_payload_bytes: u32,
 
     /// Maximum `Content-Length` for all incoming requests, in bytes.


### PR DESCRIPTION
## Description

Our current max_record_payload_bytes of 2mb isn’t due to any Spanner limits (which is 2.5mb for STRINGs) but is historical: it was carried over from the origin Python server-syncstorage.

(Which [was limited to 256K up until 2017](https://github.com/mozilla-services/server-syncstorage/pull/70) and was only bumped to 2MB when [Benson was writing the Go version](https://github.com/mozilla-services/go-syncstorage/pull/174))

This PR bumps:
- `max_record_payload_bytes` immediately to Spanner STRING’s limit of 2.5mb. 
- `max_post_bytes` & `max_request_bytes` also bumped accordingly
- `max_request_bytes` also needing adjustment in nginx’s config (as it also enforces it).

## Issue(s)

Closes [STOR-343](mozilla-hub.atlassian.net/browse/STOR-343).


[STOR-343]: https://mozilla-hub.atlassian.net/browse/STOR-343?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ