### PR TITLE
fix: kill unnecessary transactions (savepoints)

### DIFF
--- a/syncstorage-mysql/src/batch.rs
+++ b/syncstorage-mysql/src/batch.rs
@@ -159,7 +159,7 @@ pub fn commit(db: &MysqlDb, params: params::CommitBatch) -> DbResult<results::Co
         .bind::<BigInt, _>(&db.timestamp().as_i64())
         .execute(&mut *db.conn.write()?)?;
 
-    db.update_collection(user_id as u32, collection_id, None)?;
+    db.update_collection(user_id as u32, collection_id)?;
 
     delete(
         db,


### PR DESCRIPTION
## Description

These methods are only called within `lock_for_write` based transactions created by `transaction_http` (all sync writes get this transaction implicitly), so there's no need for them to initiate a transaction (which actually is a savepoint since a transaction already exists). This was old sqlite impl code (possibly inherited from go-syncstorage).

This also simplifies borrowing for `&mut self`.

## Issue(s)

Issue STOR-327
