### PR TITLE
test: add max total records e2e test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -256,10 +256,10 @@ jobs:
     steps:
       - checkout
       - display-versions
-      # - setup-rust-check
-      # - rust-check
-      # - rust-clippy-spanner
-      # - rust-clippy-mysql
+      - setup-rust-check
+      - rust-check
+      - rust-clippy-spanner
+      - rust-clippy-mysql
       - setup-python
       - python-check
 
@@ -298,21 +298,21 @@ jobs:
       - write-version
       - install-test-deps
       - make-test-dir
-      # - run-unit-tests
-      # - run-spanner-tests
-      # - merge-unit-test-coverage
+      - run-unit-tests
+      - run-spanner-tests
+      - merge-unit-test-coverage
       # if the above tests don't run tokenserver-db tests (i.e. using --workspace)
       # then run-tokenserver-scripts-tests will fail. These tests expect the db to be
       # configured already, and it appears unit-tests modify the db to the expected state
-      # - store-test-results
-      # - gcs-configure-and-upload:
-      #     source: workflow/test-results
-      #     destination: gs://ecosystem-test-eng-metrics/syncstorage-rs/junit
-      #     extension: xml
-      # - gcs-configure-and-upload:
-      #     source: workflow/test-results
-      #     destination: gs://ecosystem-test-eng-metrics/syncstorage-rs/coverage
-      #     extension: json
+      - store-test-results
+      - gcs-configure-and-upload:
+          source: workflow/test-results
+          destination: gs://ecosystem-test-eng-metrics/syncstorage-rs/junit
+          extension: xml
+      - gcs-configure-and-upload:
+          source: workflow/test-results
+          destination: gs://ecosystem-test-eng-metrics/syncstorage-rs/coverage
+          extension: json
       # - save-sccache-cache
 
   build-mysql-image:
@@ -599,50 +599,50 @@ workflows:
           filters:
             tags:
               only: /.*/
-      # - build-spanner-image:
-      #     requires:
-      #       - build-and-test
-      # filters:
-      #   tags:
-      #     only: /.*/
+      - build-spanner-image:
+          requires:
+            - build-and-test
+          filters:
+            tags:
+              only: /.*/
       - mysql-e2e-tests:
           requires:
             - build-mysql-image
           filters:
             tags:
               only: /.*/
-      # - spanner-e2e-tests:
-      #     requires:
-      #       - build-spanner-image
-      #     filters:
-      #       tags:
-      #         only: /.*/
+      - spanner-e2e-tests:
+          requires:
+            - build-spanner-image
+          filters:
+            tags:
+              only: /.*/
       - deploy:
           requires:
             - mysql-e2e-tests
-            # - spanner-e2e-tests
+            - spanner-e2e-tests
           filters:
             tags:
               only: /.*/
             branches:
               only: master
               # touch: 1676417203
-      # - deploy-to-gar:
-      #     registry-url: us-docker.pkg.dev
-      #     gar-repo: sync-prod
-      #     image: syncstorage-rs
-      #     requires:
-      #       - mysql-e2e-tests
-      #       - spanner-e2e-tests
-      #     filters:
-      #       tags:
-      #         only: /.*/
-      #       branches:
-      #         only: master
-      # - deploy-python-utils:
-      #     requires:
-      #       - mysql-e2e-tests
-      #       - spanner-e2e-tests
-      #     filters:
-      #       tags:
-      #         only: /.*/
+      - deploy-to-gar:
+          registry-url: us-docker.pkg.dev
+          gar-repo: sync-prod
+          image: syncstorage-rs
+          requires:
+            - mysql-e2e-tests
+            - spanner-e2e-tests
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              only: master
+      - deploy-python-utils:
+          requires:
+            - mysql-e2e-tests
+            - spanner-e2e-tests
+          filters:
+            tags:
+              only: /.*/


### PR DESCRIPTION
## Description
Add a test to  validate our `max_total_records` setting sent to clients via the `/info/configuration` endpoint. The e2e test can retrieve the value, uploading a batch sized to that max value and asserting it’s accepted.

## Issue(s)

Closes [STOR-119](https://mozilla-hub.atlassian.net/browse/STOR-119).


[STOR-119]: https://mozilla-hub.atlassian.net/browse/STOR-119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ