### PR TITLE
chore: use environment value from syncserver settings for Sentry

### DIFF
--- a/syncserver/src/main.rs
+++ b/syncserver/src/main.rs
@@ -45,10 +45,12 @@ async fn main() -> Result<(), Box<dyn Error>> {
         // Note: set "debug: true," to diagnose sentry issues
         transport: Some(Arc::new(curl_transport_factory)),
         release: sentry::release_name!(),
+        environment: Some(settings.environment.clone().into()),
         ..sentry::ClientOptions::default()
     });
     opts.integrations.retain(|i| i.name() != "debug-images");
     opts.default_integrations = false;
+
     let _sentry = sentry::init(opts);
 
     // Setup and run the server


### PR DESCRIPTION
## Description

Use `environment` value from syncserver settings for Sentry's environment config value.

## Testing

sync server should start without error and sentry should continue to function.

## Issue(s)

Closes STOR-90
