### PR TITLE
feat: table models for orm schemas

### DIFF
--- a/tokenserver-db-postgres/src/lib.rs
+++ b/tokenserver-db-postgres/src/lib.rs
@@ -3,7 +3,11 @@ extern crate diesel;
 extern crate diesel_migrations;
 
 mod models;
+mod orm_models;
 mod pool;
+mod schema;
 
 pub use models::TokenserverPgDb;
+pub use orm_models::{Node, Service, User};
 pub use pool::TokenserverPgPool;
+pub use tokenserver_db_common::{params, results, Db, DbPool};

--- a/tokenserver-db-postgres/src/orm_models.rs
+++ b/tokenserver-db-postgres/src/orm_models.rs
@@ -1,0 +1,35 @@
+use crate::schema::{nodes, services, users};
+use diesel::{Identifiable, Insertable, Queryable};
+
+#[derive(Queryable, Debug, Identifiable, Insertable)]
+pub struct Service {
+    pub id: i32,
+    pub service: Option<String>,
+    pub pattern: Option<String>,
+}
+
+#[derive(Queryable, Debug, Identifiable, Insertable)]
+#[diesel(primary_key(uid))]
+pub struct User {
+    pub uid: i64,
+    pub service: i32,
+    pub email: String,
+    pub generation: i64,
+    pub client_state: String,
+    pub created_at: i64,
+    pub replaced_at: Option<i64>,
+    pub nodeid: i64,
+    pub keys_changed_at: Option<i64>,
+}
+
+#[derive(Queryable, Debug, Identifiable, Insertable)]
+pub struct Node {
+    pub id: i64,
+    pub service: i32,
+    pub node: String,
+    pub available: i32,
+    pub current_load: i32,
+    pub capacity: i32,
+    pub downed: i32,
+    pub backoff: i32,
+}


### PR DESCRIPTION
## Description

The use of raw queries as we have used for Tokenserver are advantageous from a readability perspective, but favor should be given to the ORM query constructor. This is especially important as a performance consideration for Postgres, where raw queries needing sql_query will deserialize its data by name, not by index. That means that you cannot deserialize into a tuple, and structs which you deserialize from this function will need to have #[derive(QueryableByName)].

This PR introduces the model structs to be used in cases where we want to move away from raw queries in favor of diesel ORM methods. However, given the readability advantage, it is easy to use a Rust doc comment, which when indented one point, allows one to paste the raw query as part of the method. We should do this because it makes the ORM queries instantaneously understandable. 

See [Diesel Getting Started](https://diesel.rs/guides/getting-started.html)

Note: will rebase upon upcoming changes

## Issue(s)

Closes [STOR-363](https://mozilla-hub.atlassian.net/browse/STOR-363).


[STOR-363]: https://mozilla-hub.atlassian.net/browse/STOR-363?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ