### PR TITLE
refactor(db): return only a SyncTimestamp from post_bsos db fns

### DIFF
--- a/syncstorage-db-common/src/lib.rs
+++ b/syncstorage-db-common/src/lib.rs
@@ -138,10 +138,7 @@ pub trait Db: Debug {
         params: params::GetBsos,
     ) -> DbFuture<'_, results::GetBsoIds, Self::Error>;
 
-    fn post_bsos(
-        &mut self,
-        params: params::PostBsos,
-    ) -> DbFuture<'_, results::PostBsos, Self::Error>;
+    fn post_bsos(&mut self, params: params::PostBsos) -> DbFuture<'_, SyncTimestamp, Self::Error>;
 
     fn delete_bso(
         &mut self,

--- a/syncstorage-db-common/src/params.rs
+++ b/syncstorage-db-common/src/params.rs
@@ -1,7 +1,6 @@
 //! Parameter types for database methods.
 use core::fmt;
 use std::{
-    collections::HashMap,
     fmt::{Display, Formatter},
     num::ParseIntError,
     str::FromStr,
@@ -130,7 +129,6 @@ collection_data! {
     PostBsos {
         bsos: Vec<PostCollectionBso>,
         for_batch: bool,
-        failed: HashMap<String, String>,
     },
 
     CreateBatch {

--- a/syncstorage-db-common/src/results.rs
+++ b/syncstorage-db-common/src/results.rs
@@ -23,6 +23,7 @@ pub type DeleteCollection = SyncTimestamp;
 pub type DeleteBsos = SyncTimestamp;
 pub type DeleteBso = SyncTimestamp;
 pub type PutBso = SyncTimestamp;
+pub type PostBsos = SyncTimestamp;
 
 #[derive(Debug, Default, Clone)]
 pub struct CreateBatch {
@@ -75,13 +76,6 @@ where
 
 pub type GetBsos = Paginated<GetBso>;
 pub type GetBsoIds = Paginated<String>;
-
-#[derive(Debug, Default, Deserialize, Serialize)]
-pub struct PostBsos {
-    pub modified: SyncTimestamp,
-    pub success: Vec<String>,
-    pub failed: HashMap<String, String>,
-}
 
 #[derive(Debug, Default)]
 pub struct ConnectionInfo {

--- a/syncstorage-db/src/tests/db.rs
+++ b/syncstorage-db/src/tests/db.rs
@@ -784,15 +784,8 @@ async fn post_bsos() -> Result<(), DbError> {
                 postbso("b2", Some("payload 2"), Some(100), None),
             ],
             for_batch: false,
-            failed: Default::default(),
         })
         .await?;
-
-    assert!(result.success.contains(&"b0".to_owned()));
-    assert!(result.success.contains(&"b2".to_owned()));
-    // NOTE: b1 exceeds BSO_MAX_TTL but the database layer doesn't validate.
-    // This is the extractor's responsibility
-    //assert!(!result.success.contains(&"b1".to_owned()));
 
     let ts = db
         .get_collection_timestamp(params::GetCollectionTimestamp {
@@ -801,7 +794,7 @@ async fn post_bsos() -> Result<(), DbError> {
         })
         .await?;
     // XXX: casts
-    assert_eq!(result.modified, ts);
+    assert_eq!(result, ts);
 
     let result2 = db
         .post_bsos(params::PostBsos {
@@ -812,14 +805,8 @@ async fn post_bsos() -> Result<(), DbError> {
                 postbso("b2", Some("updated 2"), Some(22), Some(10000)),
             ],
             for_batch: false,
-            failed: Default::default(),
         })
         .await?;
-
-    assert_eq!(result2.success.len(), 2);
-    assert_eq!(result2.failed.len(), 0);
-    assert!(result2.success.contains(&"b0".to_owned()));
-    assert!(result2.success.contains(&"b2".to_owned()));
 
     let bso = db.get_bso(gbso(uid, coll, "b0")).await?.unwrap();
     assert_eq!(bso.sortindex, Some(11));
@@ -834,7 +821,7 @@ async fn post_bsos() -> Result<(), DbError> {
             collection: coll.to_string(),
         })
         .await?;
-    assert_eq!(result2.modified, ts);
+    assert_eq!(result2, ts);
     Ok(())
 }
 


### PR DESCRIPTION
Update the `post_bsos` db functions to return a SyncTimestamp only.  No more "success" or "failed" fields in the db results.  The http responses are unchanged.

Closes https://github.com/mozilla-services/syncstorage-rs/issues/1807