### PR TITLE
fix: switch check to SELECT 1 to fix it on diesel-async

### DIFF
--- a/syncstorage-mysql/src/models.rs
+++ b/syncstorage-mysql/src/models.rs
@@ -788,9 +788,8 @@ impl MysqlDb {
     }
 
     fn check_sync(&mut self) -> DbResult<results::Check> {
-        // has the database been up for more than 0 seconds?
-        let result = sql_query("SHOW STATUS LIKE \"Uptime\"").execute(&mut *self.conn.write()?)?;
-        Ok(result as u64 > 0)
+        diesel::sql_query("SELECT 1").execute(&mut *self.conn.write()?)?;
+        Ok(true)
     }
 
     fn map_collection_names<T>(&mut self, by_id: HashMap<i32, T>) -> DbResult<HashMap<String, T>> {

--- a/tokenserver-db/src/models.rs
+++ b/tokenserver-db/src/models.rs
@@ -188,11 +188,10 @@ impl TokenserverDb {
     }
 
     async fn check(&mut self) -> DbResult<results::Check> {
-        // has the database been up for more than 0 seconds?
-        let result = diesel::sql_query("SHOW STATUS LIKE \"Uptime\"")
+        diesel::sql_query("SELECT 1")
             .execute(&mut self.conn)
             .await?;
-        Ok(result as u64 > 0)
+        Ok(true)
     }
 
     /// Gets the least-loaded node that has available slots.
@@ -2187,6 +2186,14 @@ mod tests {
             spanner_node_id
         );
 
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn heartbeat() -> Result<(), DbError> {
+        let pool = db_pool().await?;
+        let mut db = pool.get().await?;
+        assert!(db.check().await?);
         Ok(())
     }
 


### PR DESCRIPTION
## Description

which is sufficient vs reading uptime as we weren't reading it correctly. execute returns number of rows affected and diesel returns 1 here whereas diesel-async returns 0

Note this is against the last release's branch to avoid changes from master from going out for now (0.21.0 includes the tokenserver move to diesel-async but not much else after that)

## Issue(s)

Closes STOR-365
