### PR TITLE
Fix Postgres post_user Infinite Recursion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ docker_run_postgres_e2e_tests:
 		-f docker-compose.e2e.postgres.yaml \
 	 	up \
 	 	--exit-code-from postgres-e2e-tests \
-	 	--abort-on-container-exit || true;
+	 	--abort-on-container-exit;
 	exit_code=$$?;
 	docker cp postgres-e2e-tests:/postgres_integration_results.xml ${POSTGRES_INT_JUNIT_XML};
 	docker cp postgres-e2e-tests:/postgres_no_jwk_integration_results.xml ${POSTGRES_NO_JWK_INT_JUNIT_XML};

--- a/tokenserver-db-postgres/src/models.rs
+++ b/tokenserver-db-postgres/src/models.rs
@@ -347,7 +347,6 @@ impl TokenserverPgDb {
     }
 
     /// Method to create a new user, given a `PostUser` struct containing data regarding the user.
-    #[cfg(debug_assertions)]
     async fn post_user(&mut self, params: params::PostUser) -> DbResult<results::PostUser> {
         const QUERY: &str = r#"
             INSERT INTO users (service, email, generation, client_state, created_at,


### PR DESCRIPTION
The `postgres-e2e-tests` job was failing in CircleCI due to a stack overflow error.  The problem was that `TokenserverPgDb::post_user` had `#[cfg(debug_assertions)]` thus was not in the release build against which the integration tests were executed, resulting in an infinite recursion in the Db train impl of `post_user`.

Closes STOR-397 / https://github.com/mozilla-services/syncstorage-rs/issues/1869