### PR TITLE
feat: added mozcloud-publish workflow to create and push container images to GAR when a preview label is added to a pull request

### DIFF
--- a/.github/workflows/mozcloud-publish.yaml
+++ b/.github/workflows/mozcloud-publish.yaml
@@ -19,7 +19,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: mozilla-it/deploy-actions/.github/workflows/build-and-push.yml@78c0263d9e6c1d698fa7f4f5d76f5b1eb9dda69a # v4.5.0
+    uses: mozilla-it/deploy-actions/.github/workflows/build-and-push.yml@1b87069d293273436a84dff04954a8950d3ff9ca # v6.1.0
     with:
       image_name: syncstorage-rs
       gar_name: sync-prod


### PR DESCRIPTION
## Description

New GitHub Actions workflow to build and push `syncstorage-rs` container images to GAR when a preview label is added to a pull request. 

Will restrict paths to sync-related directories after testing. 

No changes to the existing CircleCI workflows. 

## Testing

We can add a `preview` label to this pull request to validate the build process. 
