### PR TITLE
chore: add healthcheck to prevent e2e tests starting too early

### DIFF
--- a/docker-compose.e2e.mysql.yaml
+++ b/docker-compose.e2e.mysql.yaml
@@ -12,7 +12,7 @@ services:
     # the syncserver isn't actually used for the tests,
     # but collisions can happen particularly in CI.
       syncserver:
-        condition: service_started
+        condition: service_healthy
     image: app:build
     privileged: true
     user: root

--- a/docker-compose.e2e.postgres.yaml
+++ b/docker-compose.e2e.postgres.yaml
@@ -5,7 +5,7 @@ services:
       mock-fxa-server:
         condition: service_started
       syncserver:
-        condition: service_started
+        condition: service_healthy
       tokenserver-db:
         condition: service_healthy
     image: app:build

--- a/docker-compose.e2e.spanner.yaml
+++ b/docker-compose.e2e.spanner.yaml
@@ -5,7 +5,7 @@ services:
       mock-fxa-server:
         condition: service_started
       syncserver:
-        condition: service_started
+        condition: service_healthy
       tokenserver-db:
         condition: service_healthy
     image: app:build

--- a/docker-compose.mysql.yaml
+++ b/docker-compose.mysql.yaml
@@ -79,6 +79,12 @@ services:
       SYNC_SYNCSTORAGE__DATABASE_URL: mysql://test:test@sync-db:3306/syncstorage
       SYNC_TOKENSERVER__DATABASE_URL: mysql://test:test@tokenserver-db:3306/tokenserver
       SYNC_TOKENSERVER__RUN_MIGRATIONS: "true"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:8000/__heartbeat__ || exit 1"]
+      interval: 2s
+      retries: 5
+      start_period: 30s
+      timeout: 3s
 
 volumes:
   sync_db_data:

--- a/docker-compose.postgres.yaml
+++ b/docker-compose.postgres.yaml
@@ -62,7 +62,10 @@ services:
     ports:
       - "8000:8000"
     depends_on:
-      - sync-db-setup
+      sync-db-setup:
+        condition: service_started
+      tokenserver-db:
+        condition: service_healthy
     environment:
       SYNC_HOST: 0.0.0.0
       SYNC_MASTER_SECRET: secret0
@@ -70,6 +73,12 @@ services:
       SYNC_SYNCSTORAGE__SPANNER_EMULATOR_HOST: sync-db:9010
       SYNC_TOKENSERVER__DATABASE_URL: postgres://test:test@tokenserver-db:5432/tokenserver
       SYNC_TOKENSERVER__RUN_MIGRATIONS: "true"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:8000/__heartbeat__ || exit 1"]
+      interval: 2s
+      retries: 5
+      start_period: 30s
+      timeout: 3s
 
 volumes:
   tokenserver_db_data:

--- a/docker-compose.spanner.yaml
+++ b/docker-compose.spanner.yaml
@@ -60,7 +60,10 @@ services:
     ports:
       - "8000:8000"
     depends_on:
-      - sync-db-setup
+      sync-db-setup:
+        condition: service_started
+      tokenserver-db:
+        condition: service_healthy
     environment:
       SYNC_HOST: 0.0.0.0
       SYNC_MASTER_SECRET: secret0
@@ -68,6 +71,12 @@ services:
       SYNC_SYNCSTORAGE__SPANNER_EMULATOR_HOST: sync-db:9010
       SYNC_TOKENSERVER__DATABASE_URL: mysql://test:test@tokenserver-db:3306/tokenserver
       SYNC_TOKENSERVER__RUN_MIGRATIONS: "true"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:8000/__heartbeat__ || exit 1"]
+      interval: 2s
+      retries: 5
+      start_period: 30s
+      timeout: 3s
 
 volumes:
   tokenserver_db_data:


### PR DESCRIPTION
## Description

Add healthcheck to ensure setup is ready before e2e tests start executing.

## Issue(s)

Closes STOR-416