### PR TITLE
Fix: ensure user collection exists before bsos or batches that reference it

### DIFF
--- a/syncstorage-postgres/src/db/batch_impl.rs
+++ b/syncstorage-postgres/src/db/batch_impl.rs
@@ -34,6 +34,7 @@ impl BatchDb for PgDb {
         let expiry =
             self.timestamp().as_naive_datetime()? + chrono::TimeDelta::milliseconds(BATCH_LIFETIME);
 
+        self.ensure_user_collection(user_id, collection_id).await?;
         insert_into(batches::table)
             .values((
                 batches::batch_id.eq(&batch_id),

--- a/syncstorage-postgres/src/db/db_impl.rs
+++ b/syncstorage-postgres/src/db/db_impl.rs
@@ -350,6 +350,8 @@ impl Db for PgDb {
         let collection_id = self.get_or_create_collection_id(&params.collection).await?;
         let modified = self.timestamp();
 
+        self.ensure_user_collection(params.user_id.legacy_id as i64, collection_id)
+            .await?;
         for pbso in params.bsos {
             self.put_bso(params::PutBso {
                 user_id: params.user_id.clone(),
@@ -483,6 +485,8 @@ impl Db for PgDb {
                 None
             },
         };
+        self.ensure_user_collection(user_id as i64, collection_id)
+            .await?;
         diesel::insert_into(bsos::table)
             .values((
                 bsos::user_id.eq(user_id as i64),


### PR DESCRIPTION
## Description

The code was trying to insert into the bsos and batches Postgres table without ensuring the foreign key referenced record exists in user_collections.

## Testing

tail postgres log while running the e2e tests and you should stop seeing the foreign key constraint errors after this patch.

## Issue(s)

Fixes STOR-425
