### PR TITLE
feat: update collections for standard collections

### DIFF
--- a/syncstorage-postgres/migrations/2025-10-20-155711_create_schema/up.sql
+++ b/syncstorage-postgres/migrations/2025-10-20-155711_create_schema/up.sql
@@ -43,6 +43,27 @@ CREATE TABLE collections (
     name VARCHAR(32) NOT NULL UNIQUE
 );
 
+-- Insert Standard Collections.
+-- These are the 13 standard collections that are expected to exist by clients.
+-- The IDs are fixed.
+-- Reserved spaces for additions to the standard collections begin after 100.
+INSERT INTO collections (collection_id, name) VALUES
+    ( 1, 'clients'),
+    ( 2, 'crypto'),
+    ( 3, 'forms'),
+    ( 4, 'history'),
+    ( 5, 'keys'),
+    ( 6, 'meta'),
+    ( 7, 'bookmarks'),
+    ( 8, 'prefs'),
+    ( 9, 'tabs'),
+    (10, 'passwords'),
+    (11, 'addons'),
+    (12, 'addresses'),
+    (13, 'creditcards');
+
+
+
 -- batches table
 CREATE TABLE batches (
     user_id BIGINT NOT NULL,
@@ -88,3 +109,4 @@ CREATE TABLE batch_bsos (
         batch_id
     ) ON DELETE CASCADE
 );
+


### PR DESCRIPTION
## Description
As we have set up in Spanner and MySQL, we want to explicitly create the standard collections in the `collections` table. 

This includes:
clients
crypto
forms
history
keys
meta
bookmarks
prefs
tabs
passwords
addons
addresses
creditcards

This also ensures that he first 100 slots are reserved for possible future collections, so that all following 100 are user-defined or custom. 

## Issue(s)

Closes [STOR-424](https://mozilla-hub.atlassian.net/browse/STOR-424).


[STOR-424]: https://mozilla-hub.atlassian.net/browse/STOR-424?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ