### PR TITLE
fix: initializing the app once suffices

### DIFF
--- a/syncserver/src/server/test.rs
+++ b/syncserver/src/server/test.rs
@@ -616,7 +616,6 @@ async fn accept_new_or_dev_ios() {
     let response = app.call(req).await.unwrap();
     assert!(response.status().is_success());
 
-    let app = init_app!().await;
     let mut headers = HashMap::new();
     headers.insert(
         "User-Agent",
@@ -633,7 +632,6 @@ async fn accept_new_or_dev_ios() {
     let response = app.call(req).await.unwrap();
     assert!(response.status().is_success());
 
-    let app = init_app!().await;
     let mut headers = HashMap::new();
     headers.insert(
         "User-Agent",


### PR DESCRIPTION
otherwise the postgres Pool init deadlocks on pending DDL statements from the migration

(maybe the Pool should revert back to establishing separate conns for migrations if it's that brittle with misuse of test transactions like this one, but this test should stop calling init_app! multiple times anyway..)

## Issue(s)

Closes STOR-426
