### PR TITLE
fix: ensure Postgres return types and Rust value types match

### DIFF
--- a/syncstorage-postgres/src/db/db_impl.rs
+++ b/syncstorage-postgres/src/db/db_impl.rs
@@ -5,7 +5,7 @@ use chrono::{offset::Utc, DateTime, TimeDelta};
 use diesel::{
     delete,
     dsl::{count, max, now, sql},
-    sql_types::{BigInt, Integer, Nullable},
+    sql_types::{BigInt, Nullable},
     ExpressionMethods, OptionalExtension, QueryDsl, SelectableHelper,
 };
 use diesel_async::{AsyncConnection, RunQueryDsl, TransactionManager};
@@ -259,10 +259,10 @@ impl Db for PgDb {
         &mut self,
         params: params::GetQuotaUsage,
     ) -> DbResult<results::GetQuotaUsage> {
-        let (total_bytes, count): (i64, i32) = user_collections::table
+        let (total_bytes, count): (i64, i64) = user_collections::table
             .select((
-                sql::<BigInt>("COALESCE(SUM(COALESCE(total_bytes, 0)), 0)"),
-                sql::<Integer>("COALESCE(SUM(COALESCE(count, 0)), 0)"),
+                sql::<BigInt>("COALESCE(SUM(COALESCE(total_bytes, 0)), 0)::BIGINT"),
+                sql::<BigInt>("COALESCE(SUM(COALESCE(count, 0)), 0)::BIGINT"),
             ))
             .filter(user_collections::user_id.eq(params.user_id.legacy_id as i64))
             .filter(user_collections::collection_id.eq(params.collection_id))
@@ -272,7 +272,7 @@ impl Db for PgDb {
             .unwrap_or_default();
         Ok(results::GetQuotaUsage {
             total_bytes: total_bytes as usize,
-            count,
+            count: count as i32,
         })
     }
 

--- a/syncstorage-postgres/src/db/mod.rs
+++ b/syncstorage-postgres/src/db/mod.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)] // XXX:
 use diesel::{
     dsl::{now, sql},
-    sql_types::{BigInt, Integer},
+    sql_types::BigInt,
     upsert::excluded,
     ExpressionMethods, OptionalExtension, QueryDsl,
 };
@@ -207,10 +207,10 @@ impl PgDb {
         user_id: i64,
         collection_id: i32,
     ) -> DbResult<results::GetQuotaUsage> {
-        let (total_bytes, count): (i64, i32) = bsos::table
+        let (total_bytes, count): (i64, i64) = bsos::table
             .select((
-                sql::<BigInt>(r#"COALESCE(SUM(LENGTH(COALESCE(payload, ""))),0)"#),
-                sql::<Integer>("COALESCE(COUNT(*),0)"),
+                sql::<BigInt>("COALESCE(SUM(LENGTH(COALESCE(payload, ''))),0)::BIGINT"),
+                sql::<BigInt>("COALESCE(COUNT(*),0)"),
             ))
             .filter(bsos::user_id.eq(user_id))
             .filter(bsos::expiry.gt(now))
@@ -221,7 +221,7 @@ impl PgDb {
             .unwrap_or_default();
         Ok(results::GetQuotaUsage {
             total_bytes: total_bytes as usize,
-            count,
+            count: count as i32,
         })
     }
 }


### PR DESCRIPTION
## Description

There were type mismatches from Postgres SUM or COUNT calls.

## Testing

`RUST_TEST_THREADS=1 cargo test --workspace --no-default-features --features=syncstorage-db/postgres --features=tokenserver-db/postgres --features=py_verifier` should have one fewer failing tests after the patch

## Issue(s)

Fixes STOR-427
