### PR TITLE
bug: downgrade mdbook version for preprocessor

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -14,7 +14,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      MDBOOK_ENV: 0.5.2 # Current mdbook version. See `https://crates.io/crates/mdbook`.
+      MDBOOK_ENV: 0.5.0 # Current mdbook version. See `https://crates.io/crates/mdbook`.
       MERMAID_ENV: 0.15.0 # For crate `mdbook-mermaid`. See: `https://github.com/badboy/mdBook-mermaid/`.
       DEST_DIR: /home/runner/.cargo/bin
     steps:


### PR DESCRIPTION
## Description
As noted in the mdbook-mermaid repo in [this pr](https://github.com/badboy/mdbook-mermaid/pull/61), we were/are having the same issue reported on Nov 18 with the mermaid preprocessor failing:

```
 INFO Book building has started
Unable to parse the input
 WARN Error writing the RenderContext to the backend, Broken pipe (os error 32)
ERROR The "mermaid" preprocessor exited unsuccessfully with exit status: 1 status
```

Downgrading to supported v.0.5 might hopefully fix the issue.

## Testing

Ensure workflow succeeds.
