### PR TITLE
fix: further downgrade mermaid, internal dep env problem

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -14,7 +14,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      MDBOOK_ENV: 0.5.0 # Current mdbook version. See `https://crates.io/crates/mdbook`.
+      MDBOOK_ENV: 0.4.51 # Current mdbook version. See `https://crates.io/crates/mdbook`.
       MERMAID_ENV: 0.15.0 # For crate `mdbook-mermaid`. See: `https://github.com/badboy/mdBook-mermaid/`.
       DEST_DIR: /home/runner/.cargo/bin
     steps:


### PR DESCRIPTION
## Description

Further downgrade mdbook so that it works with mdbook mermaid. There's some internal dep problem that was illustrated by the new debug output that landed:


```

DEBUG mdbook_driver::mdbook: Loading config from /home/runner/work/syncstorage-rs/syncstorage-rs/docs/book.toml
DEBUG mdbook_core::config: Updating the config from environment variables
ERROR mdbook_core::utils: invalid key `env`
Error: Process completed with exit code 101.
```

Not worth wasting time trying to fix, will user older version that should work. 
