### PR TITLE
chore: update mdbook and mermaid

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -14,8 +14,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      MDBOOK_ENV: 0.4.51 # Current mdbook version. See `https://crates.io/crates/mdbook`.
-      MERMAID_ENV: 0.15.0 # For crate `mdbook-mermaid`. See: `https://github.com/badboy/mdBook-mermaid/`.
+      MDBOOK_ENV: 0.5 # Current `mdbook` version. See `https://crates.io/crates/mdbook`.
+      MERMAID_ENV: 0.17.0 # For crate `mdbook-mermaid`. See: `https://github.com/badboy/mdBook-mermaid/`. Always check version compatibility with mdbook.
       DEST_DIR: /home/runner/.cargo/bin
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Syncstorage-rs
 
 Mozilla Sync Storage built with [Rust](https://rust-lang.org).
-For full documentation, please navigate to the service docs *WIP* [here](https://mozilla-services.github.io/syncstorage-rs/) or in the documentation directory in [docs/src](docs/src/). Our documentation is generated using [mdBook](https://rust-lang.github.io/mdBook/index.html) and published to GitHub Pages.
+For full documentation, please navigate to the service docs [here](https://mozilla-services.github.io/syncstorage-rs/) or in the documentation directory in [docs/src](docs/src/). Our documentation is generated using [mdBook](https://rust-lang.github.io/mdBook/index.html) and published to GitHub Pages.
 
 [mpl-svg]: https://img.shields.io/badge/License-MPL%202.0-blue.svg
 [mpl]: https://opensource.org/licenses/MPL-2.0

--- a/docs/src/doc-notes.md
+++ b/docs/src/doc-notes.md
@@ -10,13 +10,21 @@ To build the documentation, install mdBook:
 cargo install mdbook
 ```
 
+For mermaid diagram support, you also have to install [mdbook-mermaid](https://github.com/badboy/mdbook-mermaid).
+Then you need to run an install command to create two minified `js` files `["mermaid.min.js", "mermaid-init.js"]` to render mermaid diagrams:
+
+```bash
+cargo install mdbook-mermaid
+mdbook-mermaid install path/to/book
+```
+
 To have a live interactive instance when working with docs, you can use mdBook's `watch` feature.
 
 ```bash
 mdbook watch path/to/book
 ```
 
-Or use the Makefile utility `make doc-watch` from the rood.
+Or use the Makefile utility `make doc-watch` from the root of syncstorage-rs.
 
 To build documentation locally, run:
 


### PR DESCRIPTION
## Description

Got feedback from maintainer of mdbook-mermaid in our process to build and also support >=  mdbook v5, so updating mdbook-mermaid to 0.17. Added documentation for local build support and maintaining build/install steps in workflow to keep repo maintenance at a minimum. 

## Testing

Successful GH workflow build of docs and mermaid diagrams.

## Issue(s)

Closes [STOR-445](https://mozilla-hub.atlassian.net/browse/STOR-445).


[STOR-445]: https://mozilla-hub.atlassian.net/browse/STOR-445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ