### PR TITLE
chore: bump mbdook to 0.5.2

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -14,7 +14,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      MDBOOK_ENV: 0.5.0 # Current `mdbook` version. See `https://crates.io/crates/mdbook`.
+      MDBOOK_ENV: 0.5.2 # Current `mdbook` version. See `https://crates.io/crates/mdbook`.
       MERMAID_ENV: 0.17.0 # For crate `mdbook-mermaid`. See: `https://github.com/badboy/mdBook-mermaid/`. Always check version compatibility with mdbook.
       DEST_DIR: /home/runner/.cargo/bin
     steps:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-[![License: MPL 2.0][mpl-svg]][mpl] [![Build Status][circleci-badge]][circleci] [![Connect to Matrix via the Riot webapp][matrix-badge]][matrix]
+[![License: MPL 2.0][mpl-svg]][mpl]
+[![Build Status][circleci-badge]][circleci]
+[![docs][docs-badge]][docs]
+[![Connect to Matrix via the Riot webapp][matrix-badge]][matrix]
 
 # Syncstorage-rs
 
@@ -9,5 +12,7 @@ For full documentation, please navigate to the service docs [here](https://mozil
 [mpl]: https://opensource.org/licenses/MPL-2.0
 [circleci-badge]: https://circleci.com/gh/mozilla-services/syncstorage-rs.svg?style=shield
 [circleci]: https://circleci.com/gh/mozilla-services/syncstorage-rs
+[docs-badge]: https://github.com/mozilla-services/syncstorage-rs/actions/workflows/publish-docs.yaml/badge.svg
+[docs]: https://mozilla-services.github.io/syncstorage-rs/
 [matrix-badge]: https://img.shields.io/badge/chat%20on%20[m]-%23services%3Amozilla.org-blue
 [matrix]: https://chat.mozilla.org/#/room/#services:mozilla.org


### PR DESCRIPTION
fixes "ERROR mdbook_core::utils: invalid key `env`"

and add a docs badge