### PR TITLE
chore: move MySQL build and test to GH actions

### DIFF
--- a/.github/workflows/mozcloud-publish.yaml
+++ b/.github/workflows/mozcloud-publish.yaml
@@ -114,3 +114,29 @@ jobs:
       dockerfile_path: tools/postgres/Dockerfile
       image_build_context: tools/postgres
       should_tag_ghcr: true
+
+  build-and-push-syncstorage-rs-mysql:
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event_name == 'push' &&
+        (github.ref_name == 'master' || startsWith(github.ref, 'refs/tags/'))
+      ) ||
+      (
+        github.event_name == 'pull_request' &&
+        contains(github.event.pull_request.labels.*.name, 'preview') &&
+        github.event.pull_request.head.repo.full_name == github.repository
+      )
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
+    uses: mozilla-it/deploy-actions/.github/workflows/build-and-push.yml@1b87069d293273436a84dff04954a8950d3ff9ca # v6.1.0
+    with:
+      image_name: syncstorage-rs-mysql
+      gar_name: sync-prod
+      project_id: moz-fx-sync-prod
+      docker_build_args: |
+        SYNCSTORAGE_DATABASE_BACKEND=mysql
+        TOKENSERVER_DATABASE_BACKEND=mysql
+      should_tag_ghcr: true

--- a/.github/workflows/mysql.yml
+++ b/.github/workflows/mysql.yml
@@ -1,0 +1,213 @@
+name: MySQL Build and Test
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+  push:
+    branches:
+      - master
+    tags:
+      - '**'
+  workflow_dispatch: {}
+
+env:
+  RUST_VERSION: "1.89"
+  PYTHON_VERSION: "3.12"
+
+jobs:
+  build-and-test-mysql:
+    runs-on: ubuntu-latest
+
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: password
+          MYSQL_USER: test
+          MYSQL_PASSWORD: test
+          MYSQL_DATABASE: syncstorage
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+
+    env:
+      SYNC_SYNCSTORAGE__DATABASE_URL: mysql://test:test@127.0.0.1/syncstorage
+      SYNC_TOKENSERVER__DATABASE_URL: mysql://test:test@127.0.0.1/tokenserver
+      RUST_BACKTRACE: 1
+      RUST_TEST_THREADS: 1
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: ./.github/actions/setup-rust
+        with:
+          workspace-path: workflow/test-results
+
+      - uses: ./.github/actions/setup-python
+        with:
+          workspace-path: workflow/test-results
+
+      - name: Install MySQL client
+        run: sudo apt-get update && sudo apt-get install -y default-mysql-client
+
+      - name: Create Tokenserver database
+        run: |
+          mysql -u root -ppassword -h 127.0.0.1 -e 'CREATE DATABASE tokenserver;'
+          mysql -u root -ppassword -h 127.0.0.1 -e "GRANT ALL ON tokenserver.* to 'test'@'%';"
+
+      - name: Create version.json
+        run: |
+          printf '{"commit":"%s","version":"%s","source":"https://github.com/%s/%s","build":"%s"}\n' \
+            "${{ github.sha }}" \
+            "${{ github.ref_name }}" \
+            "${{ github.repository_owner }}" \
+            "${{ github.event.repository.name }}" \
+            "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            > syncserver/version.json
+
+      - name: Install test dependencies
+        run: cargo install --locked cargo-nextest cargo-llvm-cov
+
+      - name: Run unit tests with coverage
+        run: make test_with_coverage
+
+      - name: Run unit tests with coverage (quota enforced)
+        run: make test_with_coverage
+        env:
+          SYNC_SYNCSTORAGE__ENFORCE_QUOTA: 1
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: mysql-test-results
+          path: workflow/test-results/
+
+      # Upload to GCS on master
+      - name: Authenticate to Google Cloud
+        if: github.ref == 'refs/heads/master' && env.GCP_AUTH_KEY != ''
+        env:
+          GCP_AUTH_KEY: ${{ secrets.ETE_GCLOUD_SERVICE_KEY }}
+        uses: google-github-actions/auth@v3
+        with:
+          credentials_json: ${{ secrets.ETE_GCLOUD_SERVICE_KEY }}
+
+      - name: Upload JUnit results to GCS
+        if: github.ref == 'refs/heads/master' && env.GCP_AUTH_KEY != ''
+        env:
+          GCP_AUTH_KEY: ${{ secrets.ETE_GCLOUD_SERVICE_KEY }}
+        uses: google-github-actions/upload-cloud-storage@v2
+        with:
+          path: workflow/test-results
+          destination: ecosystem-test-eng-metrics/syncstorage-rs/junit
+          glob: "*.xml"
+          parent: false
+          process_gcloudignore: false
+
+      - name: Upload coverage results to GCS
+        if: github.ref == 'refs/heads/master' && env.GCP_AUTH_KEY != ''
+        env:
+          GCP_AUTH_KEY: ${{ secrets.ETE_GCLOUD_SERVICE_KEY }}
+        uses: google-github-actions/upload-cloud-storage@v2
+        with:
+          path: workflow/test-results
+          destination: ecosystem-test-eng-metrics/syncstorage-rs/coverage
+          glob: "*.json"
+          parent: false
+          process_gcloudignore: false
+
+  build-mysql-image:
+    runs-on: ubuntu-latest
+    needs: build-and-test-mysql
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Create version.json
+        run: |
+          printf '{"commit":"%s","version":"%s","source":"https://github.com/%s/%s","build":"%s"}\n' \
+            "${{ github.sha }}" \
+            "${{ github.ref_name }}" \
+            "${{ github.repository_owner }}" \
+            "${{ github.event.repository.name }}" \
+            "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            > syncserver/version.json
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build MySQL Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          tags: app:build
+          build-args: |
+            SYNCSTORAGE_DATABASE_BACKEND=mysql
+            TOKENSERVER_DATABASE_BACKEND=mysql
+          outputs: type=docker,dest=/tmp/mysql-image.tar
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Upload Docker image artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: mysql-docker-image
+          path: /tmp/mysql-image.tar
+          retention-days: 1
+
+  mysql-e2e-tests:
+    runs-on: ubuntu-latest
+    needs: build-mysql-image
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Download Docker image
+        uses: actions/download-artifact@v6
+        with:
+          name: mysql-docker-image
+          path: /tmp
+
+      - name: Load Docker image
+        run: docker load --input /tmp/mysql-image.tar
+
+      - name: Create test results directory
+        run: mkdir -p workflow/test-results
+
+      - name: Run MySQL e2e tests
+        run: make docker_run_mysql_e2e_tests
+        env:
+          SYNCSTORAGE_RS_IMAGE: app:build
+
+      - name: Upload e2e test results
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: mysql-e2e-test-results
+          path: workflow/test-results/
+
+      # Upload to GCS on master
+      - name: Authenticate to Google Cloud
+        if: github.ref == 'refs/heads/master' && env.GCP_AUTH_KEY != ''
+        env:
+          GCP_AUTH_KEY: ${{ secrets.ETE_GCLOUD_SERVICE_KEY }}
+        uses: google-github-actions/auth@v3
+        with:
+          credentials_json: ${{ secrets.ETE_GCLOUD_SERVICE_KEY }}
+
+      - name: Upload e2e test results to GCS
+        if: github.ref == 'refs/heads/master' && env.GCP_AUTH_KEY != ''
+        env:
+          GCP_AUTH_KEY: ${{ secrets.ETE_GCLOUD_SERVICE_KEY }}
+        uses: google-github-actions/upload-cloud-storage@v2
+        with:
+          path: workflow/test-results
+          destination: ecosystem-test-eng-metrics/syncstorage-rs/junit
+          glob: "*.xml"
+          parent: false
+          process_gcloudignore: false


### PR DESCRIPTION
This patch allows us to build and test the MySQL build with GH actions.  It will also start publishing to ghcr.

One minor downside compared to a single CircleCI workflow is that we are using mozilla-it/deploy-actions's `build-and-push` to publish the image.  That means the image is built twice on push to master or a tag, once for the e2e tests and another by `build-and-push`.  We'll see how well this works in practice and improve if necessary.  (I'm not worried that the `build-and-push` workflow runs simultaneously to the build and tests since we require the PR branch to be up to date with master before merging.)

Closes STOR-454