### PR TITLE
feat: migrate docker hub push to github actions

### DIFF
--- a/.github/workflows/mysql.yml
+++ b/.github/workflows/mysql.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - master
     tags:
-      - '**'
+      - "**"
   workflow_dispatch: {}
 
 env:
@@ -212,7 +212,7 @@ jobs:
           parent: false
           process_gcloudignore: false
 
-  deploy-mysql:
+  deploy-mysql-dockerhub:
     runs-on: ubuntu-latest
     needs: mysql-e2e-tests
     if: |

--- a/.github/workflows/postgres.yml
+++ b/.github/workflows/postgres.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - master
     tags:
-      - '**'
+      - "**"
   workflow_dispatch: {}
 
 env:
@@ -218,7 +218,7 @@ jobs:
           parent: false
           process_gcloudignore: false
 
-  deploy-postgres:
+  deploy-postgres-dockerhub:
     runs-on: ubuntu-latest
     needs: postgres-e2e-tests
     if: |
@@ -264,4 +264,3 @@ jobs:
           docker tag app:build ${{ steps.docker-tag.outputs.full_tag }}
           docker images
           docker push ${{ steps.docker-tag.outputs.full_tag }}
-

--- a/.github/workflows/spanner.yml
+++ b/.github/workflows/spanner.yml
@@ -224,3 +224,50 @@ jobs:
           glob: "*.xml"
           parent: false
           process_gcloudignore: false
+
+  deploy-spanner-dockerhub:
+    runs-on: ubuntu-latest
+    needs: spanner-e2e-tests
+    if: |
+      github.ref == 'refs/heads/master' ||
+      startsWith(github.ref, 'refs/tags/') ||
+      startsWith(github.ref, 'refs/heads/feature.')
+
+    steps:
+      - name: Download Docker image
+        uses: actions/download-artifact@v6
+        with:
+          name: spanner-docker-image
+          path: /tmp
+
+      - name: Load Docker image
+        run: docker load --input /tmp/spanner-image.tar
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PASS }}
+
+      - name: Determine Docker tag
+        id: docker-tag
+        run: |
+          if [ "${{ github.ref }}" == "refs/heads/master" ]; then
+            DOCKER_TAG="${{ github.sha }}"
+          elif [[ "${{ github.ref }}" == refs/tags/* ]]; then
+            DOCKER_TAG="${{ github.ref_name }}"
+          elif [[ "${{ github.ref }}" == refs/heads/feature.* ]]; then
+            DOCKER_TAG="${{ github.ref_name }}"
+          else
+            echo "Not pushing to DockerHub for ref=${{ github.ref }}"
+            exit 0
+          fi
+          echo "tag=${DOCKER_TAG}" >> $GITHUB_OUTPUT
+          echo "full_tag=${{ secrets.DOCKERHUB_REPO }}:${DOCKER_TAG}-spanner" >> $GITHUB_OUTPUT
+
+      - name: Tag and push Docker image
+        if: steps.docker-tag.outputs.tag != ''
+        run: |
+          docker tag app:build ${{ steps.docker-tag.outputs.full_tag }}
+          docker images
+          docker push ${{ steps.docker-tag.outputs.full_tag }}


### PR DESCRIPTION
## Description

While we will eventually no longer support DockerHub, for the time being we publish images here for self hosters and other purposes. 

This PR converts the Docker publish and deploy of the image from CircleCI to GitHub Actions.

May need to add some permissions to properly authenticate to DockerHub. I've filed an issue with SRE to issue new credentials, since copying previous ones in CircleCI is not possible.

## Issue(s)

Closes [STOR-459](https://mozilla-hub.atlassian.net/browse/STOR-459).


[STOR-459]: https://mozilla-hub.atlassian.net/browse/STOR-459?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ