### PR TITLE
docs: add one-shot docker compose yaml to how-to

### DIFF
--- a/docs/src/how-to/how-to-run-with-docker.md
+++ b/docs/src/how-to/how-to-run-with-docker.md
@@ -9,28 +9,29 @@ Images are available for both
 [MySQL](https://github.com/mozilla-services/syncstorage-rs/pkgs/container/syncstorage-rs%2Fsyncstorage-rs-mysql)
 and
 [PostgreSQL](https://github.com/mozilla-services/syncstorage-rs/pkgs/container/syncstorage-rs%2Fsyncstorage-rs-postgres)
-as the database.  The sample code will focus on MySQL.  Differences in
-configuration or deployment steps will be noted. 
+as the database.  Differences in configuration or deployment steps will be
+noted. 
 
 > **Note:** At the time of writing, there are no tagged release builds
 > available on ghcr.io.  This guide will use a build from the main development
 > branch.
 
 ## Prerequisites and Presumptions
-- The reader has a MySQL or PostgreSQL database up and running.
 - The reader is familiar with the command line interface and `docker`.
 - The reader is going to use [Mozilla accounts](https://accounts.firefox.com/)
   for authentication and authorization.
 - The service will be deployed at http://localhost:8000/.
 
-## Docker Compose
+## Docker Compose, Sync Services Only
 
-Save the yaml below into a file, e.g. `docker-compose.yaml`.
+With a MySQL or PostgreSQL database is already up and running, save the yaml
+below into a file, e.g. `docker-compose.yaml`, and ensure the `image` field is
+using the correct MySQL or PostgreSQL build for the database.
 
 ```yaml
 services:
   syncserver:
-    image: ghcr.io/mozilla-services/syncstorage-rs/syncstorage-rs-mysql:b16ef5064b
+    image: ghcr.io/mozilla-services/syncstorage-rs/syncstorage-rs-mysql:${SYNCSERVER_VERSION:-b16ef5064b}
     platform: linux/amd64
     container_name: syncserver
     ports:
@@ -102,6 +103,99 @@ service URL.
 Restart the service with 
 ```sh
 docker compose -f docker-compose.yaml restart
+```
+
+## Docker Compose, One-Shot with PostgreSQL
+
+Alternatively, the database can be started through `docker compose` as well.  The real service URL can be set with the `NODE_URL` environment variable.
+
+Save the yaml below into a file, e.g. `docker-compose.one-shot.yaml`.
+
+```yaml
+services:
+  syncserver:
+    image: ghcr.io/mozilla-services/syncstorage-rs/syncstorage-rs-postgres:${SYNCSERVER_VERSION:-11659d98f9}
+    platform: linux/amd64
+    container_name: syncserver
+    ports:
+      - "8000:8000"
+    environment:
+      SYNC_HOST: "0.0.0.0"
+      SYNC_PORT: "8000"
+      SYNC_MASTER_SECRET: "${SYNC_MASTER_SECRET:-changeme_secret_key}"
+      SYNC_SYNCSTORAGE__DATABASE_URL: "postgres://sync:sync@postgres:5432/syncserver"
+      SYNC_TOKENSERVER__DATABASE_URL: "postgres://sync:sync@postgres:5432/syncserver"
+      SYNC_TOKENSERVER__ENABLED: "true"
+      SYNC_TOKENSERVER__RUN_MIGRATIONS: "true"
+      SYNC_TOKENSERVER__FXA_EMAIL_DOMAIN: "api.accounts.firefox.com"
+      SYNC_TOKENSERVER__FXA_OAUTH_SERVER_URL: "https://oauth.accounts.firefox.com"
+      SYNC_HUMAN_LOGS: "${SYNC_HUMAN_LOGS:-false}"
+      RUST_LOG: "${RUST_LOG:-info}"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/__heartbeat__"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+
+  postgres:
+    image: postgres:18
+    container_name: syncserver-postgres
+    environment:
+      POSTGRES_USER: sync
+      POSTGRES_PASSWORD: sync
+      POSTGRES_DB: syncserver
+    volumes:
+      - postgres_data:/var/lib/postgresql
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U sync -d syncserver"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    restart: unless-stopped
+
+  # insert record for the storage node
+  bootstrap:
+    image: postgres:18
+    container_name: syncserver-bootstrap
+    environment:
+      PGHOST: postgres
+      PGPORT: 5432
+      PGUSER: sync
+      PGPASSWORD: sync
+      PGDATABASE: syncserver
+      NODE_URL: "${NODE_URL:-http://localhost:8000}"
+    depends_on:
+      syncserver:
+        condition: service_healthy
+    command: >
+      sh -c "
+      echo 'Waiting for migrations to complete...';
+      sleep 5;
+      echo 'Inserting storage node record...';
+      psql -c \"INSERT INTO nodes (service, node, available, current_load, capacity, downed, backoff)
+               VALUES ((SELECT id FROM services WHERE service = 'sync-1.5'), '\$\${NODE_URL}', 1, 0, 1000, 0, 0)
+               ON CONFLICT (service, node) DO NOTHING;\";
+      echo 'DB bootstrap complete';
+      "
+    restart: "no"
+
+volumes:
+  postgres_data:
+    driver: local
+```
+
+Next, start the service with `docker compose`:
+
+```sh
+SYNC_MASTER_SECRET=use_your_own_secret_4d3d3d3d \
+NODE_URL=http://localhost:8000 \
+docker compose -f docker-compose.one-shot.yaml up -d
 ```
 
 ## Configuring Firefox


### PR DESCRIPTION
Add a one-shot docker file to start the db with `docker compose` also.  Follow-up to STOR-118 / #1428 / PR #2019.