### PR TITLE
chore: upgrade to Rust 2024 edition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3586,6 +3586,7 @@ dependencies = [
  "slog-scope",
  "syncserver-common",
  "syncstorage-settings",
+ "temp-env",
  "tokenserver-settings",
  "url",
 ]
@@ -3726,6 +3727,15 @@ name = "target-lexicon"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
+
+[[package]]
+name = "temp-env"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96374855068f47402c3121c6eed88d29cb1de8f3ab27090e273e420bdabcf050"
+dependencies = [
+ "parking_lot",
+]
 
 [[package]]
 name = "term"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ version = "0.21.1"
 authors = [
   "Mozilla Sync Backend Engineering <sync-backend@mozilla.com",
 ]
-edition = "2021"
+edition = "2024"
 rust-version = "1.89"
 license = "MPL-2.0"
 

--- a/syncserver-common/src/lib.rs
+++ b/syncserver-common/src/lib.rs
@@ -7,8 +7,8 @@ mod tags;
 
 use std::{
     fmt,
-    sync::atomic::{AtomicU64, Ordering},
     sync::Arc,
+    sync::atomic::{AtomicU64, Ordering},
 };
 
 use actix_web::web;
@@ -17,7 +17,7 @@ use hkdf::Hkdf;
 use serde_json::Value;
 use sha2::Sha256;
 
-pub use metrics::{metrics_from_opts, MetricError, Metrics};
+pub use metrics::{MetricError, Metrics, metrics_from_opts};
 pub use tags::Taggable;
 
 // header statics must be lower case, numbers and symbols per the RFC spec. This reduces chance of error.

--- a/syncserver-db-common/src/error.rs
+++ b/syncserver-db-common/src/error.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use backtrace::Backtrace;
 use http::StatusCode;
-use syncserver_common::{from_error, impl_fmt_display, ReportableError};
+use syncserver_common::{ReportableError, from_error, impl_fmt_display};
 use thiserror::Error;
 
 /// Error specific to any SQL database backend. These errors are not related to the syncstorage

--- a/syncserver-db-common/src/lib.rs
+++ b/syncserver-db-common/src/lib.rs
@@ -5,10 +5,10 @@ use std::{error::Error, fmt::Debug};
 
 #[cfg(debug_assertions)]
 use diesel::connection::InstrumentationEvent;
-use diesel::{result::ConnectionResult, Connection};
+use diesel::{Connection, result::ConnectionResult};
 use diesel_async::{
-    async_connection_wrapper::AsyncConnectionWrapper, pooled_connection::ManagerConfig,
-    AsyncConnection, AsyncMigrationHarness,
+    AsyncConnection, AsyncMigrationHarness, async_connection_wrapper::AsyncConnectionWrapper,
+    pooled_connection::ManagerConfig,
 };
 use diesel_migrations::{EmbeddedMigrations, MigrationHarness};
 use tokio::task::spawn_blocking;

--- a/syncserver-db-common/src/test.rs
+++ b/syncserver-db-common/src/test.rs
@@ -1,5 +1,5 @@
 use deadpool::managed::{HookError, HookResult};
-use diesel_async::{pooled_connection::PoolError, AsyncConnection};
+use diesel_async::{AsyncConnection, pooled_connection::PoolError};
 
 pub async fn test_transaction_hook<T>(conn: &mut T) -> HookResult<PoolError>
 where

--- a/syncserver-settings/Cargo.toml
+++ b/syncserver-settings/Cargo.toml
@@ -15,3 +15,6 @@ syncserver-common = { path = "../syncserver-common" }
 syncstorage-settings = { path = "../syncstorage-settings" }
 tokenserver-settings = { path = "../tokenserver-settings" }
 url = "2.1"
+
+[dev-dependencies]
+temp-env = "0.3"

--- a/syncserver/src/error.rs
+++ b/syncserver/src/error.rs
@@ -9,16 +9,16 @@ use std::convert::From;
 use std::fmt;
 
 use actix_web::{
-    dev::ServiceResponse, error::ResponseError, middleware::ErrorHandlerResponse, HttpResponse,
-    HttpResponseBuilder, Result,
+    HttpResponse, HttpResponseBuilder, Result, dev::ServiceResponse, error::ResponseError,
+    middleware::ErrorHandlerResponse,
 };
 use http::StatusCode;
 use serde::{
-    ser::{SerializeMap, SerializeSeq, Serializer},
     Serialize,
+    ser::{SerializeMap, SerializeSeq, Serializer},
 };
 
-use syncserver_common::{from_error, impl_fmt_display, MetricError, ReportableError};
+use syncserver_common::{MetricError, ReportableError, from_error, impl_fmt_display};
 use syncstorage_db::{DbError, DbErrorIntrospect};
 
 use thiserror::Error;

--- a/syncserver/src/logging.rs
+++ b/syncserver/src/logging.rs
@@ -8,7 +8,7 @@ use std::os::linux::fs::MetadataExt;
 
 use crate::error::ApiResult;
 
-use slog::{self, slog_o, Drain};
+use slog::{self, Drain, slog_o};
 use slog_mozlog_json::MozLogJson;
 
 #[cfg(target_os = "linux")]

--- a/syncserver/src/server/mod.rs
+++ b/syncserver/src/server/mod.rs
@@ -5,19 +5,19 @@ use std::{convert::Infallible, num::NonZeroUsize, sync::Arc, time::Duration};
 use crate::error::ApiError;
 use actix_cors::Cors;
 use actix_web::{
+    App, FromRequest, HttpRequest, HttpResponse, HttpServer,
     dev::{self, Payload},
     http::StatusCode,
-    http::{header::LOCATION, Method},
+    http::{Method, header::LOCATION},
     middleware::ErrorHandlers,
     web::{self, Data},
-    App, FromRequest, HttpRequest, HttpResponse, HttpServer,
 };
 use cadence::{Gauged, StatsdClient};
 use futures::future::{self, Ready};
 use glean::server_events::GleanEventsLogger;
 use syncserver_common::{
-    middleware::sentry::SentryWrapper, BlockingThreadpool, BlockingThreadpoolMetrics, Metrics,
-    Taggable,
+    BlockingThreadpool, BlockingThreadpoolMetrics, Metrics, Taggable,
+    middleware::sentry::SentryWrapper,
 };
 use syncserver_db_common::{GetPoolState, PoolState};
 use syncserver_settings::Settings;

--- a/syncserver/src/server/test.rs
+++ b/syncserver/src/server/test.rs
@@ -10,22 +10,21 @@ use actix_web::{
     test,
     web::Bytes,
 };
-use base64::{engine, Engine};
+use base64::{Engine, engine};
 use chrono::offset::Utc;
 use hawk::{self, Credentials, Key, RequestBuilder};
 use hmac::{Hmac, Mac};
 use http::StatusCode;
 use lazy_static::lazy_static;
-use rand::{thread_rng, Rng};
+use rand::{Rng, thread_rng};
 use serde::de::DeserializeOwned;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use sha2::Sha256;
 use syncserver_common::{self, X_LAST_MODIFIED};
 use syncserver_settings::{Secrets, Settings};
 use syncstorage_db::{
-    params,
+    DbPoolImpl, SyncTimestamp, params,
     results::{DeleteBso, GetBso, PutBso},
-    DbPoolImpl, SyncTimestamp,
 };
 use syncstorage_settings::ServerLimits;
 

--- a/syncserver/src/tokenserver/handlers.rs
+++ b/syncserver/src/tokenserver/handlers.rs
@@ -3,22 +3,22 @@ use std::{
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
-use actix_web::{http::StatusCode, Error, HttpResponse};
-use base64::{engine, Engine};
+use actix_web::{Error, HttpResponse, http::StatusCode};
+use base64::{Engine, engine};
 use serde::Serialize;
 use serde_json::Value;
 use tokenserver_auth::{MakeTokenPlaintext, Tokenlib, TokenserverOrigin};
 use tokenserver_common::{NodeType, TokenserverError};
 use tokenserver_db::{
-    params::{GetNodeId, PostUser, PutUser, ReplaceUsers},
     Db,
+    params::{GetNodeId, PostUser, PutUser, ReplaceUsers},
 };
 use tokio::time::timeout;
 use utoipa::ToSchema;
 
 use super::{
-    extractors::{DbWrapper, TokenserverRequest},
     TokenserverMetrics,
+    extractors::{DbWrapper, TokenserverRequest},
 };
 
 #[derive(Debug, Serialize, ToSchema)]

--- a/syncserver/src/tokenserver/logging.rs
+++ b/syncserver/src/tokenserver/logging.rs
@@ -1,15 +1,18 @@
 use actix_web::{
-    dev::{Service, ServiceRequest, ServiceResponse},
     HttpMessage,
+    dev::{Service, ServiceRequest, ServiceResponse},
 };
 use futures::future::Future;
 
 use super::LogItems;
 
-pub fn handle_request_log_line<B>(
+pub fn handle_request_log_line<B, S>(
     request: ServiceRequest,
-    service: &impl Service<ServiceRequest, Response = ServiceResponse<B>, Error = actix_web::Error>,
-) -> impl Future<Output = Result<ServiceResponse<B>, actix_web::Error>> {
+    service: &S,
+) -> impl Future<Output = Result<ServiceResponse<B>, actix_web::Error>> + use<B, S>
+where
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = actix_web::Error>,
+{
     let items = LogItems::from(request.head());
     request.extensions_mut().insert(items);
     let fut = service.call(request);

--- a/syncserver/src/web/auth.rs
+++ b/syncserver/src/web/auth.rs
@@ -8,7 +8,7 @@
 
 use std::convert::TryInto;
 
-use base64::{engine, Engine};
+use base64::{Engine, engine};
 use chrono::offset::Utc;
 use hawk::{self, Header as HawkHeader, Key, RequestBuilder};
 use hmac::{Hmac, Mac};
@@ -497,12 +497,7 @@ mod tests {
                     "h1Ch4vo=",
                     1_569_608_439,
                 ),
-                request: Request::new(
-                    "GET",
-                    "/storage/1.5/1/storage/col2",
-                    "localhost",
-                    5000,
-                ),
+                request: Request::new("GET", "/storage/1.5/1/storage/col2", "localhost", 5000),
                 master_secret: Secrets::new("Ted Koppel is a robot").unwrap(),
                 expected: HawkPayload {
                     expires: 1_884_968_439.0,
@@ -511,8 +506,12 @@ mod tests {
                     user_id: 1,
                     fxa_uid: "319b98f9961ff1dbdd07313cd6ba925a".to_owned(),
                     fxa_kid: "de697ad66d845b2873c9d7e13b8971af".to_owned(),
-                    hashed_fxa_uid: "0e8df5d41398a389913bd8402435649518af46493da1d4a437a46dc1784c501a".to_owned(),
-                    hashed_device_id: "2bcb92f4d4698c3d7b083a3c698a16ccd78bc2a8d20a96e4bb128ddceaf4e0b6".to_owned(),
+                    hashed_fxa_uid:
+                        "0e8df5d41398a389913bd8402435649518af46493da1d4a437a46dc1784c501a"
+                            .to_owned(),
+                    hashed_device_id:
+                        "2bcb92f4d4698c3d7b083a3c698a16ccd78bc2a8d20a96e4bb128ddceaf4e0b6"
+                            .to_owned(),
                     tokenserver_origin: Default::default(),
                 },
             }

--- a/syncserver/src/web/error.rs
+++ b/syncserver/src/web/error.rs
@@ -2,16 +2,16 @@
 #![allow(clippy::single_match)]
 use std::fmt;
 
-use actix_web::http::header::ToStrError;
 use actix_web::Error as ActixError;
+use actix_web::http::header::ToStrError;
 use base64::DecodeError;
 
 use hawk::Error as ParseError;
 use hmac::digest::{InvalidLength, MacError};
 use http::StatusCode;
 use serde::{
-    ser::{SerializeSeq, Serializer},
     Serialize,
+    ser::{SerializeSeq, Serializer},
 };
 use serde_json::{Error as JsonError, Value};
 use syncserver_common::{from_error, impl_fmt_display};
@@ -111,12 +111,7 @@ impl ValidationError {
 
     pub fn weave_error_code(&self) -> WeaveError {
         match &self.kind {
-            ValidationErrorKind::FromDetails(
-                ref description,
-                ref location,
-                name,
-                ref _metric_label,
-            ) => {
+            ValidationErrorKind::FromDetails(description, location, name, _metric_label) => {
                 match description.as_ref() {
                     "over-quota" => return WeaveError::OverQuota,
                     "size-limit-exceeded" => return WeaveError::SizeLimitExceeded,
@@ -130,7 +125,7 @@ impl ValidationError {
                 }
                 WeaveError::UnknownError
             }
-            ValidationErrorKind::FromValidationErrors(ref _err, ref location, _metric_label) => {
+            ValidationErrorKind::FromValidationErrors(_err, location, _metric_label) => {
                 if *location == RequestErrorLocation::Body {
                     WeaveError::InvalidWbo
                 } else {

--- a/syncserver/src/web/extractors/batch_request.rs
+++ b/syncserver/src/web/extractors/batch_request.rs
@@ -1,7 +1,7 @@
 use actix_web::{
+    Error, FromRequest, HttpRequest,
     dev::Payload,
     web::{Data, Query},
-    Error, FromRequest, HttpRequest,
 };
 use futures::future::{LocalBoxFuture, TryFutureExt};
 use serde::Deserialize;
@@ -9,7 +9,7 @@ use validator::{Validate, ValidationError};
 
 use syncserver_common::X_WEAVE_RECORDS;
 
-use super::{request_error, RequestErrorLocation, TRUE_REGEX};
+use super::{RequestErrorLocation, TRUE_REGEX, request_error};
 use crate::{
     error::ApiError,
     server::ServerState,

--- a/syncserver/src/web/extractors/bso_bodies.rs
+++ b/syncserver/src/web/extractors/bso_bodies.rs
@@ -1,19 +1,19 @@
 use std::collections::{HashMap, HashSet};
 
 use actix_web::{
+    Error, FromRequest, HttpRequest,
     dev::Payload,
     http::header::{ContentType, Header},
     web::Data,
-    Error, FromRequest, HttpRequest,
 };
 use futures::{
-    future::{self, LocalBoxFuture},
     TryFutureExt,
+    future::{self, LocalBoxFuture},
 };
 use serde::Deserialize;
 use serde_json::Value;
 
-use super::{BatchBsoBody, RequestErrorLocation, ACCEPTED_CONTENT_TYPES};
+use super::{ACCEPTED_CONTENT_TYPES, BatchBsoBody, RequestErrorLocation};
 use crate::{server::ServerState, web::error::ValidationErrorKind};
 
 #[derive(Default, Deserialize)]
@@ -48,7 +48,7 @@ impl FromRequest for BsoBodies {
                         Some("request.error.invalid_content_type"),
                     )
                     .into(),
-                ))
+                ));
             }
         };
         let content_type = format!("{}/{}", ctype.type_(), ctype.subtype());

--- a/syncserver/src/web/extractors/bso_body.rs
+++ b/syncserver/src/web/extractors/bso_body.rs
@@ -1,16 +1,16 @@
 use actix_web::{
+    Error, FromRequest, HttpRequest,
     dev::Payload,
     http::header::{ContentType, Header},
     web::Data,
-    Error, FromRequest, HttpRequest,
 };
 use futures::future::LocalBoxFuture;
-use serde::{de::IgnoredAny, Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::IgnoredAny};
 use validator::Validate;
 
 use super::{
-    validate_body_bso_id, validate_body_bso_sortindex, validate_body_bso_ttl, RequestErrorLocation,
-    ACCEPTED_CONTENT_TYPES,
+    ACCEPTED_CONTENT_TYPES, RequestErrorLocation, validate_body_bso_id,
+    validate_body_bso_sortindex, validate_body_bso_ttl,
 };
 use crate::{server::ServerState, web::error::ValidationErrorKind};
 
@@ -54,7 +54,7 @@ impl FromRequest for BsoBody {
                         Some("Content-Type".to_owned()),
                         Some("request.error.invalid_content_type"),
                     )
-                    .into())
+                    .into());
                 }
             };
 

--- a/syncserver/src/web/extractors/bso_param.rs
+++ b/syncserver/src/web/extractors/bso_param.rs
@@ -1,9 +1,9 @@
 use std::str::FromStr;
 
 use actix_web::{
+    Error, FromRequest, HttpMessage, HttpRequest,
     dev::{Extensions, Payload, RequestHead},
     http::Uri,
-    Error, FromRequest, HttpMessage, HttpRequest,
 };
 use futures::future::{self, Ready};
 use lazy_static::lazy_static;
@@ -11,7 +11,7 @@ use regex::Regex;
 use serde::Deserialize;
 use validator::Validate;
 
-use super::{urldecode, RequestErrorLocation};
+use super::{RequestErrorLocation, urldecode};
 use crate::{server::BSO_ID_REGEX, web::error::ValidationErrorKind};
 
 lazy_static! {

--- a/syncserver/src/web/extractors/bso_put_request.rs
+++ b/syncserver/src/web/extractors/bso_put_request.rs
@@ -1,4 +1,4 @@
-use actix_web::{dev::Payload, Error, FromRequest, HttpRequest};
+use actix_web::{Error, FromRequest, HttpRequest, dev::Payload};
 use futures::future::{FutureExt, LocalBoxFuture};
 
 use syncserver_common::Metrics;
@@ -6,8 +6,8 @@ use syncstorage_db::UserIdentifier;
 use tokenserver_auth::TokenserverOrigin;
 
 use super::{
-    BsoBody, BsoParam, BsoQueryParams, CollectionParam, HawkIdentifier, RequestErrorLocation,
-    KNOWN_BAD_PAYLOAD_REGEX,
+    BsoBody, BsoParam, BsoQueryParams, CollectionParam, HawkIdentifier, KNOWN_BAD_PAYLOAD_REGEX,
+    RequestErrorLocation,
 };
 use crate::{server::MetricsWrapper, web::error::ValidationErrorKind};
 
@@ -47,16 +47,16 @@ impl FromRequest for BsoPutRequest {
             let collection = collection.collection;
             if collection == "crypto" {
                 // Verify the client didn't mess up the crypto if we have a payload
-                if let Some(ref data) = body.payload {
-                    if KNOWN_BAD_PAYLOAD_REGEX.is_match(data) {
-                        return Err(ValidationErrorKind::FromDetails(
-                            "Known-bad BSO payload".to_owned(),
-                            RequestErrorLocation::Body,
-                            Some("bsos".to_owned()),
-                            Some("request.process.known_bad_bso"),
-                        )
-                        .into());
-                    }
+                if let Some(ref data) = body.payload
+                    && KNOWN_BAD_PAYLOAD_REGEX.is_match(data)
+                {
+                    return Err(ValidationErrorKind::FromDetails(
+                        "Known-bad BSO payload".to_owned(),
+                        RequestErrorLocation::Body,
+                        Some("bsos".to_owned()),
+                        Some("request.process.known_bad_bso"),
+                    )
+                    .into());
                 }
             }
             Ok(BsoPutRequest {
@@ -79,8 +79,8 @@ mod tests {
 
     use actix_http::h1;
     use actix_web::{
-        dev::ServiceResponse, http::Method, test::TestRequest, web::Bytes, FromRequest,
-        HttpMessage, HttpResponse,
+        FromRequest, HttpMessage, HttpResponse, dev::ServiceResponse, http::Method,
+        test::TestRequest, web::Bytes,
     };
     use futures::executor::block_on;
     use serde_json::json;
@@ -88,8 +88,8 @@ mod tests {
     use crate::web::{
         auth::HawkPayload,
         extractors::test_utils::{
-            create_valid_hawk_header, extract_body_as_str, make_db, make_state, SECRETS, TEST_HOST,
-            TEST_PORT, USER_ID, USER_ID_STR,
+            SECRETS, TEST_HOST, TEST_PORT, USER_ID, USER_ID_STR, create_valid_hawk_header,
+            extract_body_as_str, make_db, make_state,
         },
     };
 

--- a/syncserver/src/web/extractors/bso_query_params.rs
+++ b/syncserver/src/web/extractors/bso_query_params.rs
@@ -1,16 +1,16 @@
 use std::{num::ParseIntError, str::FromStr};
 
-use actix_web::{dev::Payload, web::Query, Error, FromRequest, HttpRequest};
+use actix_web::{Error, FromRequest, HttpRequest, dev::Payload, web::Query};
 use futures::future::{LocalBoxFuture, TryFutureExt};
 use serde::{
-    de::{Deserializer, Error as SerdeError},
     Deserialize,
+    de::{Deserializer, Error as SerdeError},
 };
 use validator::{Validate, ValidationError};
 
-use syncstorage_db::{params, Sorting, SyncTimestamp};
+use syncstorage_db::{Sorting, SyncTimestamp, params};
 
-use super::{request_error, RequestErrorLocation, BATCH_MAX_IDS, VALID_ID_REGEX};
+use super::{BATCH_MAX_IDS, RequestErrorLocation, VALID_ID_REGEX, request_error};
 use crate::web::error::ValidationErrorKind;
 
 #[derive(Debug, Default, Clone, Copy, Deserialize, Eq, PartialEq, Validate)]
@@ -240,10 +240,10 @@ impl FromRequest for BsoQueryParams {
 mod tests {
     use std::str::FromStr;
 
-    use actix_web::{dev::ServiceResponse, test::TestRequest, FromRequest, HttpResponse};
+    use actix_web::{FromRequest, HttpResponse, dev::ServiceResponse, test::TestRequest};
     use futures::executor::block_on;
 
-    use syncstorage_db::{params, Sorting, SyncTimestamp};
+    use syncstorage_db::{Sorting, SyncTimestamp, params};
 
     use super::{BsoQueryParams, Offset};
     use crate::web::extractors::test_utils::{extract_body_as_str, make_state};

--- a/syncserver/src/web/extractors/bso_request.rs
+++ b/syncserver/src/web/extractors/bso_request.rs
@@ -1,4 +1,4 @@
-use actix_web::{dev::Payload, Error, FromRequest, HttpRequest};
+use actix_web::{Error, FromRequest, HttpRequest, dev::Payload};
 use futures::future::LocalBoxFuture;
 
 use syncserver_common::Metrics;
@@ -54,8 +54,8 @@ mod tests {
     use std::sync::Arc;
 
     use actix_web::{
-        dev::ServiceResponse, http::Method, test::TestRequest, FromRequest, HttpMessage,
-        HttpResponse,
+        FromRequest, HttpMessage, HttpResponse, dev::ServiceResponse, http::Method,
+        test::TestRequest,
     };
     use futures::executor::block_on;
 
@@ -63,8 +63,8 @@ mod tests {
     use crate::web::{
         auth::HawkPayload,
         extractors::test_utils::{
-            create_valid_hawk_header, extract_body_as_str, make_db, make_state, INVALID_BSO_NAME,
-            SECRETS, TEST_HOST, TEST_PORT, USER_ID, USER_ID_STR,
+            INVALID_BSO_NAME, SECRETS, TEST_HOST, TEST_PORT, USER_ID, USER_ID_STR,
+            create_valid_hawk_header, extract_body_as_str, make_db, make_state,
         },
     };
 

--- a/syncserver/src/web/extractors/collection_param.rs
+++ b/syncserver/src/web/extractors/collection_param.rs
@@ -1,9 +1,9 @@
 use std::str::FromStr;
 
 use actix_web::{
+    Error, FromRequest, HttpMessage, HttpRequest,
     dev::{Extensions, Payload},
     http::Uri,
-    Error, FromRequest, HttpMessage, HttpRequest,
 };
 use futures::future::LocalBoxFuture;
 use lazy_static::lazy_static;
@@ -11,7 +11,7 @@ use regex::Regex;
 use serde::Deserialize;
 use validator::Validate;
 
-use super::{urldecode, RequestErrorLocation};
+use super::{RequestErrorLocation, urldecode};
 use crate::{server::COLLECTION_ID_REGEX, web::error::ValidationErrorKind};
 
 lazy_static! {

--- a/syncserver/src/web/extractors/collection_post_request.rs
+++ b/syncserver/src/web/extractors/collection_post_request.rs
@@ -1,4 +1,4 @@
-use actix_web::{dev::Payload, web::Data, Error, FromRequest, HttpRequest};
+use actix_web::{Error, FromRequest, HttpRequest, dev::Payload, web::Data};
 use futures::future::LocalBoxFuture;
 
 use syncserver_common::Metrics;
@@ -7,7 +7,7 @@ use tokenserver_auth::TokenserverOrigin;
 
 use super::{
     BatchRequest, BatchRequestOpt, BsoBodies, BsoQueryParams, CollectionParam, HawkIdentifier,
-    RequestErrorLocation, KNOWN_BAD_PAYLOAD_REGEX,
+    KNOWN_BAD_PAYLOAD_REGEX, RequestErrorLocation,
 };
 use crate::{
     server::{MetricsWrapper, ServerState},
@@ -71,16 +71,16 @@ impl FromRequest for CollectionPostRequest {
             if collection == "crypto" {
                 // Verify the client didn't mess up the crypto if we have a payload
                 for bso in &bsos.valid {
-                    if let Some(ref data) = bso.payload {
-                        if KNOWN_BAD_PAYLOAD_REGEX.is_match(data) {
-                            return Err(ValidationErrorKind::FromDetails(
-                                "Known-bad BSO payload".to_owned(),
-                                RequestErrorLocation::Body,
-                                Some("bsos".to_owned()),
-                                Some("request.process.known_bad_bso"),
-                            )
-                            .into());
-                        }
+                    if let Some(ref data) = bso.payload
+                        && KNOWN_BAD_PAYLOAD_REGEX.is_match(data)
+                    {
+                        return Err(ValidationErrorKind::FromDetails(
+                            "Known-bad BSO payload".to_owned(),
+                            RequestErrorLocation::Body,
+                            Some("bsos".to_owned()),
+                            Some("request.process.known_bad_bso"),
+                        )
+                        .into());
                     }
                 }
             }
@@ -113,11 +113,11 @@ impl FromRequest for CollectionPostRequest {
 
 #[cfg(test)]
 mod tests {
-    use actix_web::{dev::ServiceResponse, http::Method, test::TestRequest, HttpResponse};
+    use actix_web::{HttpResponse, dev::ServiceResponse, http::Method, test::TestRequest};
     use serde_json::json;
 
     use crate::web::extractors::test_utils::{
-        extract_body_as_str, make_state, post_collection, USER_ID,
+        USER_ID, extract_body_as_str, make_state, post_collection,
     };
 
     #[actix_rt::test]

--- a/syncserver/src/web/extractors/collection_request.rs
+++ b/syncserver/src/web/extractors/collection_request.rs
@@ -1,4 +1,4 @@
-use actix_web::{dev::Payload, Error, FromRequest, HttpRequest};
+use actix_web::{Error, FromRequest, HttpRequest, dev::Payload};
 use futures::future::{FutureExt, LocalBoxFuture};
 
 use syncserver_common::Metrics;
@@ -6,8 +6,8 @@ use syncstorage_db::UserIdentifier;
 use tokenserver_auth::TokenserverOrigin;
 
 use super::{
-    get_accepted, BsoQueryParams, CollectionParam, HawkIdentifier, RequestErrorLocation,
-    ACCEPTED_CONTENT_TYPES,
+    ACCEPTED_CONTENT_TYPES, BsoQueryParams, CollectionParam, HawkIdentifier, RequestErrorLocation,
+    get_accepted,
 };
 use crate::{server::MetricsWrapper, web::error::ValidationErrorKind};
 
@@ -79,8 +79,8 @@ mod tests {
     use std::sync::Arc;
 
     use actix_web::{
-        dev::ServiceResponse, http::Method, test::TestRequest, FromRequest, HttpMessage,
-        HttpResponse,
+        FromRequest, HttpMessage, HttpResponse, dev::ServiceResponse, http::Method,
+        test::TestRequest,
     };
     use futures::executor::block_on;
 
@@ -88,8 +88,8 @@ mod tests {
     use crate::web::{
         auth::HawkPayload,
         extractors::test_utils::{
-            create_valid_hawk_header, extract_body_as_str, make_db, make_state,
             INVALID_COLLECTION_NAME, SECRETS, TEST_HOST, TEST_PORT, USER_ID, USER_ID_STR,
+            create_valid_hawk_header, extract_body_as_str, make_db, make_state,
         },
     };
 

--- a/syncserver/src/web/extractors/hawk_identifier.rs
+++ b/syncserver/src/web/extractors/hawk_identifier.rs
@@ -1,10 +1,10 @@
 use std::{str::FromStr, sync::Arc};
 
 use actix_web::{
+    Error, FromRequest, HttpMessage, HttpRequest,
     dev::{ConnectionInfo, Extensions, Payload},
     http::Uri,
     web::Data,
-    Error, FromRequest, HttpMessage, HttpRequest,
 };
 use futures::future::{self, Ready};
 use serde::{Deserialize, Serialize};
@@ -14,13 +14,13 @@ use syncserver_settings::Secrets;
 use syncstorage_db::UserIdentifier;
 use tokenserver_auth::TokenserverOrigin;
 
-use super::{urldecode, RequestErrorLocation};
+use super::{RequestErrorLocation, urldecode};
 use crate::{
     error::{ApiError, ApiErrorKind},
     web::{
+        DOCKER_FLOW_ENDPOINTS,
         auth::HawkPayload,
         error::{HawkErrorKind, ValidationErrorKind},
-        DOCKER_FLOW_ENDPOINTS,
     },
 };
 
@@ -215,10 +215,10 @@ mod tests {
     use std::sync::Arc;
 
     use actix_web::{
+        FromRequest, HttpResponse,
         dev::{Payload, ServiceResponse},
         http::Method,
         test::TestRequest,
-        FromRequest, HttpResponse,
     };
     use futures::executor::block_on;
 
@@ -226,8 +226,8 @@ mod tests {
     use crate::web::{
         auth::HawkPayload,
         extractors::test_utils::{
-            create_valid_hawk_header, extract_body_as_str, make_state, SECRETS, TEST_HOST,
-            TEST_PORT, USER_ID, USER_ID_STR,
+            SECRETS, TEST_HOST, TEST_PORT, USER_ID, USER_ID_STR, create_valid_hawk_header,
+            extract_body_as_str, make_state,
         },
     };
 

--- a/syncserver/src/web/extractors/heartbeat_request.rs
+++ b/syncserver/src/web/extractors/heartbeat_request.rs
@@ -1,5 +1,5 @@
 use actix_web::{
-    dev::Payload, http::header::HeaderMap, web::Data, Error, FromRequest, HttpRequest,
+    Error, FromRequest, HttpRequest, dev::Payload, http::header::HeaderMap, web::Data,
 };
 use futures::future::{FutureExt, LocalBoxFuture};
 use serde::Serialize;

--- a/syncserver/src/web/extractors/meta_request.rs
+++ b/syncserver/src/web/extractors/meta_request.rs
@@ -1,4 +1,4 @@
-use actix_web::{dev::Payload, Error, FromRequest, HttpRequest};
+use actix_web::{Error, FromRequest, HttpRequest, dev::Payload};
 use futures::future::{FutureExt, LocalBoxFuture};
 
 use syncserver_common::Metrics;

--- a/syncserver/src/web/extractors/precondition_header.rs
+++ b/syncserver/src/web/extractors/precondition_header.rs
@@ -1,4 +1,4 @@
-use actix_web::{dev::Payload, http::header::HeaderMap, Error, FromRequest, HttpRequest};
+use actix_web::{Error, FromRequest, HttpRequest, dev::Payload, http::header::HeaderMap};
 use futures::future::LocalBoxFuture;
 
 use syncstorage_db::SyncTimestamp;
@@ -108,7 +108,7 @@ impl FromRequest for PreConditionHeaderOpt {
 
 #[cfg(test)]
 mod tests {
-    use actix_web::{dev::ServiceResponse, test::TestRequest, HttpResponse};
+    use actix_web::{HttpResponse, dev::ServiceResponse, test::TestRequest};
 
     use syncstorage_db::SyncTimestamp;
 

--- a/syncserver/src/web/extractors/test_error_request.rs
+++ b/syncserver/src/web/extractors/test_error_request.rs
@@ -1,4 +1,4 @@
-use actix_web::{dev::Payload, http::header::HeaderMap, Error, FromRequest, HttpRequest};
+use actix_web::{Error, FromRequest, HttpRequest, dev::Payload, http::header::HeaderMap};
 use futures::future::{self, LocalBoxFuture};
 
 #[derive(Debug)]

--- a/syncserver/src/web/extractors/test_utils.rs
+++ b/syncserver/src/web/extractors/test_utils.rs
@@ -2,19 +2,19 @@ use std::sync::Arc;
 
 use actix_http::h1;
 use actix_web::{
+    Error, FromRequest, HttpMessage,
     dev::ServiceResponse,
     http::Method,
     test::{self, TestRequest},
     web::Bytes,
-    Error, FromRequest, HttpMessage,
 };
-use base64::{engine, Engine};
+use base64::{Engine, engine};
 use futures::executor::block_on;
 use glean::server_events::GleanEventsLogger;
 use hawk::{Credentials, Key, RequestBuilder};
 use hmac::{Hmac, Mac};
 use lazy_static::lazy_static;
-use rand::{thread_rng, Rng};
+use rand::{Rng, thread_rng};
 use sha2::Sha256;
 use tokio::sync::RwLock;
 

--- a/syncserver/src/web/extractors/utils.rs
+++ b/syncserver/src/web/extractors/utils.rs
@@ -1,8 +1,8 @@
 use std::str::FromStr;
 
 use actix_web::{
-    http::header::{Accept, Header, QualityItem},
     HttpRequest,
+    http::header::{Accept, Header, QualityItem},
 };
 use mime::STAR_STAR;
 use serde::{Deserialize, Serialize};
@@ -72,7 +72,7 @@ pub fn get_accepted(req: &HttpRequest, accepted: &[&str], default: &'static str)
 #[cfg(test)]
 mod tests {
     use actix_web::{
-        http::header::{HeaderValue, ACCEPT},
+        http::header::{ACCEPT, HeaderValue},
         test::TestRequest,
     };
 

--- a/syncserver/src/web/extractors/validation.rs
+++ b/syncserver/src/web/extractors/validation.rs
@@ -1,7 +1,7 @@
 use validator::ValidationError;
 
 use super::{
-    RequestErrorLocation, BSO_MAX_SORTINDEX_VALUE, BSO_MAX_TTL, BSO_MIN_SORTINDEX_VALUE,
+    BSO_MAX_SORTINDEX_VALUE, BSO_MAX_TTL, BSO_MIN_SORTINDEX_VALUE, RequestErrorLocation,
     VALID_ID_REGEX,
 };
 
@@ -41,7 +41,7 @@ pub fn validate_body_bso_ttl(ttl: u32) -> Result<(), ValidationError> {
 mod tests {
     use serde_json::json;
 
-    use crate::web::extractors::test_utils::{post_collection, USER_ID};
+    use crate::web::extractors::test_utils::{USER_ID, post_collection};
 
     #[actix_rt::test]
     async fn test_max_ttl() {

--- a/syncserver/src/web/handlers.rs
+++ b/syncserver/src/web/handlers.rs
@@ -3,19 +3,18 @@ use std::collections::HashMap;
 use std::convert::Into;
 use std::time::{Duration, Instant};
 
-use crate::server::user_agent::{get_device_info, DeviceInfo};
+use crate::server::user_agent::{DeviceInfo, get_device_info};
 use actix_web::{
-    http::{header, StatusCode},
-    web::Data,
     HttpRequest, HttpResponse, HttpResponseBuilder,
+    http::{StatusCode, header},
+    web::Data,
 };
 use serde::Serialize;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use syncserver_common::{X_LAST_MODIFIED, X_WEAVE_NEXT_OFFSET, X_WEAVE_RECORDS};
 use syncstorage_db::{
-    params,
+    Db, DbError, DbErrorIntrospect, params,
     results::{CreateBatch, Paginated},
-    Db, DbError, DbErrorIntrospect,
 };
 use utoipa;
 
@@ -848,7 +847,7 @@ pub async fn lbheartbeat(req: HttpRequest) -> Result<HttpResponse, ApiError> {
         use std::str::FromStr;
         use syncstorage_db::PoolState;
 
-        let test_pool = PoolState {
+        PoolState {
             connections: u32::from_str(
                 req.headers()
                     .get("TEST_CONNECTIONS")
@@ -865,8 +864,7 @@ pub async fn lbheartbeat(req: HttpRequest) -> Result<HttpResponse, ApiError> {
                     .unwrap_or("0"),
             )
             .unwrap_or_default(),
-        };
-        test_pool
+        }
     } else {
         state.db_pool.clone().state()
     };

--- a/syncserver/src/web/middleware/mod.rs
+++ b/syncserver/src/web/middleware/mod.rs
@@ -9,9 +9,9 @@ use std::collections::HashMap;
 use std::future::Future;
 
 use actix_web::{
+    HttpMessage,
     dev::{Service, ServiceRequest, ServiceResponse},
     web::Data,
-    HttpMessage,
 };
 use syncserver_common::Metrics;
 use tokenserver_auth::TokenserverOrigin;
@@ -19,10 +19,13 @@ use tokenserver_auth::TokenserverOrigin;
 use crate::error::{ApiError, ApiErrorKind};
 use crate::server::ServerState;
 
-pub fn emit_http_status_with_tokenserver_origin<B>(
+pub fn emit_http_status_with_tokenserver_origin<B, S>(
     req: ServiceRequest,
-    srv: &impl Service<ServiceRequest, Response = ServiceResponse<B>, Error = actix_web::Error>,
-) -> impl Future<Output = Result<ServiceResponse<B>, actix_web::Error>> {
+    srv: &S,
+) -> impl Future<Output = Result<ServiceResponse<B>, actix_web::Error>> + use<B, S>
+where
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = actix_web::Error>,
+{
     let fut = srv.call(req);
 
     async move {

--- a/syncserver/src/web/middleware/rejectua.rs
+++ b/syncserver/src/web/middleware/rejectua.rs
@@ -1,10 +1,10 @@
 #![allow(clippy::type_complexity)]
 
 use actix_web::{
+    FromRequest, HttpResponse,
     body::EitherBody,
     dev::{Service, ServiceRequest, ServiceResponse},
     http::header::USER_AGENT,
-    FromRequest, HttpResponse,
 };
 use futures::future::LocalBoxFuture;
 use lazy_static::lazy_static;
@@ -33,8 +33,9 @@ $
 
 pub fn reject_user_agent<B>(
     request: ServiceRequest,
-    service: &(impl Service<ServiceRequest, Response = ServiceResponse<B>, Error = actix_web::Error>
-          + 'static),
+    service: &(
+         impl Service<ServiceRequest, Response = ServiceResponse<B>, Error = actix_web::Error> + 'static
+     ),
 ) -> LocalBoxFuture<'static, Result<ServiceResponse<EitherBody<B>>, actix_web::Error>> {
     match request.headers().get(USER_AGENT).cloned() {
         Some(header) if header.to_str().is_ok_and(should_reject) => Box::pin(async move {

--- a/syncserver/src/web/transaction.rs
+++ b/syncserver/src/web/transaction.rs
@@ -1,13 +1,13 @@
-use actix_http::{header::HeaderValue, BoxedPayloadStream, Error, HttpMessage, Method, StatusCode};
+use actix_http::{BoxedPayloadStream, Error, HttpMessage, Method, StatusCode, header::HeaderValue};
 use actix_web::dev::Payload;
 use actix_web::http::header;
 use actix_web::web::Data;
 use actix_web::{FromRequest, HttpRequest, HttpResponse};
-use futures::future::LocalBoxFuture;
 use futures::FutureExt;
+use futures::future::LocalBoxFuture;
 
 use syncserver_common::{Taggable, X_LAST_MODIFIED};
-use syncstorage_db::{params, results::ConnectionInfo, Db, DbError, DbPool, UserIdentifier};
+use syncstorage_db::{Db, DbError, DbPool, UserIdentifier, params, results::ConnectionInfo};
 
 use super::extractors::{
     BsoParam, CollectionParam, HawkIdentifier, PreConditionHeader, PreConditionHeaderOpt,

--- a/syncstorage-db-common/src/diesel.rs
+++ b/syncstorage-db-common/src/diesel.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use backtrace::Backtrace;
 use http::StatusCode;
-use syncserver_common::{from_error, impl_fmt_display, InternalError, ReportableError};
+use syncserver_common::{InternalError, ReportableError, from_error, impl_fmt_display};
 use syncserver_db_common::error::SqlError;
 use thiserror::Error;
 

--- a/syncstorage-db-common/src/error.rs
+++ b/syncstorage-db-common/src/error.rs
@@ -2,7 +2,7 @@ use std::{error::Error, fmt};
 
 use backtrace::Backtrace;
 use http::StatusCode;
-use syncserver_common::{impl_fmt_display, ReportableError};
+use syncserver_common::{ReportableError, impl_fmt_display};
 
 /// Errors common to all supported syncstorage database backends. These errors can be thought of
 /// as being related more to the syncstorage application logic as opposed to a particular

--- a/syncstorage-db-common/src/params.rs
+++ b/syncstorage-db-common/src/params.rs
@@ -9,7 +9,7 @@ use std::{
 use diesel::Queryable;
 use serde::{Deserialize, Serialize};
 
-use crate::{results, util::SyncTimestamp, Sorting, UserIdentifier};
+use crate::{Sorting, UserIdentifier, results, util::SyncTimestamp};
 
 macro_rules! data {
     ($name:ident {$($property:ident: $type:ty,)*}) => {

--- a/syncstorage-db-common/src/results.rs
+++ b/syncstorage-db-common/src/results.rs
@@ -2,8 +2,8 @@
 use std::collections::HashMap;
 
 use diesel::{
-    sql_types::{BigInt, Integer, Nullable, Text},
     Queryable, QueryableByName,
+    sql_types::{BigInt, Integer, Nullable, Text},
 };
 use serde::{Deserialize, Serialize};
 

--- a/syncstorage-db-common/src/util.rs
+++ b/syncstorage-db-common/src/util.rs
@@ -1,18 +1,18 @@
 use std::convert::TryInto;
 
 use chrono::{
-    offset::{TimeZone, Utc},
     DateTime, SecondsFormat,
+    offset::{TimeZone, Utc},
 };
 #[cfg(feature = "postgres")]
 use diesel::sql_types::Timestamptz;
 use diesel::{
+    FromSqlRow,
     backend::Backend,
     deserialize::{self, FromSql},
     sql_types::BigInt,
-    FromSqlRow,
 };
-use serde::{ser, Deserialize, Deserializer, Serialize, Serializer};
+use serde::{Deserialize, Deserializer, Serialize, Serializer, ser};
 
 use super::error::SyncstorageDbError;
 
@@ -219,7 +219,7 @@ pub fn to_rfc3339(val: i64) -> Result<String, SyncstorageDbError> {
 mod tests {
     use std::error::Error;
 
-    use chrono::{offset::Utc, DateTime};
+    use chrono::{DateTime, offset::Utc};
 
     use super::SyncTimestamp;
 

--- a/syncstorage-db/src/lib.rs
+++ b/syncstorage-db/src/lib.rs
@@ -33,9 +33,8 @@ pub use syncserver_db_common::{GetPoolState, PoolState};
 pub use syncstorage_db_common::error::DbErrorIntrospect;
 
 pub use syncstorage_db_common::{
-    params, results,
-    util::{to_rfc3339, SyncTimestamp},
-    Db, DbPool, Sorting, UserIdentifier,
+    Db, DbPool, Sorting, UserIdentifier, params, results,
+    util::{SyncTimestamp, to_rfc3339},
 };
 
 #[cfg(all(feature = "mysql", feature = "spanner"))]

--- a/syncstorage-db/src/mock.rs
+++ b/syncstorage-db/src/mock.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use syncserver_db_common::{GetPoolState, PoolState};
 #[cfg(debug_assertions)]
 use syncstorage_db_common::util::SyncTimestamp;
-use syncstorage_db_common::{params, results, BatchDb, Db, DbPool};
+use syncstorage_db_common::{BatchDb, Db, DbPool, params, results};
 
 use crate::DbError;
 

--- a/syncstorage-db/src/tests/batch.rs
+++ b/syncstorage-db/src/tests/batch.rs
@@ -1,7 +1,7 @@
 use log::debug;
 use syncserver_settings::Settings;
 use syncstorage_db_common::{
-    error::DbErrorIntrospect, params, results, util::SyncTimestamp, BATCH_LIFETIME,
+    BATCH_LIFETIME, error::DbErrorIntrospect, params, results, util::SyncTimestamp,
 };
 
 use super::support::{db_pool, gbso, hid, pbso, postbso, test_db};
@@ -100,10 +100,11 @@ async fn update() -> Result<(), DbError> {
     let uid = 1;
     let coll = "clients";
     let new_batch = db.create_batch(cb(uid, coll, vec![])).await?;
-    assert!(db
-        .get_batch(gb(uid, coll, new_batch.id.clone()))
-        .await?
-        .is_some());
+    assert!(
+        db.get_batch(gb(uid, coll, new_batch.id.clone()))
+            .await?
+            .is_some()
+    );
 
     let bsos = vec![
         postbso("b0", Some("payload 0"), Some(10), None),

--- a/syncstorage-db/src/tests/db.rs
+++ b/syncstorage-db/src/tests/db.rs
@@ -2,10 +2,10 @@
 use std::collections::HashMap;
 
 use lazy_static::lazy_static;
-use rand::{distributions::Alphanumeric, thread_rng, Rng};
+use rand::{Rng, distributions::Alphanumeric, thread_rng};
 use syncserver_settings::Settings;
 use syncstorage_db_common::{
-    error::DbErrorIntrospect, params, util::SyncTimestamp, Sorting, DEFAULT_BSO_TTL,
+    DEFAULT_BSO_TTL, Sorting, error::DbErrorIntrospect, params, util::SyncTimestamp,
 };
 
 use super::support::{db_pool, dbso, dbsos, gbso, gbsos, hid, pbso, postbso, test_db};
@@ -177,10 +177,10 @@ async fn get_bsos_limit_offset() -> Result<(), DbError> {
         ))
         .await?;
     assert_eq!(bsos.items.len(), 5);
-    if let Some(ref offset) = bsos.offset {
-        if !offset.chars().any(|c| c == ':') {
-            assert_eq!(offset, &"5".to_string());
-        }
+    if let Some(ref offset) = bsos.offset
+        && !offset.chars().any(|c| c == ':')
+    {
+        assert_eq!(offset, &"5".to_string());
     }
 
     assert_eq!(bsos.items[0].id, "11");
@@ -199,10 +199,10 @@ async fn get_bsos_limit_offset() -> Result<(), DbError> {
         ))
         .await?;
     assert_eq!(bsos2.items.len(), 5);
-    if let Some(ref offset) = bsos2.offset {
-        if !offset.chars().any(|c| c == ':') {
-            assert_eq!(offset, &"10".to_owned());
-        }
+    if let Some(ref offset) = bsos2.offset
+        && !offset.chars().any(|c| c == ':')
+    {
+        assert_eq!(offset, &"10".to_owned());
     }
     assert_eq!(bsos2.items[0].id, "6");
     assert_eq!(bsos2.items[4].id, "2");
@@ -975,11 +975,12 @@ async fn delete_bsos() -> Result<(), DbError> {
     }
     db.delete_bso(dbso(uid, coll, "b0")).await?;
     // deleting non existant bid errors
-    assert!(db
-        .delete_bso(dbso(uid, coll, "bxi0"))
-        .await
-        .unwrap_err()
-        .is_bso_not_found());
+    assert!(
+        db.delete_bso(dbso(uid, coll, "bxi0"))
+            .await
+            .unwrap_err()
+            .is_bso_not_found()
+    );
     db.delete_bsos(dbsos(uid, coll, &["b1", "b2"])).await?;
     for bid in bids {
         let bso = db.get_bso(gbso(uid, coll, &bid)).await?;

--- a/syncstorage-db/src/tests/support.rs
+++ b/syncstorage-db/src/tests/support.rs
@@ -2,7 +2,7 @@ use std::{str::FromStr, sync::Arc};
 
 use syncserver_common::{BlockingThreadpool, Metrics};
 use syncserver_settings::Settings as SyncserverSettings;
-use syncstorage_db_common::{params, util::SyncTimestamp, Db, DbPool, Sorting, UserIdentifier};
+use syncstorage_db_common::{Db, DbPool, Sorting, UserIdentifier, params, util::SyncTimestamp};
 use syncstorage_settings::Settings as SyncstorageSettings;
 
 use crate::{DbError, DbPoolImpl};

--- a/syncstorage-mysql/src/db/batch_impl.rs
+++ b/syncstorage-mysql/src/db/batch_impl.rs
@@ -3,20 +3,19 @@ use std::collections::HashSet;
 
 use async_trait::async_trait;
 use diesel::{
-    self,
+    self, ExpressionMethods, OptionalExtension, QueryDsl,
     dsl::sql,
     insert_into,
     result::{DatabaseErrorKind::UniqueViolation, Error as DieselError},
     sql_query,
     sql_types::{BigInt, Integer},
-    ExpressionMethods, OptionalExtension, QueryDsl,
 };
 use diesel_async::RunQueryDsl;
-use syncstorage_db_common::{params, results, BatchDb, Db, UserIdentifier, BATCH_LIFETIME};
+use syncstorage_db_common::{BATCH_LIFETIME, BatchDb, Db, UserIdentifier, params, results};
 
 use super::{
-    schema::{batch_upload_items, batch_uploads},
     MysqlDb,
+    schema::{batch_upload_items, batch_uploads},
 };
 use crate::{DbError, DbResult};
 

--- a/syncstorage-mysql/src/db/db_impl.rs
+++ b/syncstorage-mysql/src/db/db_impl.rs
@@ -2,27 +2,26 @@ use std::collections::HashMap;
 
 use async_trait::async_trait;
 use diesel::{
-    delete,
+    ExpressionMethods, OptionalExtension, QueryDsl, delete,
     dsl::max,
     dsl::sql,
     sql_query,
     sql_types::{BigInt, Integer, Nullable, Text},
-    ExpressionMethods, OptionalExtension, QueryDsl,
 };
 use diesel_async::{AsyncConnection, RunQueryDsl, TransactionManager};
 use syncstorage_db_common::{
-    error::DbErrorIntrospect, params, results, util::SyncTimestamp, Db, Sorting, UserIdentifier,
-    DEFAULT_BSO_TTL,
+    DEFAULT_BSO_TTL, Db, Sorting, UserIdentifier, error::DbErrorIntrospect, params, results,
+    util::SyncTimestamp,
 };
 use syncstorage_settings::DEFAULT_MAX_TOTAL_RECORDS;
 
 use super::{
+    COLLECTION_ID, COUNT, CollectionLock, EXPIRY, LAST_MODIFIED, MODIFIED, MysqlDb, TOMBSTONE,
+    TOTAL_BYTES, USER_ID,
     diesel_ext::LockInShareModeDsl,
     schema::{bso, user_collections},
-    CollectionLock, MysqlDb, COLLECTION_ID, COUNT, EXPIRY, LAST_MODIFIED, MODIFIED, TOMBSTONE,
-    TOTAL_BYTES, USER_ID,
 };
-use crate::{pool::Conn, DbError, DbResult};
+use crate::{DbError, DbResult, pool::Conn};
 
 // this is the max number of records we will return.
 static DEFAULT_LIMIT: u32 = DEFAULT_MAX_TOTAL_RECORDS;

--- a/syncstorage-mysql/src/db/mod.rs
+++ b/syncstorage-mysql/src/db/mod.rs
@@ -1,22 +1,22 @@
 use std::{collections::HashMap, fmt, sync::Arc};
 
 use diesel::{
+    ExpressionMethods, OptionalExtension, QueryDsl,
     dsl::sql,
     sql_query,
     sql_types::{BigInt, Integer, Text},
-    ExpressionMethods, OptionalExtension, QueryDsl,
 };
 use diesel_async::RunQueryDsl;
 use syncserver_common::Metrics;
 use syncstorage_db_common::{
-    error::DbErrorIntrospect, results, util::SyncTimestamp, Db, UserIdentifier,
-    FIRST_CUSTOM_COLLECTION_ID,
+    Db, FIRST_CUSTOM_COLLECTION_ID, UserIdentifier, error::DbErrorIntrospect, results,
+    util::SyncTimestamp,
 };
 use syncstorage_settings::Quota;
 
 use crate::{
-    pool::{CollectionCache, Conn},
     DbError, DbResult,
+    pool::{CollectionCache, Conn},
 };
 use schema::{bso, collections, last_insert_id};
 

--- a/syncstorage-mysql/src/pool.rs
+++ b/syncstorage-mysql/src/pool.rs
@@ -9,24 +9,24 @@ use std::{
 
 use deadpool::managed::PoolError;
 use diesel_async::{
-    pooled_connection::{
-        deadpool::{Object, Pool},
-        AsyncDieselConnectionManager,
-    },
     AsyncMysqlConnection,
+    pooled_connection::{
+        AsyncDieselConnectionManager,
+        deadpool::{Object, Pool},
+    },
 };
-use diesel_migrations::{embed_migrations, EmbeddedMigrations};
+use diesel_migrations::{EmbeddedMigrations, embed_migrations};
 use syncserver_common::{BlockingThreadpool, Metrics};
 #[cfg(debug_assertions)]
 use syncserver_db_common::test::test_transaction_hook;
 use syncserver_db_common::{
-    establish_connection_with_logging, manager_config_with_logging, run_embedded_migrations,
-    GetPoolState, PoolState,
+    GetPoolState, PoolState, establish_connection_with_logging, manager_config_with_logging,
+    run_embedded_migrations,
 };
 use syncstorage_db_common::{Db, DbPool, STD_COLLS};
 use syncstorage_settings::{Quota, Settings};
 
-use super::{db::MysqlDb, DbError, DbResult};
+use super::{DbError, DbResult, db::MysqlDb};
 
 pub const MIGRATIONS: EmbeddedMigrations = embed_migrations!();
 

--- a/syncstorage-mysql/src/test.rs
+++ b/syncstorage-mysql/src/test.rs
@@ -13,9 +13,9 @@ use syncstorage_settings::Settings as SyncstorageSettings;
 use url::Url;
 
 use crate::{
-    db::{schema::collections, MysqlDb},
-    pool::MysqlDbPool,
     DbResult,
+    db::{MysqlDb, schema::collections},
+    pool::MysqlDbPool,
 };
 
 async fn db(settings: &SyncstorageSettings) -> DbResult<MysqlDb> {

--- a/syncstorage-postgres/src/db/batch_impl.rs
+++ b/syncstorage-postgres/src/db/batch_impl.rs
@@ -1,22 +1,21 @@
 use async_trait::async_trait;
 use diesel::{
-    self, delete,
+    self, ExpressionMethods, OptionalExtension, QueryDsl, delete,
     dsl::{now, sql},
     insert_into, sql_query,
     sql_types::{BigInt, Integer, Nullable, Text, Timestamptz, Uuid as SqlUuid},
-    ExpressionMethods, OptionalExtension, QueryDsl,
 };
 use diesel_async::RunQueryDsl;
 use uuid::Uuid;
 
 use syncstorage_db_common::{
-    params, results, BatchDb, Db, UserIdentifier, BATCH_LIFETIME, DEFAULT_BSO_TTL,
+    BATCH_LIFETIME, BatchDb, DEFAULT_BSO_TTL, Db, UserIdentifier, params, results,
 };
 
 use super::PgDb;
 use crate::{
-    schema::{batch_bsos, batches},
     DbError, DbResult,
+    schema::{batch_bsos, batches},
 };
 
 #[async_trait(?Send)]

--- a/syncstorage-postgres/src/db/db_impl.rs
+++ b/syncstorage-postgres/src/db/db_impl.rs
@@ -1,26 +1,24 @@
 use async_trait::async_trait;
-use chrono::{offset::Utc, DateTime, TimeDelta};
+use chrono::{DateTime, TimeDelta, offset::Utc};
 use diesel::{
-    delete,
+    ExpressionMethods, IntoSql, OptionalExtension, QueryDsl, SelectableHelper, delete,
     dsl::{count, max, now, sql},
     sql_types::{Array, BigInt, Integer, Nullable, Timestamptz},
     upsert::excluded,
-    ExpressionMethods, IntoSql, OptionalExtension, QueryDsl, SelectableHelper,
 };
 use diesel_async::{AsyncConnection, RunQueryDsl, TransactionManager};
 use futures::TryStreamExt;
 use syncstorage_db_common::{
-    error::DbErrorIntrospect, params, results, util::SyncTimestamp, Db, Sorting, DEFAULT_BSO_TTL,
+    DEFAULT_BSO_TTL, Db, Sorting, error::DbErrorIntrospect, params, results, util::SyncTimestamp,
 };
 
 use super::{PgDb, TOMBSTONE};
 use crate::{
-    bsos_query,
+    DbError, DbResult, bsos_query,
     db::{CollectionLock, PRETOUCH_DT},
-    orm_models::{sql_types::PostBso, BsoChangeset},
+    orm_models::{BsoChangeset, sql_types::PostBso},
     pool::Conn,
     schema::{bsos, collections, user_collections},
-    DbError, DbResult,
 };
 
 #[async_trait(?Send)]

--- a/syncstorage-postgres/src/db/mod.rs
+++ b/syncstorage-postgres/src/db/mod.rs
@@ -1,24 +1,24 @@
 use chrono::{DateTime, NaiveDate, Utc};
 use diesel::{
+    ExpressionMethods, OptionalExtension, QueryDsl,
     dsl::{now, sql},
     sql_types::BigInt,
     upsert::excluded,
-    ExpressionMethods, OptionalExtension, QueryDsl,
 };
 use diesel_async::RunQueryDsl;
 use std::{collections::HashMap, fmt, sync::Arc};
 
 use syncserver_common::Metrics;
 use syncstorage_db_common::{
-    diesel::DbError, error::DbErrorIntrospect, params, results, util::SyncTimestamp, Db,
-    UserIdentifier, FIRST_CUSTOM_COLLECTION_ID,
+    Db, FIRST_CUSTOM_COLLECTION_ID, UserIdentifier, diesel::DbError, error::DbErrorIntrospect,
+    params, results, util::SyncTimestamp,
 };
 use syncstorage_settings::Quota;
 
 use super::schema::{bsos, collections, user_collections};
 use super::{
-    pool::{CollectionCache, Conn},
     DbResult,
+    pool::{CollectionCache, Conn},
 };
 
 mod batch_impl;

--- a/syncstorage-postgres/src/orm_models.rs
+++ b/syncstorage-postgres/src/orm_models.rs
@@ -1,4 +1,4 @@
-use chrono::{offset::Utc, DateTime};
+use chrono::{DateTime, offset::Utc};
 use diesel::{AsChangeset, Identifiable, Queryable};
 use uuid::Uuid;
 

--- a/syncstorage-postgres/src/pool.rs
+++ b/syncstorage-postgres/src/pool.rs
@@ -9,18 +9,18 @@ use std::{
 
 use deadpool::managed::PoolError;
 use diesel_async::{
-    pooled_connection::{
-        deadpool::{Object, Pool},
-        AsyncDieselConnectionManager,
-    },
     AsyncPgConnection,
+    pooled_connection::{
+        AsyncDieselConnectionManager,
+        deadpool::{Object, Pool},
+    },
 };
-use diesel_migrations::{embed_migrations, EmbeddedMigrations};
+use diesel_migrations::{EmbeddedMigrations, embed_migrations};
 use syncserver_common::{BlockingThreadpool, Metrics};
 #[cfg(debug_assertions)]
 use syncserver_db_common::test::test_transaction_hook;
 use syncserver_db_common::{
-    manager_config_with_logging, run_embedded_migrations, GetPoolState, PoolState,
+    GetPoolState, PoolState, manager_config_with_logging, run_embedded_migrations,
 };
 use syncstorage_db_common::{Db, DbPool, STD_COLLS};
 use syncstorage_settings::{Quota, Settings};

--- a/syncstorage-settings/src/lib.rs
+++ b/syncstorage-settings/src/lib.rs
@@ -5,7 +5,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use rand::{thread_rng, Rng};
+use rand::{Rng, thread_rng};
 use serde::{Deserialize, Serialize};
 use syncserver_common::{self, MAX_SPANNER_LOAD_SIZE};
 

--- a/syncstorage-spanner/src/db/db_impl.rs
+++ b/syncstorage-spanner/src/db/db_impl.rs
@@ -11,16 +11,16 @@ use google_cloud_rust_raw::spanner::v1::{
 };
 #[allow(unused_imports)]
 use protobuf::{
-    well_known_types::{ListValue, Value},
     Message, RepeatedField,
+    well_known_types::{ListValue, Value},
 };
-use syncstorage_db_common::{error::DbErrorIntrospect, params, results, util::SyncTimestamp, Db};
+use syncstorage_db_common::{Db, error::DbErrorIntrospect, params, results, util::SyncTimestamp};
 
 use super::{
-    support::{as_type, bso_from_row, IntoSpannerValue},
     CollectionLock, SpannerDb, TOMBSTONE,
+    support::{IntoSpannerValue, as_type, bso_from_row},
 };
-use crate::{error::DbError, DbResult};
+use crate::{DbResult, error::DbError};
 
 pub(super) const PRETOUCH_TS: &str = "0001-01-01T00:00:00.00Z";
 

--- a/syncstorage-spanner/src/db/mod.rs
+++ b/syncstorage-spanner/src/db/mod.rs
@@ -13,24 +13,24 @@ use google_cloud_rust_raw::spanner::v1::{
 };
 #[allow(unused_imports)]
 use protobuf::{
-    well_known_types::{ListValue, Value},
     Message, RepeatedField,
+    well_known_types::{ListValue, Value},
 };
-use syncserver_common::{Metrics, MAX_SPANNER_LOAD_SIZE};
+use syncserver_common::{MAX_SPANNER_LOAD_SIZE, Metrics};
 use syncstorage_db_common::{
-    error::DbErrorIntrospect, params, results, util::SyncTimestamp, Db, Sorting, UserIdentifier,
-    DEFAULT_BSO_TTL, FIRST_CUSTOM_COLLECTION_ID,
+    DEFAULT_BSO_TTL, Db, FIRST_CUSTOM_COLLECTION_ID, Sorting, UserIdentifier,
+    error::DbErrorIntrospect, params, results, util::SyncTimestamp,
 };
 use syncstorage_settings::Quota;
 
 use crate::{
+    DbResult,
     error::DbError,
     pool::{CollectionCache, Conn},
-    DbResult,
 };
 use support::{
-    as_type, bso_to_insert_row, bso_to_update_row, ExecuteSqlRequestBuilder, IntoSpannerValue,
-    StreamedResultSetAsync,
+    ExecuteSqlRequestBuilder, IntoSpannerValue, StreamedResultSetAsync, as_type, bso_to_insert_row,
+    bso_to_update_row,
 };
 
 mod batch_impl;

--- a/syncstorage-spanner/src/db/stream.rs
+++ b/syncstorage-spanner/src/db/stream.rs
@@ -1,6 +1,6 @@
 use std::{collections::VecDeque, mem};
 
-use futures::{stream::StreamFuture, Stream, StreamExt};
+use futures::{Stream, StreamExt, stream::StreamFuture};
 use google_cloud_rust_raw::spanner::v1::{
     result_set::{PartialResultSet, ResultSetMetadata, ResultSetStats},
     type_pb::{StructType_Field, Type, TypeCode},
@@ -9,7 +9,7 @@ use grpcio::ClientSStreamReceiver;
 use protobuf::well_known_types::Value;
 
 use super::support::IntoSpannerValue;
-use crate::{error::DbError, DbResult};
+use crate::{DbResult, error::DbError};
 
 pub struct StreamedResultSetAsync<T = ClientSStreamReceiver<PartialResultSet>> {
     /// Stream from execute_streaming_sql

--- a/syncstorage-spanner/src/db/support.rs
+++ b/syncstorage-spanner/src/db/support.rs
@@ -6,15 +6,15 @@ use google_cloud_rust_raw::spanner::v1::{
 };
 
 use protobuf::{
-    well_known_types::{ListValue, NullValue, Struct, Value},
     RepeatedField,
+    well_known_types::{ListValue, NullValue, Struct, Value},
 };
 use syncstorage_db_common::{
-    params, results, util::to_rfc3339, util::SyncTimestamp, UserIdentifier, DEFAULT_BSO_TTL,
+    DEFAULT_BSO_TTL, UserIdentifier, params, results, util::SyncTimestamp, util::to_rfc3339,
 };
 
 pub use super::stream::StreamedResultSetAsync;
-use crate::{error::DbError, pool::Conn, DbResult};
+use crate::{DbResult, error::DbError, pool::Conn};
 
 pub trait IntoSpannerValue {
     const TYPE_CODE: TypeCode;

--- a/syncstorage-spanner/src/error.rs
+++ b/syncstorage-spanner/src/error.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use backtrace::Backtrace;
 use grpcio::RpcStatusCode;
 use http::StatusCode;
-use syncserver_common::{from_error, impl_fmt_display, InternalError, ReportableError};
+use syncserver_common::{InternalError, ReportableError, from_error, impl_fmt_display};
 use syncstorage_db_common::error::{DbErrorIntrospect, SyncstorageDbError};
 use thiserror::Error;
 

--- a/syncstorage-spanner/src/macros.rs
+++ b/syncstorage-spanner/src/macros.rs
@@ -22,8 +22,8 @@ fn test_params_macro() {
     use crate::db::support::IntoSpannerValue;
     use google_cloud_rust_raw::spanner::v1::type_pb::{Type, TypeCode};
     use protobuf::{
-        well_known_types::{ListValue, Value},
         RepeatedField,
+        well_known_types::{ListValue, Value},
     };
     use std::collections::HashMap;
 

--- a/syncstorage-spanner/src/manager/deadpool.rs
+++ b/syncstorage-spanner/src/manager/deadpool.rs
@@ -6,7 +6,7 @@ use syncserver_common::{BlockingThreadpool, Metrics};
 use syncstorage_settings::Settings;
 
 use super::session::{
-    create_spanner_session, recycle_spanner_session, SpannerSession, SpannerSessionSettings,
+    SpannerSession, SpannerSessionSettings, create_spanner_session, recycle_spanner_session,
 };
 use crate::error::DbError;
 

--- a/syncstorage-spanner/src/metadata.rs
+++ b/syncstorage-spanner/src/metadata.rs
@@ -92,7 +92,7 @@ mod tests {
     use std::{collections::HashMap, str};
 
     use super::{
-        MetadataBuilder, LEADER_AWARE_KEY, METRICS_KEY, PREFIX_KEY, ROUTING_KEY, USER_AGENT,
+        LEADER_AWARE_KEY, METRICS_KEY, MetadataBuilder, PREFIX_KEY, ROUTING_KEY, USER_AGENT,
     };
 
     // Resource paths should not start with a "/"

--- a/syncstorage-spanner/src/pool.rs
+++ b/syncstorage-spanner/src/pool.rs
@@ -9,7 +9,7 @@ use syncstorage_settings::{Quota, Settings};
 use tokio::sync::RwLock;
 
 pub(super) use super::manager::Conn;
-use super::{db::SpannerDb, error::DbError, manager::SpannerSessionManager, DbResult};
+use super::{DbResult, db::SpannerDb, error::DbError, manager::SpannerSessionManager};
 
 #[derive(Clone)]
 pub struct SpannerDbPool {

--- a/tokenserver-auth/src/crypto.rs
+++ b/tokenserver-auth/src/crypto.rs
@@ -1,6 +1,6 @@
 use hkdf::Hkdf;
 use hmac::{Hmac, Mac};
-use jsonwebtoken::{errors::ErrorKind, jwk::Jwk, Algorithm, DecodingKey, Validation};
+use jsonwebtoken::{Algorithm, DecodingKey, Validation, errors::ErrorKind, jwk::Jwk};
 use ring::rand::{SecureRandom, SystemRandom};
 use serde::de::DeserializeOwned;
 use sha2::Sha256;

--- a/tokenserver-auth/src/oauth/native.rs
+++ b/tokenserver-auth/src/oauth/native.rs
@@ -1,7 +1,7 @@
 use super::VerifyOutput;
+use crate::VerifyToken;
 pub use crate::crypto::JWTVerifier;
 use crate::crypto::OAuthVerifyError;
-use crate::VerifyToken;
 use async_trait::async_trait;
 use reqwest::Url;
 use serde::{Deserialize, Serialize};

--- a/tokenserver-auth/src/oauth/py.rs
+++ b/tokenserver-auth/src/oauth/py.rs
@@ -1,10 +1,10 @@
 use async_trait::async_trait;
 use jsonwebtoken::jwk::{AlgorithmParameters, Jwk, PublicKeyUse, RSAKeyParameters};
 use pyo3::{
+    Bound,
     ffi::c_str,
     prelude::{Py, PyAny, PyErr, PyModule, Python},
     types::{IntoPyDict, PyAnyMethods, PyString},
-    Bound,
 };
 use serde_json;
 use std::ffi::CStr;

--- a/tokenserver-auth/src/token/native.rs
+++ b/tokenserver-auth/src/token/native.rs
@@ -1,6 +1,6 @@
 use crate::{
-    crypto::{Crypto, CryptoImpl},
     MakeTokenPlaintext,
+    crypto::{Crypto, CryptoImpl},
 };
 use base64::Engine;
 use serde::{Deserialize, Serialize};
@@ -58,7 +58,7 @@ impl Tokenlib {
 
 #[cfg(test)]
 mod tests {
-    use crate::{crypto::SHA256_OUTPUT_LEN, TokenserverOrigin};
+    use crate::{TokenserverOrigin, crypto::SHA256_OUTPUT_LEN};
 
     use super::*;
 

--- a/tokenserver-auth/src/token/py.rs
+++ b/tokenserver-auth/src/token/py.rs
@@ -1,8 +1,8 @@
 use crate::{MakeTokenPlaintext, TokenserverError};
 use pyo3::{
+    Bound,
     prelude::{IntoPyObject, PyErr, PyModule, Python},
     types::{IntoPyDict, PyAnyMethods, PyDict},
-    Bound,
 };
 
 pub struct PyTokenlib {}

--- a/tokenserver-common/src/error.rs
+++ b/tokenserver-common/src/error.rs
@@ -4,8 +4,8 @@ use actix_web::{HttpResponse, ResponseError};
 use backtrace::Backtrace;
 use http::StatusCode;
 use serde::{
-    ser::{SerializeMap, Serializer},
     Serialize,
+    ser::{SerializeMap, Serializer},
 };
 use syncserver_common::{InternalError, ReportableError};
 

--- a/tokenserver-db-common/src/error.rs
+++ b/tokenserver-db-common/src/error.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use backtrace::Backtrace;
 use deadpool::managed::PoolError;
 use http::StatusCode;
-use syncserver_common::{from_error, impl_fmt_display, InternalError, ReportableError};
+use syncserver_common::{InternalError, ReportableError, from_error, impl_fmt_display};
 use syncserver_db_common::error::SqlError;
 use thiserror::Error;
 use tokenserver_common::TokenserverError;

--- a/tokenserver-db-common/src/lib.rs
+++ b/tokenserver-db-common/src/lib.rs
@@ -52,7 +52,7 @@ pub trait Db {
 
     /// Mark the user with the given uid and service ID as being replaced.
     async fn replace_user(&mut self, params: params::ReplaceUser)
-        -> DbResult<results::ReplaceUser>;
+    -> DbResult<results::ReplaceUser>;
 
     /// Mark users matching the given email and service ID as replaced.
     async fn replace_users(
@@ -309,7 +309,7 @@ pub trait Db {
     #[cfg(debug_assertions)]
     /// Creates new service and returns new service_id.
     async fn post_service(&mut self, params: params::PostService)
-        -> DbResult<results::PostService>;
+    -> DbResult<results::PostService>;
 
     #[cfg(debug_assertions)]
     fn set_spanner_node_id(&mut self, params: params::SpannerNodeId);

--- a/tokenserver-db-common/src/results.rs
+++ b/tokenserver-db-common/src/results.rs
@@ -1,6 +1,6 @@
 use diesel::{
-    sql_types::{Bigint, Integer, Nullable, Text},
     QueryableByName,
+    sql_types::{Bigint, Integer, Nullable, Text},
 };
 use serde::{Deserialize, Serialize};
 

--- a/tokenserver-db/src/lib.rs
+++ b/tokenserver-db/src/lib.rs
@@ -5,7 +5,7 @@ mod tests;
 use url::Url;
 
 use syncserver_common::Metrics;
-pub use tokenserver_db_common::{params, results, Db, DbError, DbPool};
+pub use tokenserver_db_common::{Db, DbError, DbPool, params, results};
 use tokenserver_settings::Settings;
 
 pub fn pool_from_settings(
@@ -31,7 +31,7 @@ pub fn pool_from_settings(
         invalid_scheme => {
             return Err(DbError::internal(format!(
                 "Invalid SYNC_TOKENSERVER__DATABASE_URL scheme: {invalid_scheme}://"
-            )))
+            )));
         }
     })
 }

--- a/tokenserver-db/src/mock.rs
+++ b/tokenserver-db/src/mock.rs
@@ -5,7 +5,7 @@ use std::sync::LazyLock;
 use async_trait::async_trait;
 use syncserver_common::Metrics;
 use syncserver_db_common::{GetPoolState, PoolState};
-use tokenserver_db_common::{params, results, Db, DbError, DbPool};
+use tokenserver_db_common::{Db, DbError, DbPool, params, results};
 
 #[derive(Clone, Debug)]
 pub struct MockDbPool;

--- a/tokenserver-db/src/tests.rs
+++ b/tokenserver-db/src/tests.rs
@@ -5,7 +5,7 @@ use std::{
 
 use syncserver_common::Metrics;
 use syncserver_settings::Settings;
-use tokenserver_db_common::{params, results, DbError, DbPool, DbResult, MAX_GENERATION};
+use tokenserver_db_common::{DbError, DbPool, DbResult, MAX_GENERATION, params, results};
 
 use crate::pool_from_settings;
 

--- a/tokenserver-mysql/src/db/db_impl.rs
+++ b/tokenserver-mysql/src/db/db_impl.rs
@@ -4,13 +4,13 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use async_trait::async_trait;
 use diesel::{
-    sql_types::{Bigint, Float, Integer, Nullable, Text},
     OptionalExtension,
+    sql_types::{Bigint, Float, Integer, Nullable, Text},
 };
 use diesel_async::RunQueryDsl;
 use http::StatusCode;
 use syncserver_common::Metrics;
-use tokenserver_db_common::{params, results, Db, DbError, DbResult};
+use tokenserver_db_common::{Db, DbError, DbResult, params, results};
 
 use super::TokenserverDb;
 

--- a/tokenserver-mysql/src/pool.rs
+++ b/tokenserver-mysql/src/pool.rs
@@ -2,21 +2,21 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use diesel_async::{
-    pooled_connection::{
-        deadpool::{Object, Pool},
-        AsyncDieselConnectionManager,
-    },
     AsyncMysqlConnection,
+    pooled_connection::{
+        AsyncDieselConnectionManager,
+        deadpool::{Object, Pool},
+    },
 };
-use diesel_migrations::{embed_migrations, EmbeddedMigrations};
+use diesel_migrations::{EmbeddedMigrations, embed_migrations};
 use syncserver_common::Metrics;
 #[cfg(debug_assertions)]
 use syncserver_db_common::test::test_transaction_hook;
 use syncserver_db_common::{
-    establish_connection_with_logging, manager_config_with_logging, run_embedded_migrations,
-    GetPoolState, PoolState,
+    GetPoolState, PoolState, establish_connection_with_logging, manager_config_with_logging,
+    run_embedded_migrations,
 };
-use tokenserver_db_common::{params, Db, DbError, DbPool, DbResult};
+use tokenserver_db_common::{Db, DbError, DbPool, DbResult, params};
 
 use tokenserver_settings::Settings;
 

--- a/tokenserver-postgres/src/db/db_impl.rs
+++ b/tokenserver-postgres/src/db/db_impl.rs
@@ -7,13 +7,13 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use async_trait::async_trait;
 use diesel::{
-    sql_types::{BigInt, Float, Integer, Nullable, Text},
     OptionalExtension,
+    sql_types::{BigInt, Float, Integer, Nullable, Text},
 };
 use diesel_async::RunQueryDsl;
 use http::StatusCode;
 use syncserver_common::Metrics;
-use tokenserver_db_common::{params, results, Db, DbError, DbResult};
+use tokenserver_db_common::{Db, DbError, DbResult, params, results};
 
 use super::TokenserverPgDb;
 

--- a/tokenserver-postgres/src/lib.rs
+++ b/tokenserver-postgres/src/lib.rs
@@ -6,8 +6,8 @@ mod db;
 mod pool;
 
 pub use db::{
-    orm_models::{Node, Service, User},
     TokenserverPgDb,
+    orm_models::{Node, Service, User},
 };
 pub use pool::TokenserverPgPool;
-pub use tokenserver_db_common::{params, results, Db, DbPool};
+pub use tokenserver_db_common::{Db, DbPool, params, results};

--- a/tokenserver-postgres/src/pool.rs
+++ b/tokenserver-postgres/src/pool.rs
@@ -2,21 +2,21 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use diesel_async::{
-    pooled_connection::{
-        deadpool::{Object, Pool},
-        AsyncDieselConnectionManager,
-    },
     AsyncPgConnection,
+    pooled_connection::{
+        AsyncDieselConnectionManager,
+        deadpool::{Object, Pool},
+    },
 };
 
-use diesel_migrations::{embed_migrations, EmbeddedMigrations};
+use diesel_migrations::{EmbeddedMigrations, embed_migrations};
 use syncserver_common::Metrics;
 #[cfg(debug_assertions)]
 use syncserver_db_common::test::test_transaction_hook;
 use syncserver_db_common::{
-    manager_config_with_logging, run_embedded_migrations, GetPoolState, PoolState,
+    GetPoolState, PoolState, manager_config_with_logging, run_embedded_migrations,
 };
-use tokenserver_db_common::{params, Db, DbError, DbPool, DbResult};
+use tokenserver_db_common::{Db, DbError, DbPool, DbResult, params};
 
 use crate::db::TokenserverPgDb;
 use tokenserver_settings::Settings;


### PR DESCRIPTION
Upgrade to Rust 2024 edition, with changes related to
 - https://doc.rust-lang.org/edition-guide/rust-2024/rpit-lifetime-capture.html
 - https://doc.rust-lang.org/edition-guide/rust-2024/match-ergonomics.html
 - https://doc.rust-lang.org/edition-guide/rust-2024/newly-unsafe-functions.html#stdenvset_var-remove_var

Closes  STOR-435