### PR TITLE
docs: load test runs for locust and molotov

### DIFF
--- a/tools/syncstorage-loadtest/README.md
+++ b/tools/syncstorage-loadtest/README.md
@@ -61,7 +61,33 @@ If you already have Poetry installed:
 ```bash
 poetry install
 ```
+### Generate Key
+ Run the `generate-keys.sh` script to generate an RSA keypair and derive the public JWK.
 
+Since this script calls `get_jwk.py` and it has a dependency on `autlib`, call the shell script using Poetry:
+
+```bash
+poetry run ./generate-keys.sh 
+```
+
+Otherwise, if in built virtual environment with installed Poetry dependencies:
+
+```bash
+./generate-keys.sh
+```
+
+This script will output two files:
+
+- `load_test.pem`: The private key to be used by the load tests to create OAuth tokens
+- `jwk.json`: The public JWK associated with the private key. This is a key of the form:
+
+```json
+{
+   "n": ...,
+   "e": ...,
+   "kty": "RSA"
+}
+```
 ## Mode 1: Direct Access
 
 With a known syncstorage master secret:

--- a/tools/syncstorage-loadtest/generate-keys.sh
+++ b/tools/syncstorage-loadtest/generate-keys.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# Generate a private RSA key
+openssl genrsa -out load_test.pem 2048
+
+# Derive the public key from the private key
+openssl rsa -in load_test.pem -pubout > load_test.pub
+
+# Derive and print the JWK from the public key
+python3 get_jwk.py load_test.pub > jwk.json
+rm load_test.pub

--- a/tools/syncstorage-loadtest/get_jwk.py
+++ b/tools/syncstorage-loadtest/get_jwk.py
@@ -1,0 +1,7 @@
+import sys
+
+from authlib.jose import JsonWebKey
+
+raw_public_key = open(sys.argv[1], "rb").read()
+public_key = JsonWebKey.import_key(raw_public_key, {"kty": "RSA"})
+print(public_key.as_json())

--- a/tools/tokenserver/loadtests/README.md
+++ b/tools/tokenserver/loadtests/README.md
@@ -48,30 +48,31 @@ Ex. `poetry run python locustfile.py`
    ```
 
 2. Run the `generate-keys.sh` script to generate an RSA keypair and derive the public JWK.
-   Since this script calls `get_jwk.py` and it has a dependency on `autlib`, call the shell script using Poetry:
 
-      ```sh
-   poetry run ./generate-keys.sh 
+Since this script calls `get_jwk.py` and it has a dependency on `autlib`, call the shell script using Poetry:
+
+```sh
+poetry run ./generate-keys.sh 
+```
+
+Otherwise, if in built virtual environment with installed Poetry dependencies:
+
+```sh
+./generate-keys.sh
+```
+
+This script will output two files:
+
+- `load_test.pem`: The private key to be used by the load tests to create OAuth tokens
+- `jwk.json`: The public JWK associated with the private key. This is a key of the form:
+
+```json
+{
+   "n": ...,
+   "e": ...,
+   "kty": "RSA"
+}
    ```
-
-   Otherwise, if in built virtual environment with installed Poetry dependencies:
-   
-   ```sh
-   ./generate-keys.sh
-   ```
-
-   This script will output two files:
-
-   - `load_test.pem`: The private key to be used by the load tests to create OAuth tokens
-   - `jwk.json`: The public JWK associated with the private key. This is a key of the form
-
-     ```json
-     {
-        "n": ...,
-        "e": ...,
-        "kty": "RSA"
-     }
-     ```
 
 3. Set the following environment variables/settings on Tokenserver:
 


### PR DESCRIPTION
## Description

As part of documenting our load tests, we determined some steps were missing in the setup and configuration for both Tokenserver and Sync load tests.

This also adds the key generation scripts required for both.

## Issue(s)

Closes [STOR-491](https://mozilla-hub.atlassian.net/browse/STOR-491).


[STOR-491]: https://mozilla-hub.atlassian.net/browse/STOR-491?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ