### PR TITLE
chore: rmv oauth tokenserver auth method

### DIFF
--- a/tools/integration_tests/conftest.py
+++ b/tools/integration_tests/conftest.py
@@ -114,19 +114,6 @@ def setup_server_local_testing():
 
 
 @pytest.fixture(scope="session")
-def setup_server_local_testing_with_oauth():
-    """
-    Fixture to set up the server for local testing with OAuth.
-    This fixture sets the necessary environment variables and
-    starts the server.
-    """
-    _set_local_test_env_vars()
-
-    # Start the server
-    yield from _server_manager()
-
-
-@pytest.fixture(scope="session")
 def setup_server_end_to_end_testing():
     """
     Fixture to set up the server for end-to-end testing.

--- a/tools/integration_tests/tokenserver/test_authorization.py
+++ b/tools/integration_tests/tokenserver/test_authorization.py
@@ -6,7 +6,7 @@ import unittest
 from integration_tests.tokenserver.test_support import TestCase
 
 
-@pytest.mark.usefixtures("setup_server_local_testing_with_oauth")
+@pytest.mark.usefixtures("setup_server_local_testing")
 class TestAuthorization(TestCase, unittest.TestCase):
     def setUp(self):
         super(TestAuthorization, self).setUp()

--- a/tools/integration_tests/tokenserver/test_misc.py
+++ b/tools/integration_tests/tokenserver/test_misc.py
@@ -9,7 +9,7 @@ from integration_tests.tokenserver.test_support import TestCase
 MAX_GENERATION = 9223372036854775807
 
 
-@pytest.mark.usefixtures("setup_server_local_testing_with_oauth")
+@pytest.mark.usefixtures("setup_server_local_testing")
 class TestMisc(TestCase, unittest.TestCase):
     def setUp(self):
         super(TestMisc, self).setUp()

--- a/tools/integration_tests/tokenserver/test_node_assignment.py
+++ b/tools/integration_tests/tokenserver/test_node_assignment.py
@@ -8,7 +8,7 @@ from integration_tests.tokenserver.test_support import TestCase
 from sqlalchemy.sql import text as sqltext
 
 
-@pytest.mark.usefixtures("setup_server_local_testing_with_oauth")
+@pytest.mark.usefixtures("setup_server_local_testing")
 class TestNodeAssignment(TestCase, unittest.TestCase):
     def setUp(self):
         super(TestNodeAssignment, self).setUp()


### PR DESCRIPTION
## Description

Remove the `TOKENSERVER_AUTH_METHOD` env var, since alternating between OAuth and BrowserID is no longer required.

## Issue(s)

Closes [STOR-510](https://mozilla-hub.atlassian.net/browse/STOR-510).


[STOR-510]: https://mozilla-hub.atlassian.net/browse/STOR-510?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ