### PR TITLE
chore: resolve aws-lc-rs vuln

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,9 +383,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.1"
+version = "1.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -394,9 +394,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+checksum = "1fa7e52a4c5c547c741610a2c6f123f3881e409b714cd27e6798ef020c514f0a"
 dependencies = [
  "cc",
  "cmake",


### PR DESCRIPTION
## Description

Updates two CVEs in `aws-lc-sys` showd up from a `cargo audit run`. 

RUSTSEC-2026-0044: X.509 name constraints bypass — a TLS certificate with a wildcard or Unicode common name (CN) could circumvent name constraint validation, potentially allowing a rogue cert to be accepted as valid.
RUSTSEC-2026-0048 (high, 7.4): CRL distribution point scope logic error — incorrect scoping when checking Certificate Revocation Lists, meaning a revoked certificate might not be flagged.

Transitive deps using it:
```
jsonwebtoken = { ..., features = ["aws_lc_rs"] } — used for FxA JWT verification in tokenserver-auth
reqwest = { ..., features = ["rustls"] } — rustls defaults to aws-lc-rs as its crypto provider, used throughout for HTTP clients
```
## Testing

cargo audit

## Issue(s)
