### PR TITLE
chore: build and push "directly" instead of using mozilla-it/deploy-actions

### DIFF
--- a/.github/actions/setup-build-and-push/action.yml
+++ b/.github/actions/setup-build-and-push/action.yml
@@ -1,0 +1,71 @@
+name: Build and Push Setup
+description: Checkout, version.json, image tag, buildx, GCP auth, and registry logins
+
+inputs:
+  version_json_path:
+    description: Path for version.json
+    required: false
+    default: ./version.json
+  workload_identity_provider:
+    description: GCP Workload Identity provider
+    required: true
+  gcp_service_account:
+    description: GCP service account email
+    required: true
+
+outputs:
+  image_tag:
+    description: Computed image tag
+    value: ${{ steps.tag.outputs.value }}
+  push_latest:
+    description: Whether to push a latest tag
+    value: ${{ steps.tag.outputs.push_latest }}
+
+runs:
+  using: composite
+  steps:
+    - name: Create version.json
+      shell: bash
+      run: |
+        printf '{"commit":"%s","version":"%s","source":"%s","build":"%s"}\n' \
+          "$GITHUB_SHA" "$GITHUB_REF_NAME" \
+          "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY" \
+          "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
+          > ${{ inputs.version_json_path }}
+
+    - name: Compute image tag
+      id: tag
+      shell: bash
+      run: |
+        if [[ "$GITHUB_REF_TYPE" == "tag" ]]; then
+          echo "value=$GITHUB_REF_NAME" >> "$GITHUB_OUTPUT"
+          echo "push_latest=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "value=${GITHUB_SHA:0:10}" >> "$GITHUB_OUTPUT"
+          echo "push_latest=false" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
+
+    - name: GCP auth
+      id: gcp_auth
+      uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+      with:
+        workload_identity_provider: ${{ inputs.workload_identity_provider }}
+        service_account: ${{ inputs.gcp_service_account }}
+        token_format: access_token
+
+    - name: Log in to GAR
+      uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+      with:
+        registry: us-docker.pkg.dev
+        username: oauth2accesstoken
+        password: ${{ steps.gcp_auth.outputs.access_token }}
+
+    - name: Log in to GHCR
+      uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ github.token }}

--- a/.github/workflows/mozcloud-publish.yaml
+++ b/.github/workflows/mozcloud-publish.yaml
@@ -1,15 +1,8 @@
-# Mozilla Deploy Actions url: <https://github.com/mozilla-it/deploy-actions>
-# Note: even though Mozilla maintains the above actions, it is still suggested
-# when upgrading to use the full commit SHA and comment with version.
-# See <https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions>
-# Ex. `mozilla-it/deploy-actions/.github/workflows/build-and-push.yml@4784cb70739a4f32ce010921f60fb1ebbc791a38 # v6.2.2`
-name: Build, Tag and Push Container Images to GAR Repository
+name: Build, Tag and Push Container Images to GAR
 
 on:
   pull_request:
     types: [opened, labeled, unlabeled, synchronize]
-    # paths:
-    #     - '**/sync*/**'
   push:
     branches:
       - master
@@ -48,15 +41,44 @@ jobs:
       contents: read
       id-token: write
       packages: write
-    uses: mozilla-it/deploy-actions/.github/workflows/build-and-push.yml@4784cb70739a4f32ce010921f60fb1ebbc791a38 # v6.2.2
-    with:
-      image_name: syncstorage-rs
-      gar_name: sync-prod
-      project_id: moz-fx-sync-prod
-      docker_build_args: |
-        SYNCSTORAGE_DATABASE_BACKEND=spanner
-        MYSQLCLIENT_PKG=libmysqlclient-dev
-      should_tag_ghcr: true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup-build-and-push
+        id: setup
+        with:
+          workload_identity_provider: ${{ vars.GCPV2_GITHUB_WORKLOAD_IDENTITY_PROVIDER }}
+          gcp_service_account: "${{ vars.SERVICE_ACCOUNT_NAME || 'artifact-writer' }}@moz-fx-sync-prod.iam.gserviceaccount.com"
+
+      - name: Compute tags
+        run: |
+          TAGS=$(cat <<EOF
+          us-docker.pkg.dev/moz-fx-sync-prod/sync-prod/syncstorage-rs:${{ steps.setup.outputs.image_tag }}
+          ghcr.io/${{ github.repository }}/syncstorage-rs:${{ steps.setup.outputs.image_tag }}
+          EOF
+          )
+          if [[ "${{ steps.setup.outputs.push_latest }}" == "true" ]]; then
+            TAGS="$TAGS
+          us-docker.pkg.dev/moz-fx-sync-prod/sync-prod/syncstorage-rs:latest
+          ghcr.io/${{ github.repository }}/syncstorage-rs:latest"
+          fi
+          echo "IMAGE_TAGS<<EOF" >> "$GITHUB_ENV"
+          echo "$TAGS" >> "$GITHUB_ENV"
+          echo "EOF" >> "$GITHUB_ENV"
+
+      - uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
+        with:
+          context: .
+          push: true
+          build-args: |
+            SYNCSTORAGE_DATABASE_BACKEND=spanner
+            MYSQLCLIENT_PKG=libmysqlclient-dev
+          tags: ${{ env.IMAGE_TAGS }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
   build-and-push-syncserver-postgres:
     needs: check
@@ -64,30 +86,71 @@ jobs:
       contents: read
       id-token: write
       packages: write
-    uses: mozilla-it/deploy-actions/.github/workflows/build-and-push.yml@4784cb70739a4f32ce010921f60fb1ebbc791a38 # v6.2.2
-    with:
-      image_name: syncserver-postgres
-      gar_name: sync-prod
-      project_id: moz-fx-sync-prod
-      docker_build_args: |
-        SYNCSTORAGE_DATABASE_BACKEND=postgres
-        TOKENSERVER_DATABASE_BACKEND=postgres
-      should_tag_ghcr: true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
-  build-and-push-syncserver-postgres-enterprise-gar:
-    needs: check
-    permissions:
-      contents: read
-      id-token: write
-      packages: write
-    uses: mozilla-it/deploy-actions/.github/workflows/build-and-push.yml@4784cb70739a4f32ce010921f60fb1ebbc791a38 # v6.2.2
-    with:
-      image_name: syncserver-postgres
-      gar_name: fx-enterprise-private
-      project_id: moz-fx-fx-enterprise-prod
-      docker_build_args: |
-        SYNCSTORAGE_DATABASE_BACKEND=postgres
-        TOKENSERVER_DATABASE_BACKEND=postgres
+      - uses: ./.github/actions/setup-build-and-push
+        id: setup
+        with:
+          workload_identity_provider: ${{ vars.GCPV2_GITHUB_WORKLOAD_IDENTITY_PROVIDER }}
+          gcp_service_account: "${{ vars.SERVICE_ACCOUNT_NAME || 'artifact-writer' }}@moz-fx-sync-prod.iam.gserviceaccount.com"
+
+      - name: Compute tags
+        run: |
+          TAGS=$(cat <<EOF
+          us-docker.pkg.dev/moz-fx-sync-prod/sync-prod/syncserver-postgres:${{ steps.setup.outputs.image_tag }}
+          ghcr.io/${{ github.repository }}/syncserver-postgres:${{ steps.setup.outputs.image_tag }}
+          EOF
+          )
+          if [[ "${{ steps.setup.outputs.push_latest }}" == "true" ]]; then
+            TAGS="$TAGS
+          us-docker.pkg.dev/moz-fx-sync-prod/sync-prod/syncserver-postgres:latest
+          ghcr.io/${{ github.repository }}/syncserver-postgres:latest"
+          fi
+          echo "IMAGE_TAGS<<EOF" >> "$GITHUB_ENV"
+          echo "$TAGS" >> "$GITHUB_ENV"
+          echo "EOF" >> "$GITHUB_ENV"
+
+      - name: Build and push to prod GAR and ghcr
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
+        with:
+          context: .
+          push: true
+          build-args: |
+            SYNCSTORAGE_DATABASE_BACKEND=postgres
+            TOKENSERVER_DATABASE_BACKEND=postgres
+          tags: ${{ env.IMAGE_TAGS }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: GCP auth (enterprise)
+        id: gcp_auth_ent
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          workload_identity_provider: ${{ vars.GCPV2_GITHUB_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: "${{ vars.SERVICE_ACCOUNT_NAME || 'artifact-writer' }}@moz-fx-fx-enterprise-prod.iam.gserviceaccount.com"
+          token_format: access_token
+
+      - name: Log in to enterprise GAR
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: us-docker.pkg.dev
+          username: oauth2accesstoken
+          password: ${{ steps.gcp_auth_ent.outputs.access_token }}
+
+      - name: Build and push to enterprise GAR
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
+        with:
+          context: .
+          push: true
+          build-args: |
+            SYNCSTORAGE_DATABASE_BACKEND=postgres
+            TOKENSERVER_DATABASE_BACKEND=postgres
+          tags: us-docker.pkg.dev/moz-fx-fx-enterprise-prod/fx-enterprise-private/syncserver-postgres:${{ steps.setup.outputs.image_tag }}
+          cache-from: type=gha
 
   # Note: we are moving towards renaming all images `syncserver`, the union of sync and tokenserver.
   # This presently remains for the time being to simplify deploys by maintaining `image_name: syncstorage-rs-spanner-python-utils`.
@@ -98,14 +161,43 @@ jobs:
       contents: read
       id-token: write
       packages: write
-    uses: mozilla-it/deploy-actions/.github/workflows/build-and-push.yml@4784cb70739a4f32ce010921f60fb1ebbc791a38 # v6.2.2
-    with:
-      image_name: syncstorage-rs-spanner-python-utils
-      gar_name: sync-prod
-      project_id: moz-fx-sync-prod
-      dockerfile_path: tools/spanner/Dockerfile
-      image_build_context: tools/spanner
-      should_tag_ghcr: true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup-build-and-push
+        id: setup
+        with:
+          workload_identity_provider: ${{ vars.GCPV2_GITHUB_WORKLOAD_IDENTITY_PROVIDER }}
+          gcp_service_account: "${{ vars.SERVICE_ACCOUNT_NAME || 'artifact-writer' }}@moz-fx-sync-prod.iam.gserviceaccount.com"
+          version_json_path: ./tools/spanner/version.json
+
+      - name: Compute tags
+        run: |
+          TAGS=$(cat <<EOF
+          us-docker.pkg.dev/moz-fx-sync-prod/sync-prod/syncstorage-rs-spanner-python-utils:${{ steps.setup.outputs.image_tag }}
+          ghcr.io/${{ github.repository }}/syncstorage-rs-spanner-python-utils:${{ steps.setup.outputs.image_tag }}
+          EOF
+          )
+          if [[ "${{ steps.setup.outputs.push_latest }}" == "true" ]]; then
+            TAGS="$TAGS
+          us-docker.pkg.dev/moz-fx-sync-prod/sync-prod/syncstorage-rs-spanner-python-utils:latest
+          ghcr.io/${{ github.repository }}/syncstorage-rs-spanner-python-utils:latest"
+          fi
+          echo "IMAGE_TAGS<<EOF" >> "$GITHUB_ENV"
+          echo "$TAGS" >> "$GITHUB_ENV"
+          echo "EOF" >> "$GITHUB_ENV"
+
+      - uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
+        with:
+          context: tools/spanner
+          file: tools/spanner/Dockerfile
+          push: true
+          tags: ${{ env.IMAGE_TAGS }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
   build-and-push-syncserver-postgres-python-utils:
     needs: check
@@ -113,28 +205,68 @@ jobs:
       contents: read
       id-token: write
       packages: write
-    uses: mozilla-it/deploy-actions/.github/workflows/build-and-push.yml@4784cb70739a4f32ce010921f60fb1ebbc791a38 # v6.2.2
-    with:
-      image_name: syncserver-postgres-python-utils
-      gar_name: sync-prod
-      project_id: moz-fx-sync-prod
-      dockerfile_path: tools/postgres/Dockerfile
-      image_build_context: tools/postgres
-      should_tag_ghcr: true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
-  build-and-push-syncserver-postgres-python-utils-enterprise-gar:
-    needs: check
-    permissions:
-      contents: read
-      id-token: write
-      packages: write
-    uses: mozilla-it/deploy-actions/.github/workflows/build-and-push.yml@4784cb70739a4f32ce010921f60fb1ebbc791a38 # v6.2.2
-    with:
-      image_name: syncserver-postgres-python-utils
-      gar_name: fx-enterprise-private
-      project_id: moz-fx-fx-enterprise-prod
-      dockerfile_path: tools/postgres/Dockerfile
-      image_build_context: tools/postgres
+      - uses: ./.github/actions/setup-build-and-push
+        id: setup
+        with:
+          workload_identity_provider: ${{ vars.GCPV2_GITHUB_WORKLOAD_IDENTITY_PROVIDER }}
+          gcp_service_account: "${{ vars.SERVICE_ACCOUNT_NAME || 'artifact-writer' }}@moz-fx-sync-prod.iam.gserviceaccount.com"
+          version_json_path: ./tools/postgres/version.json
+
+      - name: Compute tags
+        run: |
+          TAGS=$(cat <<EOF
+          us-docker.pkg.dev/moz-fx-sync-prod/sync-prod/syncserver-postgres-python-utils:${{ steps.setup.outputs.image_tag }}
+          ghcr.io/${{ github.repository }}/syncserver-postgres-python-utils:${{ steps.setup.outputs.image_tag }}
+          EOF
+          )
+          if [[ "${{ steps.setup.outputs.push_latest }}" == "true" ]]; then
+            TAGS="$TAGS
+          us-docker.pkg.dev/moz-fx-sync-prod/sync-prod/syncserver-postgres-python-utils:latest
+          ghcr.io/${{ github.repository }}/syncserver-postgres-python-utils:latest"
+          fi
+          echo "IMAGE_TAGS<<EOF" >> "$GITHUB_ENV"
+          echo "$TAGS" >> "$GITHUB_ENV"
+          echo "EOF" >> "$GITHUB_ENV"
+
+      - name: Build and push to prod GAR and ghcr
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
+        with:
+          context: tools/postgres
+          file: tools/postgres/Dockerfile
+          push: true
+          tags: ${{ env.IMAGE_TAGS }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: GCP auth (enterprise)
+        id: gcp_auth_ent
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          workload_identity_provider: ${{ vars.GCPV2_GITHUB_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: "${{ vars.SERVICE_ACCOUNT_NAME || 'artifact-writer' }}@moz-fx-fx-enterprise-prod.iam.gserviceaccount.com"
+          token_format: access_token
+
+      - name: Log in to enterprise GAR
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: us-docker.pkg.dev
+          username: oauth2accesstoken
+          password: ${{ steps.gcp_auth_ent.outputs.access_token }}
+
+      - name: Build and push to enterprise GAR
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
+        with:
+          context: tools/postgres
+          file: tools/postgres/Dockerfile
+          push: true
+          tags: us-docker.pkg.dev/moz-fx-fx-enterprise-prod/fx-enterprise-private/syncserver-postgres-python-utils:${{ steps.setup.outputs.image_tag }}
+          cache-from: type=gha
 
   build-and-push-syncserver-mysql:
     needs: check
@@ -142,12 +274,41 @@ jobs:
       contents: read
       id-token: write
       packages: write
-    uses: mozilla-it/deploy-actions/.github/workflows/build-and-push.yml@4784cb70739a4f32ce010921f60fb1ebbc791a38 # v6.2.2
-    with:
-      image_name: syncserver-mysql
-      gar_name: sync-prod
-      project_id: moz-fx-sync-prod
-      docker_build_args: |
-        SYNCSTORAGE_DATABASE_BACKEND=mysql
-        TOKENSERVER_DATABASE_BACKEND=mysql
-      should_tag_ghcr: true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup-build-and-push
+        id: setup
+        with:
+          workload_identity_provider: ${{ vars.GCPV2_GITHUB_WORKLOAD_IDENTITY_PROVIDER }}
+          gcp_service_account: "${{ vars.SERVICE_ACCOUNT_NAME || 'artifact-writer' }}@moz-fx-sync-prod.iam.gserviceaccount.com"
+
+      - name: Compute tags
+        run: |
+          TAGS=$(cat <<EOF
+          us-docker.pkg.dev/moz-fx-sync-prod/sync-prod/syncserver-mysql:${{ steps.setup.outputs.image_tag }}
+          ghcr.io/${{ github.repository }}/syncserver-mysql:${{ steps.setup.outputs.image_tag }}
+          EOF
+          )
+          if [[ "${{ steps.setup.outputs.push_latest }}" == "true" ]]; then
+            TAGS="$TAGS
+          us-docker.pkg.dev/moz-fx-sync-prod/sync-prod/syncserver-mysql:latest
+          ghcr.io/${{ github.repository }}/syncserver-mysql:latest"
+          fi
+          echo "IMAGE_TAGS<<EOF" >> "$GITHUB_ENV"
+          echo "$TAGS" >> "$GITHUB_ENV"
+          echo "EOF" >> "$GITHUB_ENV"
+
+      - uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
+        with:
+          context: .
+          push: true
+          build-args: |
+            SYNCSTORAGE_DATABASE_BACKEND=mysql
+            TOKENSERVER_DATABASE_BACKEND=mysql
+          tags: ${{ env.IMAGE_TAGS }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/mysql.yml
+++ b/.github/workflows/mysql.yml
@@ -161,10 +161,10 @@ jobs:
           GITHUB_REPOSITORY_NAME: ${{ github.event.repository.name }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
       - name: Build MySQL Docker image
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
         with:
           context: .
           push: false

--- a/.github/workflows/postgres.yml
+++ b/.github/workflows/postgres.yml
@@ -168,10 +168,10 @@ jobs:
           GITHUB_REPOSITORY_NAME: ${{ github.event.repository.name }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
       - name: Build Postgres Docker image
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
         with:
           context: .
           push: false

--- a/.github/workflows/spanner.yml
+++ b/.github/workflows/spanner.yml
@@ -195,10 +195,10 @@ jobs:
           GITHUB_REPOSITORY_NAME: ${{ github.event.repository.name }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
       - name: Build Spanner Docker image (local artifact)
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
         with:
           context: .
           push: false


### PR DESCRIPTION
We relied on mozilla-it/deploy-actions's build-and-push to push a couple of Docker images to another GAR in GCP.  That duplicate the image builds.  With this patch we'll define the build-and-push actions ourselves.

Additionally, we'll push a 'latest' tag to the non-enterprise image registries on a git tag push.

Closes STOR-499, STOR-509
