### PR TITLE
perf: drop/de-allocate req body str explicitly after parsing

### DIFF
--- a/syncserver/src/web/extractors/bso_bodies.rs
+++ b/syncserver/src/web/extractors/bso_bodies.rs
@@ -134,6 +134,8 @@ impl FromRequest for BsoBodies {
                 return future::err(make_error());
             };
 
+            drop(body);
+
             // Validate all the BSO's, move invalid to our other list. Assume they'll all make
             // it with our pre-allocation
             let mut valid: Vec<BatchBsoBody> = Vec::with_capacity(bsos.len());


### PR DESCRIPTION
In the BsoBodies::from_request extractor, the request body string is dropped at the end of its scope.  But it can be explicitly dropped once it's no longer needed.

Low risk so seems worth trying.