### PR TITLE
refactor: stop passing collection id to get_quota_usage

### DIFF
--- a/syncserver/src/web/handlers.rs
+++ b/syncserver/src/web/handlers.rs
@@ -471,12 +471,10 @@ pub async fn post_collection_batch(
             .await?;
 
         if is_valid {
-            let collection_id = db.get_collection_id(&coll.collection).await?;
             let usage = db
                 .get_quota_usage(params::GetQuotaUsage {
                     user_id: coll.user_id.clone(),
                     collection: coll.collection.clone(),
-                    collection_id,
                 })
                 .await?;
             CreateBatch {

--- a/syncstorage-db-common/src/lib.rs
+++ b/syncstorage-db-common/src/lib.rs
@@ -207,9 +207,7 @@ pub trait Db: BatchDb {
 
     // Internal methods used by the db tests
 
-    // TODO: should be test only but currently isn't:
-    // https://github.com/mozilla-services/syncstorage-rs/issues/1959
-    //#[cfg(debug_assertions)]
+    #[cfg(debug_assertions)]
     async fn get_collection_id(&mut self, name: &str) -> Result<i32, Self::Error>;
 
     #[cfg(debug_assertions)]

--- a/syncstorage-db-common/src/params.rs
+++ b/syncstorage-db-common/src/params.rs
@@ -193,7 +193,6 @@ collection_data! {
         id: String,
     },
     GetQuotaUsage {
-        collection_id: i32,
     },
 }
 

--- a/syncstorage-db/src/mock.rs
+++ b/syncstorage-db/src/mock.rs
@@ -206,6 +206,7 @@ impl Db for MockDb {
         Default::default()
     }
 
+    #[cfg(debug_assertions)]
     async fn get_collection_id(
         &mut self,
         _params: &str,

--- a/syncstorage-db/src/tests/db.rs
+++ b/syncstorage-db/src/tests/db.rs
@@ -648,12 +648,10 @@ async fn get_collection_usage() -> Result<(), DbError> {
         assert_eq!(total, sum as u64);
         let settings = Settings::test_settings();
         if settings.syncstorage.enable_quota {
-            let collection_id = db.get_collection_id("bookmarks").await?;
             let quota = db
                 .get_quota_usage(params::GetQuotaUsage {
                     user_id: hid(uid),
                     collection: "ignored".to_owned(),
-                    collection_id,
                 })
                 .await?;
             assert_eq!(
@@ -1076,7 +1074,7 @@ async fn lock_for_read() -> Result<(), DbError> {
         collection: coll.to_owned(),
     })
     .await?;
-    let result = db.get_collection_id("NewCollection").await;
+    let result: Result<i32, DbError> = db.get_collection_id("NewCollection").await;
     assert!(result.unwrap_err().is_collection_not_found());
     Ok(())
 }

--- a/syncstorage-mysql/src/db/batch_impl.rs
+++ b/syncstorage-mysql/src/db/batch_impl.rs
@@ -32,7 +32,7 @@ impl BatchDb for MysqlDb {
         params: params::CreateBatch,
     ) -> DbResult<results::CreateBatch> {
         let user_id = params.user_id.legacy_id as i64;
-        let collection_id = self.get_collection_id(&params.collection).await?;
+        let collection_id = self._get_collection_id(&params.collection).await?;
         // Careful, there's some weirdness here!
         //
         // Sync timestamps are in seconds and quantized to two decimal places, so
@@ -85,7 +85,7 @@ impl BatchDb for MysqlDb {
         }
 
         let user_id = params.user_id.legacy_id as i64;
-        let collection_id = self.get_collection_id(&params.collection).await?;
+        let collection_id = self._get_collection_id(&params.collection).await?;
         let exists = batch_uploads::table
             .select(sql::<Integer>("1"))
             .filter(batch_uploads::batch_id.eq(&batch_id))
@@ -111,7 +111,7 @@ impl BatchDb for MysqlDb {
         }
 
         let batch_id = decode_id(&params.batch.id)?;
-        let collection_id = self.get_collection_id(&params.collection).await?;
+        let collection_id = self._get_collection_id(&params.collection).await?;
         do_append(self, batch_id, params.user_id, collection_id, params.bsos).await?;
         Ok(())
     }
@@ -135,7 +135,7 @@ impl BatchDb for MysqlDb {
     async fn delete_batch(&mut self, params: params::DeleteBatch) -> DbResult<()> {
         let batch_id = decode_id(&params.id)?;
         let user_id = params.user_id.legacy_id as i64;
-        let collection_id = self.get_collection_id(&params.collection).await?;
+        let collection_id = self._get_collection_id(&params.collection).await?;
         diesel::delete(batch_uploads::table)
             .filter(batch_uploads::batch_id.eq(&batch_id))
             .filter(batch_uploads::user_id.eq(&user_id))
@@ -157,7 +157,7 @@ impl BatchDb for MysqlDb {
     ) -> DbResult<results::CommitBatch> {
         let batch_id = decode_id(&params.batch.id)?;
         let user_id = params.user_id.legacy_id as i64;
-        let collection_id = self.get_collection_id(&params.collection).await?;
+        let collection_id = self._get_collection_id(&params.collection).await?;
         let timestamp = self.session.timestamp;
         sql_query(include_str!("batch_commit.sql"))
             .bind::<BigInt, _>(user_id)

--- a/syncstorage-mysql/src/db/db_impl.rs
+++ b/syncstorage-mysql/src/db/db_impl.rs
@@ -43,7 +43,7 @@ impl Db for MysqlDb {
         // Lock the db
         self.begin(false).await?;
         let collection_id = self
-            .get_collection_id(&params.collection)
+            ._get_collection_id(&params.collection)
             .await
             .or_else(|e| {
                 if e.is_collection_not_found() {
@@ -165,7 +165,7 @@ impl Db for MysqlDb {
         params: params::DeleteCollection,
     ) -> DbResult<SyncTimestamp> {
         let user_id = params.user_id.legacy_id as i64;
-        let collection_id = self.get_collection_id(&params.collection).await?;
+        let collection_id = self._get_collection_id(&params.collection).await?;
         let mut count = delete(bso::table)
             .filter(bso::user_id.eq(user_id))
             .filter(bso::collection_id.eq(&collection_id))
@@ -182,28 +182,6 @@ impl Db for MysqlDb {
             self.erect_tombstone(user_id as i32).await?;
         }
         self.get_storage_timestamp(params.user_id).await
-    }
-
-    async fn get_collection_id(&mut self, name: &str) -> DbResult<i32> {
-        if let Some(id) = self.coll_cache.get_id(name)? {
-            return Ok(id);
-        }
-
-        let id = sql_query(
-            "SELECT id
-               FROM collections
-              WHERE name = ?",
-        )
-        .bind::<Text, _>(name)
-        .get_result::<IdResult>(&mut self.conn)
-        .await
-        .optional()?
-        .ok_or_else(DbError::collection_not_found)?
-        .id;
-        if !self.session.in_write_transaction {
-            self.coll_cache.put(id, name.to_owned())?;
-        }
-        Ok(id)
     }
 
     async fn put_bso(&mut self, bso: params::PutBso) -> DbResult<results::PutBso> {
@@ -223,7 +201,6 @@ impl Db for MysqlDb {
                 .get_quota_usage(params::GetQuotaUsage {
                     user_id: bso.user_id.clone(),
                     collection: bso.collection.clone(),
-                    collection_id,
                 })
                 .await?;
             if usage.total_bytes >= self.quota.size {
@@ -311,7 +288,7 @@ impl Db for MysqlDb {
 
     async fn get_bsos(&mut self, params: params::GetBsos) -> DbResult<results::GetBsos> {
         let user_id = params.user_id.legacy_id as i64;
-        let collection_id = self.get_collection_id(&params.collection).await?;
+        let collection_id = self._get_collection_id(&params.collection).await?;
         let now = self.session.timestamp.as_i64();
         let mut query = bso::table
             .select((
@@ -412,7 +389,7 @@ impl Db for MysqlDb {
 
     async fn get_bso_ids(&mut self, params: params::GetBsos) -> DbResult<results::GetBsoIds> {
         let user_id = params.user_id.legacy_id as i64;
-        let collection_id = self.get_collection_id(&params.collection).await?;
+        let collection_id = self._get_collection_id(&params.collection).await?;
         let mut query = bso::table
             .select(bso::id)
             .filter(bso::user_id.eq(user_id))
@@ -475,7 +452,7 @@ impl Db for MysqlDb {
 
     async fn get_bso(&mut self, params: params::GetBso) -> DbResult<Option<results::GetBso>> {
         let user_id = params.user_id.legacy_id as i64;
-        let collection_id = self.get_collection_id(&params.collection).await?;
+        let collection_id = self._get_collection_id(&params.collection).await?;
         Ok(bso::table
             .select((
                 bso::id,
@@ -495,7 +472,7 @@ impl Db for MysqlDb {
 
     async fn delete_bso(&mut self, params: params::DeleteBso) -> DbResult<results::DeleteBso> {
         let user_id = params.user_id.legacy_id;
-        let collection_id = self.get_collection_id(&params.collection).await?;
+        let collection_id = self._get_collection_id(&params.collection).await?;
         let affected_rows = delete(bso::table)
             .filter(bso::user_id.eq(user_id as i64))
             .filter(bso::collection_id.eq(&collection_id))
@@ -516,7 +493,7 @@ impl Db for MysqlDb {
 
     async fn delete_bsos(&mut self, params: params::DeleteBsos) -> DbResult<results::DeleteBsos> {
         let user_id = params.user_id.legacy_id as i64;
-        let collection_id = self.get_collection_id(&params.collection).await?;
+        let collection_id = self._get_collection_id(&params.collection).await?;
         delete(bso::table)
             .filter(bso::user_id.eq(user_id))
             .filter(bso::collection_id.eq(&collection_id))
@@ -572,7 +549,7 @@ impl Db for MysqlDb {
         params: params::GetCollectionTimestamp,
     ) -> DbResult<SyncTimestamp> {
         let user_id = params.user_id.legacy_id as u32;
-        let collection_id = self.get_collection_id(&params.collection).await?;
+        let collection_id = self._get_collection_id(&params.collection).await?;
         if let Some(modified) = self
             .session
             .coll_modified_cache
@@ -595,7 +572,7 @@ impl Db for MysqlDb {
         params: params::GetBsoTimestamp,
     ) -> DbResult<SyncTimestamp> {
         let user_id = params.user_id.legacy_id as i64;
-        let collection_id = self.get_collection_id(&params.collection).await?;
+        let collection_id = self._get_collection_id(&params.collection).await?;
         let modified = bso::table
             .select(bso::modified)
             .filter(bso::user_id.eq(user_id))
@@ -705,13 +682,14 @@ impl Db for MysqlDb {
         params: params::GetQuotaUsage,
     ) -> DbResult<results::GetQuotaUsage> {
         let uid = params.user_id.legacy_id as i64;
+        let collection_id = self._get_collection_id(&params.collection).await?;
         let (total_bytes, count): (i64, i32) = user_collections::table
             .select((
                 sql::<BigInt>("COALESCE(SUM(COALESCE(total_bytes, 0)), 0)"),
                 sql::<Integer>("COALESCE(SUM(COALESCE(count, 0)), 0)"),
             ))
             .filter(user_collections::user_id.eq(uid))
-            .filter(user_collections::collection_id.eq(params.collection_id))
+            .filter(user_collections::collection_id.eq(collection_id))
             .get_result(&mut self.conn)
             .await
             .optional()?
@@ -770,6 +748,11 @@ impl Db for MysqlDb {
     }
 
     #[cfg(debug_assertions)]
+    async fn get_collection_id(&mut self, name: &str) -> DbResult<i32> {
+        self._get_collection_id(name).await
+    }
+
+    #[cfg(debug_assertions)]
     fn timestamp(&self) -> SyncTimestamp {
         self.session.timestamp
     }
@@ -793,12 +776,6 @@ impl Db for MysqlDb {
             enforced,
         }
     }
-}
-
-#[derive(Debug, QueryableByName)]
-struct IdResult {
-    #[diesel(sql_type = Integer)]
-    id: i32,
 }
 
 #[derive(Debug, QueryableByName)]

--- a/syncstorage-mysql/src/db/mod.rs
+++ b/syncstorage-mysql/src/db/mod.rs
@@ -9,7 +9,7 @@ use diesel::{
 use diesel_async::RunQueryDsl;
 use syncserver_common::Metrics;
 use syncstorage_db_common::{
-    Db, FIRST_CUSTOM_COLLECTION_ID, UserIdentifier, error::DbErrorIntrospect, results,
+    FIRST_CUSTOM_COLLECTION_ID, UserIdentifier, error::DbErrorIntrospect, results,
     util::SyncTimestamp,
 };
 use syncstorage_settings::Quota;
@@ -113,7 +113,7 @@ impl MysqlDb {
     }
 
     pub(super) async fn get_or_create_collection_id(&mut self, name: &str) -> DbResult<i32> {
-        match self.get_collection_id(name).await {
+        match self._get_collection_id(name).await {
             Err(e) if e.is_collection_not_found() => self._create_collection(name).await,
             result => result,
         }
@@ -143,6 +143,28 @@ impl MysqlDb {
             ));
         }
         Ok(collection_id)
+    }
+
+    async fn _get_collection_id(&mut self, name: &str) -> DbResult<i32> {
+        if let Some(id) = self.coll_cache.get_id(name)? {
+            return Ok(id);
+        }
+
+        let id = sql_query(
+            "SELECT id
+               FROM collections
+              WHERE name = ?",
+        )
+        .bind::<Text, _>(name)
+        .get_result::<IdResult>(&mut self.conn)
+        .await
+        .optional()?
+        .ok_or_else(DbError::collection_not_found)?
+        .id;
+        if !self.session.in_write_transaction {
+            self.coll_cache.put(id, name.to_owned())?;
+        }
+        Ok(id)
     }
 
     async fn map_collection_names<T>(
@@ -222,4 +244,10 @@ impl MysqlDb {
 struct NameResult {
     #[diesel(sql_type = Text)]
     name: String,
+}
+
+#[derive(Debug, QueryableByName)]
+struct IdResult {
+    #[diesel(sql_type = Integer)]
+    id: i32,
 }

--- a/syncstorage-postgres/src/db/batch_impl.rs
+++ b/syncstorage-postgres/src/db/batch_impl.rs
@@ -167,7 +167,7 @@ impl BatchDb for PgDb {
     ) -> DbResult<results::DeleteBatch> {
         let batch_id = validate_batch_id(&params.id)?;
         let user_id = params.user_id.legacy_id as i64;
-        let collection_id = self.get_collection_id(&params.collection).await?;
+        let collection_id = self._get_collection_id(&params.collection).await?;
 
         delete(
             batches::table

--- a/syncstorage-postgres/src/db/db_impl.rs
+++ b/syncstorage-postgres/src/db/db_impl.rs
@@ -21,7 +21,7 @@ use crate::{
     db::{CollectionLock, PRETOUCH_DT},
     orm_models::{BsoChangeset, sql_types::PostBso},
     pool::Conn,
-    schema::{bsos, collections, user_collections},
+    schema::{bsos, user_collections},
 };
 
 #[async_trait(?Send)]
@@ -76,7 +76,7 @@ impl Db for PgDb {
         self.begin(false).await?;
         let user_id = params.user_id.legacy_id as i64;
         let collection_id = self
-            .get_collection_id(&params.collection)
+            ._get_collection_id(&params.collection)
             .await
             .or_else(|e| {
                 if e.is_collection_not_found() {
@@ -181,7 +181,7 @@ impl Db for PgDb {
         params: params::GetCollectionTimestamp,
     ) -> DbResult<results::GetCollectionTimestamp> {
         let user_id = params.user_id.legacy_id as i64;
-        let collection_id = self.get_collection_id(&params.collection).await?;
+        let collection_id = self._get_collection_id(&params.collection).await?;
         if let Some(modified) = self
             .session
             .coll_modified_cache
@@ -265,13 +265,14 @@ impl Db for PgDb {
         &mut self,
         params: params::GetQuotaUsage,
     ) -> DbResult<results::GetQuotaUsage> {
+        let collection_id = self._get_collection_id(&params.collection).await?;
         let (total_bytes, count): (i64, i64) = user_collections::table
             .select((
                 sql::<BigInt>("COALESCE(SUM(COALESCE(total_bytes, 0)), 0)::BIGINT"),
                 sql::<BigInt>("COALESCE(SUM(COALESCE(count, 0)), 0)::BIGINT"),
             ))
             .filter(user_collections::user_id.eq(params.user_id.legacy_id as i64))
-            .filter(user_collections::collection_id.eq(params.collection_id))
+            .filter(user_collections::collection_id.eq(collection_id))
             .get_result(&mut self.conn)
             .await
             .optional()?
@@ -303,7 +304,7 @@ impl Db for PgDb {
         params: params::DeleteCollection,
     ) -> DbResult<results::DeleteCollection> {
         let user_id = params.user_id.legacy_id as i64;
-        let collection_id = self.get_collection_id(&params.collection).await?;
+        let collection_id = self._get_collection_id(&params.collection).await?;
         let mut count = delete(bsos::table)
             .filter(bsos::user_id.eq(user_id))
             .filter(bsos::collection_id.eq(&collection_id))
@@ -325,7 +326,7 @@ impl Db for PgDb {
 
     async fn delete_bsos(&mut self, params: params::DeleteBsos) -> DbResult<results::DeleteBsos> {
         let user_id = params.user_id.legacy_id as i64;
-        let collection_id = self.get_collection_id(&params.collection).await?;
+        let collection_id = self._get_collection_id(&params.collection).await?;
         delete(bsos::table)
             .filter(bsos::user_id.eq(user_id))
             .filter(bsos::collection_id.eq(&collection_id))
@@ -378,7 +379,7 @@ impl Db for PgDb {
 
     async fn delete_bso(&mut self, params: params::DeleteBso) -> DbResult<results::DeleteBso> {
         let user_id = params.user_id.legacy_id as i64;
-        let collection_id = self.get_collection_id(&params.collection).await?;
+        let collection_id = self._get_collection_id(&params.collection).await?;
         let affected_rows = delete(bsos::table)
             .filter(bsos::user_id.eq(user_id))
             .filter(bsos::collection_id.eq(&collection_id))
@@ -399,7 +400,7 @@ impl Db for PgDb {
 
     async fn get_bso(&mut self, params: params::GetBso) -> DbResult<Option<results::GetBso>> {
         let user_id = params.user_id.legacy_id as i64;
-        let collection_id = self.get_collection_id(&params.collection).await?;
+        let collection_id = self._get_collection_id(&params.collection).await?;
         let bso = bsos::table
             .select(GetBso::as_select())
             .filter(bsos::user_id.eq(user_id))
@@ -419,7 +420,7 @@ impl Db for PgDb {
         params: params::GetBsoTimestamp,
     ) -> DbResult<results::GetBsoTimestamp> {
         let user_id = params.user_id.legacy_id as i64;
-        let collection_id = self.get_collection_id(&params.collection).await?;
+        let collection_id = self._get_collection_id(&params.collection).await?;
         let modified = bsos::table
             .select(bsos::modified)
             .filter(bsos::user_id.eq(user_id))
@@ -436,8 +437,7 @@ impl Db for PgDb {
         let user_id = bso.user_id.legacy_id as i64;
         let collection_id = self.get_or_create_collection_id(&bso.collection).await?;
 
-        self.check_quota(&bso.user_id, &bso.collection, collection_id)
-            .await?;
+        self.check_quota(&bso.user_id, &bso.collection).await?;
 
         let payload = bso.payload.as_deref().unwrap_or_default();
         let sortindex = bso.sortindex;
@@ -482,7 +482,7 @@ impl Db for PgDb {
     async fn post_bsos(&mut self, params: params::PostBsos) -> DbResult<results::PostBsos> {
         let user_id = params.user_id.legacy_id as i64;
         let collection_id = self.get_or_create_collection_id(&params.collection).await?;
-        self.check_quota(&params.user_id, &params.collection, collection_id)
+        self.check_quota(&params.user_id, &params.collection)
             .await?;
         self.ensure_user_collection(user_id, collection_id).await?;
 
@@ -506,25 +506,6 @@ impl Db for PgDb {
             collection: params.collection,
         })
         .await
-    }
-
-    async fn get_collection_id(&mut self, name: &str) -> DbResult<results::GetCollectionId> {
-        if let Some(id) = self.coll_cache.get_id(name)? {
-            return Ok(id);
-        }
-
-        let id = collections::table
-            .select(collections::collection_id)
-            .filter(collections::name.eq(name))
-            .first::<i32>(&mut self.conn)
-            .await
-            .optional()?
-            .ok_or_else(DbError::collection_not_found)?;
-
-        if !self.session.in_write_transaction {
-            self.coll_cache.put(id, name.to_owned())?;
-        }
-        Ok(id)
     }
 
     fn get_connection_info(&self) -> results::ConnectionInfo {
@@ -574,6 +555,11 @@ impl Db for PgDb {
     #[cfg(debug_assertions)]
     async fn create_collection(&mut self, name: &str) -> DbResult<i32> {
         self._create_collection(name).await
+    }
+
+    #[cfg(debug_assertions)]
+    async fn get_collection_id(&mut self, name: &str) -> DbResult<i32> {
+        self._get_collection_id(name).await
     }
 
     #[cfg(debug_assertions)]

--- a/syncstorage-postgres/src/db/mod.rs
+++ b/syncstorage-postgres/src/db/mod.rs
@@ -100,7 +100,7 @@ impl PgDb {
     /// Checks collection cache first to see if matching collection stored.
     /// Uses logic to not make change sif there is a conflict during insert.
     async fn get_or_create_collection_id(&mut self, name: &str) -> DbResult<i32> {
-        match self.get_collection_id(name).await {
+        match self._get_collection_id(name).await {
             Err(e) if e.is_collection_not_found() => self._create_collection(name).await,
             result => result,
         }
@@ -124,6 +124,25 @@ impl PgDb {
             ));
         }
         Ok(collection_id)
+    }
+
+    async fn _get_collection_id(&mut self, name: &str) -> DbResult<results::GetCollectionId> {
+        if let Some(id) = self.coll_cache.get_id(name)? {
+            return Ok(id);
+        }
+
+        let id = collections::table
+            .select(collections::collection_id)
+            .filter(collections::name.eq(name))
+            .first::<i32>(&mut self.conn)
+            .await
+            .optional()?
+            .ok_or_else(DbError::collection_not_found)?;
+
+        if !self.session.in_write_transaction {
+            self.coll_cache.put(id, name.to_owned())?;
+        }
+        Ok(id)
     }
 
     /// Given a set of collection_ids, return a HashMap of collection_id's
@@ -212,7 +231,6 @@ impl PgDb {
         &mut self,
         user_id: &UserIdentifier,
         collection: &str,
-        collection_id: i32,
     ) -> DbResult<Option<usize>> {
         if !self.quota.enabled {
             return Ok(None);
@@ -221,7 +239,6 @@ impl PgDb {
             .get_quota_usage(params::GetQuotaUsage {
                 user_id: user_id.clone(),
                 collection: collection.to_owned(),
-                collection_id,
             })
             .await?;
         if usage.total_bytes >= self.quota.size {
@@ -274,7 +291,7 @@ macro_rules! bsos_query {
     ($self:expr, $params:expr, $selection:expr) => {
         {
             let user_id = $params.user_id.legacy_id as i64;
-            let collection_id = $self.get_collection_id(&$params.collection).await?;
+            let collection_id = $self._get_collection_id(&$params.collection).await?;
             let limit = $params.limit.map(i64::from);
 
             let mut query = bsos::table

--- a/syncstorage-spanner/src/db/batch_impl.rs
+++ b/syncstorage-spanner/src/db/batch_impl.rs
@@ -31,7 +31,7 @@ impl BatchDb for SpannerDb {
         params: params::CreateBatch,
     ) -> DbResult<results::CreateBatch> {
         let batch_id = Uuid::new_v4().simple().to_string();
-        let collection_id = self.get_collection_id(&params.collection).await?;
+        let collection_id = self._get_collection_id(&params.collection).await?;
         let timestamp = self.checked_timestamp()?.as_i64();
 
         // Ensure a parent record exists in user_collections before writing to batches
@@ -39,7 +39,7 @@ impl BatchDb for SpannerDb {
         pretouch_collection(self, &params.user_id, collection_id).await?;
         let new_batch = results::CreateBatch {
             size: self
-                .check_quota(&params.user_id, &params.collection, collection_id)
+                .check_quota(&params.user_id, &params.collection)
                 .await?,
             id: batch_id,
         };
@@ -83,10 +83,10 @@ impl BatchDb for SpannerDb {
     async fn append_to_batch(&mut self, params: params::AppendToBatch) -> DbResult<()> {
         let mut metrics = self.metrics.clone();
         metrics.start_timer("storage.spanner.append_items_to_batch", None);
-        let collection_id = self.get_collection_id(&params.collection).await?;
+        let collection_id = self._get_collection_id(&params.collection).await?;
 
         let current_size = self
-            .check_quota(&params.user_id, &params.collection, collection_id)
+            .check_quota(&params.user_id, &params.collection)
             .await?;
         let mut batch = params.batch;
         if let Some(size) = current_size {
@@ -120,7 +120,7 @@ impl BatchDb for SpannerDb {
     }
 
     async fn get_batch(&mut self, params: params::GetBatch) -> DbResult<Option<results::GetBatch>> {
-        let collection_id = self.get_collection_id(&params.collection).await?;
+        let collection_id = self._get_collection_id(&params.collection).await?;
         let (sqlparams, sqlparam_types) = params! {
             "fxa_uid" => params.user_id.fxa_uid.clone(),
             "fxa_kid" => params.user_id.fxa_kid.clone(),
@@ -148,7 +148,7 @@ impl BatchDb for SpannerDb {
     }
 
     async fn delete_batch(&mut self, params: params::DeleteBatch) -> DbResult<()> {
-        let collection_id = self.get_collection_id(&params.collection).await?;
+        let collection_id = self._get_collection_id(&params.collection).await?;
         let (sqlparams, sqlparam_types) = params! {
             "fxa_uid" => params.user_id.fxa_uid.clone(),
             "fxa_kid" => params.user_id.fxa_kid.clone(),
@@ -178,7 +178,7 @@ impl BatchDb for SpannerDb {
     ) -> DbResult<results::CommitBatch> {
         let mut metrics = self.metrics.clone();
         metrics.start_timer("storage.spanner.apply_batch", None);
-        let collection_id = self.get_collection_id(&params.collection).await?;
+        let collection_id = self._get_collection_id(&params.collection).await?;
 
         // Ensure a parent record exists in user_collections before writing to bsos
         // (INTERLEAVE IN PARENT user_collections)

--- a/syncstorage-spanner/src/db/db_impl.rs
+++ b/syncstorage-spanner/src/db/db_impl.rs
@@ -26,40 +26,12 @@ pub(super) const PRETOUCH_TS: &str = "0001-01-01T00:00:00.00Z";
 
 #[async_trait(?Send)]
 impl Db for SpannerDb {
-    async fn get_collection_id(&mut self, name: &str) -> DbResult<i32> {
-        if let Some(id) = self.coll_cache.get_id(name).await {
-            return Ok(id);
-        }
-        let (sqlparams, sqlparam_types) = params! { "name" => name.to_string() };
-        let result = self
-            .sql(
-                "SELECT collection_id
-                   FROM collections
-                  WHERE name = @name",
-            )
-            .await?
-            .params(sqlparams)
-            .param_types(sqlparam_types)
-            .execute(&self.conn)?
-            .one_or_none()
-            .await?
-            .ok_or_else(DbError::collection_not_found)?;
-        let id = result[0]
-            .get_string_value()
-            .parse::<i32>()
-            .map_err(|e| DbError::integrity(e.to_string()))?;
-        if !self.in_write_transaction() {
-            self.coll_cache.put(id, name.to_owned()).await;
-        }
-        Ok(id)
-    }
-
     async fn lock_for_read(&mut self, params: params::LockCollection) -> DbResult<()> {
         // Begin a transaction
         self.begin(false).await?;
 
         let collection_id = self
-            .get_collection_id(&params.collection)
+            ._get_collection_id(&params.collection)
             .await
             .or_else(|e| {
                 if e.is_collection_not_found() {
@@ -230,7 +202,7 @@ impl Db for SpannerDb {
         &mut self,
         params: params::GetCollectionTimestamp,
     ) -> DbResult<SyncTimestamp> {
-        let collection_id = self.get_collection_id(&params.collection).await?;
+        let collection_id = self._get_collection_id(&params.collection).await?;
         if let Some(modified) = self
             .session
             .coll_modified_cache
@@ -446,6 +418,7 @@ impl Db for SpannerDb {
         if !self.quota.enabled {
             return Ok(results::GetQuotaUsage::default());
         }
+        let collection_id = self._get_collection_id(&params.collection).await?;
         let check_sql = "SELECT COALESCE(total_bytes,0), COALESCE(count,0)
             FROM user_collections
            WHERE fxa_uid = @fxa_uid
@@ -454,7 +427,7 @@ impl Db for SpannerDb {
         let (sqlparams, sqlparam_types) = params! {
             "fxa_uid" => params.user_id.fxa_uid.clone(),
             "fxa_kid" => params.user_id.fxa_kid.clone(),
-            "collection_id" => params.collection_id,
+            "collection_id" => collection_id,
         };
         let result = self
             .sql(check_sql)
@@ -509,7 +482,7 @@ impl Db for SpannerDb {
     ) -> DbResult<results::DeleteCollection> {
         // Also deletes child bsos/batch rows (INTERLEAVE IN PARENT
         // user_collections ON DELETE CASCADE)
-        let collection_id = self.get_collection_id(&params.collection).await?;
+        let collection_id = self._get_collection_id(&params.collection).await?;
         let (sqlparams, mut sqlparam_types) = params! {
             "fxa_uid" => params.user_id.fxa_uid.clone(),
             "fxa_kid" => params.user_id.fxa_kid.clone(),
@@ -619,7 +592,7 @@ impl Db for SpannerDb {
     }
 
     async fn delete_bso(&mut self, params: params::DeleteBso) -> DbResult<results::DeleteBso> {
-        let collection_id = self.get_collection_id(&params.collection).await?;
+        let collection_id = self._get_collection_id(&params.collection).await?;
         let user_id = params.user_id.clone();
         let (sqlparams, sqlparam_types) = params! {
             "fxa_uid" => params.user_id.fxa_uid,
@@ -652,7 +625,7 @@ impl Db for SpannerDb {
 
     async fn delete_bsos(&mut self, params: params::DeleteBsos) -> DbResult<results::DeleteBsos> {
         let user_id = params.user_id.clone();
-        let collection_id = self.get_collection_id(&params.collection).await?;
+        let collection_id = self._get_collection_id(&params.collection).await?;
 
         let (sqlparams, sqlparam_types) = params! {
             "fxa_uid" => user_id.fxa_uid,
@@ -761,7 +734,7 @@ impl Db for SpannerDb {
     }
 
     async fn get_bso(&mut self, params: params::GetBso) -> DbResult<Option<results::GetBso>> {
-        let collection_id = self.get_collection_id(&params.collection).await?;
+        let collection_id = self._get_collection_id(&params.collection).await?;
         let (sqlparams, sqlparam_types) = params! {
             "fxa_uid" => params.user_id.fxa_uid,
             "fxa_kid" => params.user_id.fxa_kid,
@@ -791,7 +764,7 @@ impl Db for SpannerDb {
         &mut self,
         params: params::GetBsoTimestamp,
     ) -> DbResult<SyncTimestamp> {
-        let collection_id = self.get_collection_id(&params.collection).await?;
+        let collection_id = self._get_collection_id(&params.collection).await?;
         let (sqlparams, sqlparam_types) = params! {
             "fxa_uid" => params.user_id.fxa_uid,
             "fxa_kid" => params.user_id.fxa_kid,
@@ -867,6 +840,11 @@ impl Db for SpannerDb {
     #[cfg(debug_assertions)]
     async fn create_collection(&mut self, name: &str) -> DbResult<i32> {
         self._create_collection(name).await
+    }
+
+    #[cfg(debug_assertions)]
+    async fn get_collection_id(&mut self, name: &str) -> DbResult<i32> {
+        self._get_collection_id(name).await
     }
 
     #[cfg(debug_assertions)]

--- a/syncstorage-spanner/src/db/mod.rs
+++ b/syncstorage-spanner/src/db/mod.rs
@@ -112,7 +112,7 @@ impl SpannerDb {
     }
 
     async fn get_or_create_collection_id(&mut self, name: &str) -> DbResult<i32> {
-        match self.get_collection_id(name).await {
+        match self._get_collection_id(name).await {
             Err(e) if e.is_collection_not_found() => self._create_collection(name).await,
             result => result,
         }
@@ -155,6 +155,34 @@ impl SpannerDb {
         .param_types(sqlparam_types)
         .execute_dml(&self.conn)
         .await?;
+        Ok(id)
+    }
+
+    async fn _get_collection_id(&mut self, name: &str) -> DbResult<i32> {
+        if let Some(id) = self.coll_cache.get_id(name).await {
+            return Ok(id);
+        }
+        let (sqlparams, sqlparam_types) = params! { "name" => name.to_string() };
+        let result = self
+            .sql(
+                "SELECT collection_id
+                   FROM collections
+                  WHERE name = @name",
+            )
+            .await?
+            .params(sqlparams)
+            .param_types(sqlparam_types)
+            .execute(&self.conn)?
+            .one_or_none()
+            .await?
+            .ok_or_else(DbError::collection_not_found)?;
+        let id = result[0]
+            .get_string_value()
+            .parse::<i32>()
+            .map_err(|e| DbError::integrity(e.to_string()))?;
+        if !self.in_write_transaction() {
+            self.coll_cache.put(id, name.to_owned()).await;
+        }
         Ok(id)
     }
 
@@ -464,7 +492,7 @@ impl SpannerDb {
         let (mut sqlparams, mut sqlparam_types) = params! {
             "fxa_uid" => params.user_id.fxa_uid,
             "fxa_kid" => params.user_id.fxa_kid,
-            "collection_id" => self.get_collection_id(&params.collection).await?,
+            "collection_id" => self._get_collection_id(&params.collection).await?,
         };
 
         if !params.ids.is_empty() {
@@ -642,8 +670,7 @@ impl SpannerDb {
         let collection_id = self.get_or_create_collection_id(&params.collection).await?;
 
         if !params.for_batch {
-            self.check_quota(&user_id, &params.collection, collection_id)
-                .await?;
+            self.check_quota(&user_id, &params.collection).await?;
         }
 
         // Ensure a parent record exists in user_collections before writing to
@@ -760,7 +787,6 @@ impl SpannerDb {
         &mut self,
         user_id: &UserIdentifier,
         collection: &str,
-        collection_id: i32,
     ) -> DbResult<Option<usize>> {
         // duplicate quota trap in test func below.
         if !self.quota.enabled {
@@ -770,7 +796,6 @@ impl SpannerDb {
             .get_quota_usage(params::GetQuotaUsage {
                 user_id: user_id.clone(),
                 collection: collection.to_owned(),
-                collection_id,
             })
             .await?;
         if usage.total_bytes >= self.quota.size {
@@ -792,8 +817,7 @@ impl SpannerDb {
         use syncstorage_db_common::util::to_rfc3339;
         let collection_id = self.get_or_create_collection_id(&bso.collection).await?;
 
-        self.check_quota(&bso.user_id, &bso.collection, collection_id)
-            .await?;
+        self.check_quota(&bso.user_id, &bso.collection).await?;
 
         let (mut sqlparams, mut sqlparam_types) = params! {
             "fxa_uid" => bso.user_id.fxa_uid.clone(),


### PR DESCRIPTION
The db impl crates will look up the collection by name internally.  `get_collection_id` is a test, debug build, only method now.

Closes STOR-440