### PR TITLE
Update syncserver-postgres Docker image version

### DIFF
--- a/docs/src/how-to/how-to-run-with-docker.md
+++ b/docs/src/how-to/how-to-run-with-docker.md
@@ -31,7 +31,7 @@ using the correct MySQL or PostgreSQL build for the database.
 ```yaml
 services:
   syncserver:
-    image: ghcr.io/mozilla-services/syncstorage-rs/syncstorage-rs-mysql:${SYNCSERVER_VERSION:-b16ef5064b}
+    image: ghcr.io/mozilla-services/syncstorage-rs/syncstorage-rs-mysql:${SYNCSERVER_VERSION:-latest}
     platform: linux/amd64
     container_name: syncserver
     ports:
@@ -83,7 +83,7 @@ Save the yaml below into a file, e.g. `docker-compose.one-shot.yaml`.
 ```yaml
 services:
   syncserver:
-    image: ghcr.io/mozilla-services/syncstorage-rs/syncserver-postgres:${SYNCSERVER_VERSION:-0.22.0}
+    image: ghcr.io/mozilla-services/syncstorage-rs/syncserver-postgres:${SYNCSERVER_VERSION:-latest}
     platform: linux/amd64
     container_name: syncserver
     ports:


### PR DESCRIPTION
Updated Docker image tag of the syncserver-postgres container image and removed duplicated removed environment variables in postgres example.

## Description

I have Updated the how-to-page [https://mozilla-services.github.io/syncstorage-rs/how-to/how-to-run-with-docker.html#docker-compose-one-shot-with-postgresql](https://mozilla-services.github.io/syncstorage-rs/how-to/how-to-run-with-docker.html#docker-compose-one-shot-with-postgresql)

## Testing

Have tested the syncserver-postgres imgage `0.22.0` and it works.

## Issue(s)

Closes [#2154](https://github.com/mozilla-services/syncstorage-rs/issues/2154)
