### PR TITLE
chore: add group-by for python deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -77,6 +77,7 @@ updates:
       - dependencies
     groups:
       python-deps:
+        group-by: dependency-name
         patterns:
           - "*"
 


### PR DESCRIPTION


## Description

Trying this out, see STOR-530 for more info

> **NOTE:** We can only accept PRS with all commits [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#ssh-commit-verification). PRs that contain _any_ unsigned commits will not be accepted and the PR _must_ be resubmitted. If this is something you cannot provide, please disclose and a team member _may_ duplicate the PR as signed for you (depending on availablity and priority. Thank you for your understanding and cooperation.)

## Issue(s)

Closes STOR-530
