### PR TITLE
chore: updates for cargo release

### DIFF
--- a/.github/workflows/main-workflow.yml
+++ b/.github/workflows/main-workflow.yml
@@ -212,6 +212,45 @@ jobs:
       - name: Rust Clippy ${{ matrix.target }}
         run: make clippy_${{ matrix.target }}
 
+  # Rust clippy release mode lint checker
+  clippy-release:
+    needs: rust-env
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      matrix:
+        target: [spanner, mysql, postgres]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Restore Rust toolchain
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+        with:
+          path: |
+            ~/.rustup/toolchains
+            ~/.rustup/update-hashes
+          key: ${{ runner.os }}-rust-toolchain-${{ env.RUST_VERSION }}
+
+      - name: Restore Rust cache
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-release-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-release-${{ matrix.target }}-
+
+      - name: Set Rust toolchain
+        run: rustup default ${{ env.RUST_VERSION }}
+
+      - name: Rust Clippy release ${{ matrix.target }}
+        run: make clippy_release_${{ matrix.target }}
+
   # Postgres unit tests ======
   build-and-unit-test-postgres:
     needs: [rust-env, python-env]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3567,9 +3567,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,18 @@ clippy_spanner:
 	# Matches what's run in circleci
 	cargo clippy --workspace --all-targets --no-default-features --features=syncstorage-db/spanner --features=py_verifier -- -D clippy::dbg_macro -D warnings
 
+clippy_release_mysql:
+	# Release mode clippy — catches dead code and issues only visible with optimizations
+	cargo clippy --release --workspace --no-default-features --features=syncstorage-db/mysql --features=py_verifier -- -D warnings
+
+clippy_release_postgres:
+	# Release mode clippy — catches dead code and issues only visible with optimizations
+	cargo clippy --release --workspace --no-default-features --features=syncstorage-db/postgres --features=tokenserver-db/postgres --features=py_verifier -- -D warnings
+
+clippy_release_spanner:
+	# Release mode clippy — catches dead code and issues only visible with optimizations
+	cargo clippy --release --workspace --no-default-features --features=syncstorage-db/spanner --features=py_verifier -- -D warnings
+
 clean:
 	cargo clean
 

--- a/syncstorage-mysql/src/pool.rs
+++ b/syncstorage-mysql/src/pool.rs
@@ -216,6 +216,7 @@ impl CollectionCache {
             .cloned())
     }
 
+    #[allow(dead_code)]
     pub fn clear(&self) {
         self.by_name.write().expect("by_name write").clear();
         self.by_id.write().expect("by_id write").clear();

--- a/syncstorage-mysql/src/test.rs
+++ b/syncstorage-mysql/src/test.rs
@@ -8,7 +8,7 @@ use diesel::{
 use diesel_async::RunQueryDsl;
 use syncserver_common::{BlockingThreadpool, Metrics};
 use syncserver_settings::Settings as SyncserverSettings;
-use syncstorage_db_common::DbPool;
+use syncstorage_db_common::{Db, DbPool};
 use syncstorage_settings::Settings as SyncstorageSettings;
 use url::Url;
 

--- a/syncstorage-mysql/src/test.rs
+++ b/syncstorage-mysql/src/test.rs
@@ -8,7 +8,7 @@ use diesel::{
 use diesel_async::RunQueryDsl;
 use syncserver_common::{BlockingThreadpool, Metrics};
 use syncserver_settings::Settings as SyncserverSettings;
-use syncstorage_db_common::{Db, DbPool};
+use syncstorage_db_common::DbPool;
 use syncstorage_settings::Settings as SyncstorageSettings;
 use url::Url;
 

--- a/syncstorage-postgres/src/pool.rs
+++ b/syncstorage-postgres/src/pool.rs
@@ -212,6 +212,7 @@ impl CollectionCache {
             .cloned())
     }
 
+    #[allow(dead_code)]
     pub fn clear(&self) {
         self.by_name.write().expect("by_name write").clear();
         self.by_id.write().expect("by_id write").clear();

--- a/syncstorage-spanner/src/pool.rs
+++ b/syncstorage-spanner/src/pool.rs
@@ -190,6 +190,7 @@ impl CollectionCache {
         (names, missing)
     }
 
+    #[allow(dead_code)]
     pub async fn clear(&self) {
         self.by_name.write().await.clear();
         self.by_id.write().await.clear();

--- a/tokenserver-mysql/src/db/db_impl.rs
+++ b/tokenserver-mysql/src/db/db_impl.rs
@@ -97,7 +97,7 @@ impl Db for TokenserverDb {
                AND replaced_at IS NULL
         "#;
 
-        let now = chrono::Utc::now().timestamp_millis();
+        let now = Utc::now().timestamp_millis();
 
         diesel::sql_query(QUERY)
             .bind::<Bigint, _>(tokenserver_db_common::MAX_GENERATION)

--- a/tokenserver-mysql/src/db/mod.rs
+++ b/tokenserver-mysql/src/db/mod.rs
@@ -20,6 +20,7 @@ impl TokenserverDb {
     // most recently-inserted record *for a given connection*. If connections were shared across
     // requests, using this function would introduce a race condition, as we could potentially
     // get IDs from records created during other requests.
+    #[allow(dead_code)]
     const LAST_INSERT_ID_QUERY: &'static str = "SELECT LAST_INSERT_ID() AS id";
     const LAST_INSERT_UID_QUERY: &'static str = "SELECT LAST_INSERT_ID() AS uid";
 

--- a/tokenserver-postgres/src/db/db_impl.rs
+++ b/tokenserver-postgres/src/db/db_impl.rs
@@ -486,7 +486,7 @@ impl Db for TokenserverPgDb {
                AND replaced_at IS NULL
         "#;
 
-        let now = chrono::Utc::now().timestamp_millis();
+        let now = Utc::now().timestamp_millis();
 
         diesel::sql_query(QUERY)
             .bind::<BigInt, _>(tokenserver_db_common::MAX_GENERATION)


### PR DESCRIPTION
## Description
Building in release mode emits a few warnings on unused imports, etc. that we’ve missed as they don’t appear when compiling locally in debug mode, or even w/ clippy. Adds updates to silence this errors and added makefile targets to run release mode for such checks.

## Issue(s)

Closes [STOR-525](https://mozilla-hub.atlassian.net/browse/STOR-525).


[STOR-525]: https://mozilla-hub.atlassian.net/browse/STOR-525?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ