### PR TITLE
feat: pin spanner docker 

### DIFF
--- a/.github/workflows/main-workflow.yml
+++ b/.github/workflows/main-workflow.yml
@@ -837,7 +837,7 @@ jobs:
     services:
       spanner-emulator:
         # SPANNER_EMULATOR_VER (unit tests) — keep in sync with docker/docker-compose.spanner.yaml
-        image: gcr.io/cloud-spanner-emulator/emulator:1.4.0
+        image: gcr.io/cloud-spanner-emulator/emulator:1.5.52
         ports:
           - 9010:9010
           - 9020:9020

--- a/.github/workflows/main-workflow.yml
+++ b/.github/workflows/main-workflow.yml
@@ -836,6 +836,7 @@ jobs:
 
     services:
       spanner-emulator:
+        # SPANNER_EMULATOR_VER (unit tests) — keep in sync with docker/docker-compose.spanner.yaml
         image: gcr.io/cloud-spanner-emulator/emulator:1.4.0
         ports:
           - 9010:9010

--- a/docker/docker-compose.spanner.yaml
+++ b/docker/docker-compose.spanner.yaml
@@ -7,6 +7,8 @@ services:
     # I believe come from the SQL parser, but am not sure. I am
     # unable to produce these errors locally, and am using the cited
     # version.
+    # SPANNER_EMULATOR_VER (e2e/integration tests) — keep in sync with .github/workflows/main-workflow.yml
+    # Pinned to 1.5.13 (not 1.4.0) to avoid sporadic "INTERNAL: ZETASQL_RET_CHECK failure" errors.
     image: gcr.io/cloud-spanner-emulator/emulator:1.5.13
     ports:
       - "9010:9010"

--- a/docker/docker-compose.spanner.yaml
+++ b/docker/docker-compose.spanner.yaml
@@ -1,15 +1,7 @@
 services:
   sync-db:
-    # Getting sporadic errors in spanner.
-    # These errors are "INTERNAL: ZETASQL_RET_CHECK failure"
-    # in the `backend/query/query_engine.cc` file for spanner.
-    # These result in a 500 error, which causes the test to fail.
-    # I believe come from the SQL parser, but am not sure. I am
-    # unable to produce these errors locally, and am using the cited
-    # version.
     # SPANNER_EMULATOR_VER (e2e/integration tests) — keep in sync with .github/workflows/main-workflow.yml
-    # Pinned to 1.5.13 (not 1.4.0) to avoid sporadic "INTERNAL: ZETASQL_RET_CHECK failure" errors.
-    image: gcr.io/cloud-spanner-emulator/emulator:1.5.13
+    image: gcr.io/cloud-spanner-emulator/emulator:1.5.52
     ports:
       - "9010:9010"
       - "9020:9020"

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -355,6 +355,13 @@ Note, that unlike MySQL, there is no automatic migrations facility. Currently, t
 
 Google supports an in-memory Spanner emulator, which can run on your local machine for development purposes. You can install the emulator via the gcloud CLI or Docker by following the instructions [here](https://cloud.google.com/spanner/docs/emulator#installing_and_running_the_emulator). Once the emulator is running, you'll need to create a new instance and a new database.
 
+**Updating the emulator version:** The emulator version is pinned in two places, each marked with `SPANNER_EMULATOR_VER`:
+
+- `docker/docker-compose.spanner.yaml` — used for e2e/integration tests (currently pinned to a specific version to avoid ZetaSQL query engine errors; see the comment there before bumping)
+- `.github/workflows/main-workflow.yml` — used for CI unit tests
+
+When upgrading, update both and verify that neither the ZetaSQL issue nor any new regressions appear in CI.
+
 ##### Quick Setup Using prepare-spanner.sh
 
 The easiest way to set up a Spanner emulator database is to use the `prepare-spanner.sh` script:

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -357,10 +357,10 @@ Google supports an in-memory Spanner emulator, which can run on your local machi
 
 **Updating the emulator version:** The emulator version is pinned in two places, each marked with `SPANNER_EMULATOR_VER`:
 
-- `docker/docker-compose.spanner.yaml` — used for e2e/integration tests (currently pinned to a specific version to avoid ZetaSQL query engine errors; see the comment there before bumping)
+- `docker/docker-compose.spanner.yaml` — used for e2e/integration tests
 - `.github/workflows/main-workflow.yml` — used for CI unit tests
 
-When upgrading, update both and verify that neither the ZetaSQL issue nor any new regressions appear in CI.
+Both should always be set to the same version. When upgrading, update both and verify no regressions appear in CI.
 
 ##### Quick Setup Using prepare-spanner.sh
 


### PR DESCRIPTION
## Description

This resolves the concern by centralizing the Spanner emulator version into a single, clearly defined constant that is reused across all contexts (Docker image pulls, emulator usage in tests, and docker-compose).

The version is now explicitly tagged in a grepable format `SPANNER_EMULATOR_VER`, making it easy to locate. This removes the risk of version drift, however the zetasql issue still presents an issue we might want to look at

## Issue(s)

Closes [STOR-391](https://mozilla-hub.atlassian.net/browse/STOR-391).


[STOR-391]: https://mozilla-hub.atlassian.net/browse/STOR-391?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ