### PR TITLE
docs: update outdated release tagging notes

### DIFF
--- a/docs/src/how-to/how-to-run-with-docker.md
+++ b/docs/src/how-to/how-to-run-with-docker.md
@@ -12,9 +12,11 @@ and
 as the database.  Differences in configuration or deployment steps will be
 noted. 
 
-> **Note:** At the time of writing, there are no tagged release builds
-> available on ghcr.io.  This guide will use a build from the main development
-> branch.
+Tagged release builds are available on ghcr.io. To pin to a specific version,
+set `SYNCSERVER_VERSION` to the desired release tag (e.g., `SYNCSERVER_VERSION=v1.45.0`)
+before running `docker compose`. Available releases can be found on the
+[syncstorage-rs releases page](https://github.com/mozilla-services/syncstorage-rs/releases).
+If `SYNCSERVER_VERSION` is not set, the compose files below default to `latest`.
 
 ## Prerequisites and Presumptions
 - The reader is familiar with the command line interface and `docker`.


### PR DESCRIPTION
## Description

Remove the outdated note stating "there are no tagged release builds available on ghcr.io" and replace it with accurate information.

The setup-build-and-push composite action `.github/actions/setup-build-and-push/action.yml` now publishes versioned image tags plus latest to both ghcr.io and GAR whenever a git tag is pushed. The note was true at time of writing but is no longer accurate.

Documents that users can pin to a specific release via SYNCSERVER_VERSION=<tag>
Links to the [releases page](https://github.com/mozilla-services/syncstorage-rs/releases) for tags

## Issue(s)

Closes [STOR-538](https://mozilla-hub.atlassian.net/browse/STOR-538).


[STOR-538]: https://mozilla-hub.atlassian.net/browse/STOR-538?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ