### PR TITLE
fix: api db error metric 

### DIFF
--- a/syncstorage-spanner/src/error.rs
+++ b/syncstorage-spanner/src/error.rs
@@ -184,6 +184,8 @@ impl ReportableError for DbError {
 /// emitted as metrics rather than reported to Sentry. The RST_STREAM variants
 /// are safe to suppress because the server resets the stream before any
 /// application state is changed, making them candidates for client retry.
+/// Due to gPRC libs being a bit inconsistent with formatting, the array covers
+/// possible variants.
 fn is_ignored_internal(status: &grpcio::RpcStatus) -> bool {
     let msg = status.message().to_lowercase();
     [

--- a/syncstorage-spanner/src/error.rs
+++ b/syncstorage-spanner/src/error.rs
@@ -178,14 +178,21 @@ impl ReportableError for DbError {
     }
 }
 
-/// Whether to ignore a 13 - INTERNAL error based on its status
+/// Whether to ignore a 13 - INTERNAL error based on its status message.
+///
+/// These errors are transient gRPC/HTTP2 transport errors that should be
+/// emitted as metrics rather than reported to Sentry. The RST_STREAM variants
+/// are safe to suppress because the server resets the stream before any
+/// application state is changed, making them candidates for client retry.
 fn is_ignored_internal(status: &grpcio::RpcStatus) -> bool {
+    let msg = status.message().to_lowercase();
     [
         "rst_stream",
         "rst stream",
         "received unexpected eos on data frame from server",
     ]
-    .contains(&status.message().to_lowercase().as_str())
+    .iter()
+    .any(|s| msg.contains(s))
 }
 
 impl InternalError for DbError {


### PR DESCRIPTION
## Description

Resolves given API Error from gRPC: ApiError: A database error occurred: RpcFailure: 13-INTERNAL Received RST_STREAM with error code 2
```
ApiError: A database error occurred: RpcFailure: 13-INTERNAL Received RST_STREAM with error code 2
  File "error.rs", line 95, in syncstorage_spanner::error::DbError::from
  File "lib.rs", line 50, in syncstorage_spanner::error::DbError::from
  File "stream.rs", line 95, in syncstorage_spanner::stream::StreamedResultSetAsync<T>::consume_next::{{closure}}
  File "stream.rs", line 153, in syncstorage_spanner::stream::StreamedResultSetAsync<T>::try_next::{{closure}}
  File "stream.rs", line 74, in syncstorage_spanner::stream::StreamedResultSetAsync<T>::one_or_none::{{closure}}
...
```

The previous implementation used exact string equality (.contains(&msg_as_str)) against the array of known transient gRPC patterns. The actual Spanner error message is "Received RST_STREAM with error code 2", which lower case  didn't exactly match "rst_stream" — so the check silently fell through and these errors were being captured by Sentry rather than emitted as metrics.

Switching to .any(|s| msg.contains(s)) makes this a substring check, which correctly identifies RST_STREAM and EOS errors regardless of surrounding message text. These are transient HTTP/2 transport-level resets that occur before any application state changes, so Sentry noise is not useful here — the statsd counter storage.spanner.grpc.internal is the right metric that should pick this up now.

## Issue(s)

Closes [STOR-377](https://mozilla-hub.atlassian.net/browse/STOR-377).


[STOR-377]: https://mozilla-hub.atlassian.net/browse/STOR-377?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ