### PR TITLE
fix: apply zizmor autofixes to github actions

### DIFF
--- a/.github/actions/setup-build-and-push/action.yml
+++ b/.github/actions/setup-build-and-push/action.yml
@@ -31,7 +31,9 @@ runs:
           "$GITHUB_SHA" "$GITHUB_REF_NAME" \
           "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY" \
           "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
-          > ${{ inputs.version_json_path }}
+          > ${JSON_PATH}
+      env:
+        JSON_PATH: ${{ inputs.version_json_path }}
 
     - name: Compute image tag
       id: tag

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -58,6 +58,8 @@ updates:
       - dependency-name: slog-scope
         versions:
           - 4.4.0
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "pip" # Applies for poetry deps as well
     directories:
@@ -80,6 +82,8 @@ updates:
         group-by: dependency-name
         patterns:
           - "*"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -93,3 +97,5 @@ updates:
       actions-deps:
         patterns:
           - "*"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/main-workflow.yml
+++ b/.github/workflows/main-workflow.yml
@@ -52,6 +52,7 @@ jobs:
             ~/.cache/pip
             ~/.cache/pypoetry/virtualenvs
           key: ${{ runner.os }}-python-${{ hashFiles('pyproject.toml', 'poetry.lock') }}
+          lookup-only: true
 
       - name: Install Poetry
         run: pip3 install poetry
@@ -77,10 +78,11 @@ jobs:
             ~/.rustup/toolchains
             ~/.rustup/update-hashes
           key: ${{ runner.os }}-rust-toolchain-${{ env.RUST_VERSION }}
+          lookup-only: true
 
       - name: Install Rust toolchain
         if: steps.cache-rust-toolchain.outputs.cache-hit != 'true'
-        run: rustup toolchain install ${{ env.RUST_VERSION }} --component rustfmt --component clippy --component llvm-tools-preview --no-self-update && rustup default ${{ env.RUST_VERSION }}
+        run: rustup toolchain install ${RUST_VERSION} --component rustfmt --component clippy --component llvm-tools-preview --no-self-update && rustup default ${RUST_VERSION}
 
       - name: Display Rust Version Info
         shell: bash
@@ -112,6 +114,7 @@ jobs:
             ~/.cache/pip
             ~/.cache/pypoetry/virtualenvs
           key: ${{ runner.os }}-python-${{ hashFiles('pyproject.toml', 'poetry.lock') }}
+          lookup-only: true
 
       - name: Install Poetry
         run: pip3 install poetry
@@ -148,9 +151,10 @@ jobs:
             ~/.rustup/toolchains
             ~/.rustup/update-hashes
           key: ${{ runner.os }}-rust-toolchain-${{ env.RUST_VERSION }}
+          lookup-only: true
 
       - name: Set Rust toolchain
-        run: rustup default ${{ env.RUST_VERSION }}
+        run: rustup default ${RUST_VERSION}
 
       - name: Cache cargo-audit
         id: cache-cargo-audit
@@ -158,6 +162,7 @@ jobs:
         with:
           path: ~/.cargo/bin/cargo-audit
           key: ${{ runner.os }}-cargo-audit-${{ hashFiles('.github/workflows/main-workflow.yml') }}
+          lookup-only: true
 
       - name: Install cargo-audit
         if: steps.cache-cargo-audit.outputs.cache-hit != 'true'
@@ -171,6 +176,7 @@ jobs:
             ~/.cargo/bin/mdbook
             ~/.cargo/bin/mdbook-mermaid
           key: ${{ runner.os }}-mdbook-${{ hashFiles('Makefile') }}
+          lookup-only: true
 
       - name: Setup documentation checks
         if: steps.cache-mdbook.outputs.cache-hit != 'true'
@@ -205,9 +211,10 @@ jobs:
             ~/.rustup/toolchains
             ~/.rustup/update-hashes
           key: ${{ runner.os }}-rust-toolchain-${{ env.RUST_VERSION }}
+          lookup-only: true
 
       - name: Set Rust toolchain
-        run: rustup default ${{ env.RUST_VERSION }}
+        run: rustup default ${RUST_VERSION}
 
       - name: Rust Clippy ${{ matrix.target }}
         run: make clippy_${{ matrix.target }}
@@ -233,6 +240,7 @@ jobs:
             ~/.rustup/toolchains
             ~/.rustup/update-hashes
           key: ${{ runner.os }}-rust-toolchain-${{ env.RUST_VERSION }}
+          lookup-only: true
 
       - name: Restore Rust cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
@@ -244,9 +252,10 @@ jobs:
           key: ${{ runner.os }}-cargo-release-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-release-${{ matrix.target }}-
+          lookup-only: true
 
       - name: Set Rust toolchain
-        run: rustup default ${{ env.RUST_VERSION }}
+        run: rustup default ${RUST_VERSION}
 
       - name: Rust Clippy release ${{ matrix.target }}
         run: make clippy_release_${{ matrix.target }}
@@ -294,9 +303,10 @@ jobs:
             ~/.rustup/toolchains
             ~/.rustup/update-hashes
           key: ${{ runner.os }}-rust-toolchain-${{ env.RUST_VERSION }}
+          lookup-only: true
 
       - name: Set Rust toolchain
-        run: rustup default ${{ env.RUST_VERSION }}
+        run: rustup default ${RUST_VERSION}
 
       - name: Restore pip and Poetry virtualenv
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
@@ -305,6 +315,7 @@ jobs:
             ~/.cache/pip
             ~/.cache/pypoetry/virtualenvs
           key: ${{ runner.os }}-python-${{ hashFiles('pyproject.toml', 'poetry.lock') }}
+          lookup-only: true
 
       - name: Cache Cargo build artifacts
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
@@ -317,6 +328,7 @@ jobs:
           key: ${{ runner.os }}-cargo-postgres-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-postgres-
+          lookup-only: true
 
       - name: Create test results directory
         run: mkdir -p workflow/test-results
@@ -346,6 +358,7 @@ jobs:
         with:
           path: ~/.cargo/bin/cargo-nextest
           key: ${{ runner.os }}-cargo-nextest-${{ hashFiles('**/Cargo.lock') }}
+          lookup-only: true
 
       - name: Install cargo-nextest
         if: steps.cache-cargo-nextest-postgres.outputs.cache-hit != 'true'
@@ -357,6 +370,7 @@ jobs:
         with:
           path: ~/.cargo/bin/cargo-llvm-cov
           key: ${{ runner.os }}-cargo-llvm-cov-${{ hashFiles('**/Cargo.lock') }}
+          lookup-only: true
 
       - name: Install cargo-llvm-cov
         if: steps.cache-cargo-llvm-cov-postgres.outputs.cache-hit != 'true'
@@ -455,6 +469,7 @@ jobs:
         with:
           path: /tmp/postgres-image.tar
           key: ${{ runner.os }}-postgres-image-${{ hashFiles('Dockerfile', 'Cargo.lock', '**/*.rs', '**/Cargo.toml', 'tools/**', 'scripts/**') }}
+          lookup-only: true
 
       - name: Set up Docker Buildx
         if: steps.cache-postgres-image.outputs.cache-hit != 'true'
@@ -587,9 +602,10 @@ jobs:
             ~/.rustup/toolchains
             ~/.rustup/update-hashes
           key: ${{ runner.os }}-rust-toolchain-${{ env.RUST_VERSION }}
+          lookup-only: true
 
       - name: Set Rust toolchain
-        run: rustup default ${{ env.RUST_VERSION }}
+        run: rustup default ${RUST_VERSION}
 
       - name: Restore pip and Poetry virtualenv
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
@@ -598,6 +614,7 @@ jobs:
             ~/.cache/pip
             ~/.cache/pypoetry/virtualenvs
           key: ${{ runner.os }}-python-${{ hashFiles('pyproject.toml', 'poetry.lock') }}
+          lookup-only: true
 
       - name: Cache Cargo build artifacts
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
@@ -610,6 +627,7 @@ jobs:
           key: ${{ runner.os }}-cargo-mysql-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-mysql-
+          lookup-only: true
 
       - name: Create test results directory
         run: mkdir -p workflow/test-results
@@ -640,6 +658,7 @@ jobs:
         with:
           path: ~/.cargo/bin/cargo-nextest
           key: ${{ runner.os }}-cargo-nextest-${{ hashFiles('**/Cargo.lock') }}
+          lookup-only: true
 
       - name: Install cargo-nextest
         if: steps.cache-cargo-nextest-mysql.outputs.cache-hit != 'true'
@@ -651,6 +670,7 @@ jobs:
         with:
           path: ~/.cargo/bin/cargo-llvm-cov
           key: ${{ runner.os }}-cargo-llvm-cov-${{ hashFiles('**/Cargo.lock') }}
+          lookup-only: true
 
       - name: Install cargo-llvm-cov
         if: steps.cache-cargo-llvm-cov-mysql.outputs.cache-hit != 'true'
@@ -738,6 +758,7 @@ jobs:
         with:
           path: /tmp/mysql-image.tar
           key: ${{ runner.os }}-mysql-image-${{ hashFiles('Dockerfile', 'Cargo.lock', '**/*.rs', '**/Cargo.toml', 'tools/**', 'scripts/**') }}
+          lookup-only: true
 
       - name: Set up Docker Buildx
         if: steps.cache-mysql-image.outputs.cache-hit != 'true'
@@ -876,9 +897,10 @@ jobs:
             ~/.rustup/toolchains
             ~/.rustup/update-hashes
           key: ${{ runner.os }}-rust-toolchain-${{ env.RUST_VERSION }}
+          lookup-only: true
 
       - name: Set Rust toolchain
-        run: rustup default ${{ env.RUST_VERSION }}
+        run: rustup default ${RUST_VERSION}
 
       - name: Restore pip and Poetry virtualenv
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
@@ -887,6 +909,7 @@ jobs:
             ~/.cache/pip
             ~/.cache/pypoetry/virtualenvs
           key: ${{ runner.os }}-python-${{ hashFiles('pyproject.toml', 'poetry.lock') }}
+          lookup-only: true
 
       - name: Cache Cargo build artifacts
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
@@ -899,6 +922,7 @@ jobs:
           key: ${{ runner.os }}-cargo-spanner-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-spanner-
+          lookup-only: true
 
       - name: Create test results directory
         run: mkdir -p workflow/test-results
@@ -921,6 +945,7 @@ jobs:
         with:
           path: ~/.cargo/bin/cargo-nextest
           key: ${{ runner.os }}-cargo-nextest-${{ hashFiles('**/Cargo.lock') }}
+          lookup-only: true
 
       - name: Install cargo-nextest
         if: steps.cache-cargo-nextest-spanner.outputs.cache-hit != 'true'
@@ -932,6 +957,7 @@ jobs:
         with:
           path: ~/.cargo/bin/cargo-llvm-cov
           key: ${{ runner.os }}-cargo-llvm-cov-${{ hashFiles('**/Cargo.lock') }}
+          lookup-only: true
 
       - name: Install cargo-llvm-cov
         if: steps.cache-cargo-llvm-cov-spanner.outputs.cache-hit != 'true'
@@ -1056,6 +1082,7 @@ jobs:
         with:
           path: /tmp/spanner-image.tar
           key: ${{ runner.os }}-spanner-image-${{ hashFiles('Dockerfile', 'Cargo.lock', '**/*.rs', '**/Cargo.toml', 'tools/**', 'scripts/**') }}
+          lookup-only: true
 
       - name: Set up Docker Buildx
         if: steps.cache-spanner-image.outputs.cache-hit != 'true'

--- a/.github/workflows/mozcloud-publish.yaml
+++ b/.github/workflows/mozcloud-publish.yaml
@@ -56,11 +56,11 @@ jobs:
       - name: Compute tags
         run: |
           TAGS=$(cat <<EOF
-          us-docker.pkg.dev/moz-fx-sync-prod/sync-prod/syncstorage-rs:${{ steps.setup.outputs.image_tag }}
-          ghcr.io/${{ github.repository }}/syncstorage-rs:${{ steps.setup.outputs.image_tag }}
+          us-docker.pkg.dev/moz-fx-sync-prod/sync-prod/syncstorage-rs:${IMAGE_TAG}
+          ghcr.io/${{ github.repository }}/syncstorage-rs:${IMAGE_TAG}
           EOF
           )
-          if [[ "${{ steps.setup.outputs.push_latest }}" == "true" ]]; then
+          if [[ "${PUSH_LATEST}" == "true" ]]; then
             TAGS="$TAGS
           us-docker.pkg.dev/moz-fx-sync-prod/sync-prod/syncstorage-rs:latest
           ghcr.io/${{ github.repository }}/syncstorage-rs:latest"
@@ -68,6 +68,9 @@ jobs:
           echo "IMAGE_TAGS<<EOF" >> "$GITHUB_ENV"
           echo "$TAGS" >> "$GITHUB_ENV"
           echo "EOF" >> "$GITHUB_ENV"
+        env:
+          IMAGE_TAG: ${{ steps.setup.outputs.image_tag }}
+          PUSH_LATEST: ${{ steps.setup.outputs.push_latest }}
 
       - uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
         with:
@@ -101,11 +104,11 @@ jobs:
       - name: Compute tags
         run: |
           TAGS=$(cat <<EOF
-          us-docker.pkg.dev/moz-fx-sync-prod/sync-prod/syncserver-postgres:${{ steps.setup.outputs.image_tag }}
-          ghcr.io/${{ github.repository }}/syncserver-postgres:${{ steps.setup.outputs.image_tag }}
+          us-docker.pkg.dev/moz-fx-sync-prod/sync-prod/syncserver-postgres:${IMAGE_TAG}
+          ghcr.io/${{ github.repository }}/syncserver-postgres:${IMAGE_TAG}
           EOF
           )
-          if [[ "${{ steps.setup.outputs.push_latest }}" == "true" ]]; then
+          if [[ "${PUSH_LATEST}" == "true" ]]; then
             TAGS="$TAGS
           us-docker.pkg.dev/moz-fx-sync-prod/sync-prod/syncserver-postgres:latest
           ghcr.io/${{ github.repository }}/syncserver-postgres:latest"
@@ -113,6 +116,9 @@ jobs:
           echo "IMAGE_TAGS<<EOF" >> "$GITHUB_ENV"
           echo "$TAGS" >> "$GITHUB_ENV"
           echo "EOF" >> "$GITHUB_ENV"
+        env:
+          IMAGE_TAG: ${{ steps.setup.outputs.image_tag }}
+          PUSH_LATEST: ${{ steps.setup.outputs.push_latest }}
 
       - name: Build and push to prod GAR and ghcr
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
@@ -143,14 +149,17 @@ jobs:
 
       - name: Compute enterprise tags
         run: |
-          TAGS="us-docker.pkg.dev/moz-fx-fx-enterprise-prod/fx-enterprise-private/syncserver-postgres:${{ steps.setup.outputs.image_tag }}"
-          if [[ "${{ steps.setup.outputs.push_latest }}" == "true" ]]; then
+          TAGS="us-docker.pkg.dev/moz-fx-fx-enterprise-prod/fx-enterprise-private/syncserver-postgres:${IMAGE_TAG}"
+          if [[ "${PUSH_LATEST}" == "true" ]]; then
             TAGS="$TAGS
           us-docker.pkg.dev/moz-fx-fx-enterprise-prod/fx-enterprise-private/syncserver-postgres:latest"
           fi
           echo "IMAGE_TAGS<<EOF" >> "$GITHUB_ENV"
           echo "$TAGS" >> "$GITHUB_ENV"
           echo "EOF" >> "$GITHUB_ENV"
+        env:
+          IMAGE_TAG: ${{ steps.setup.outputs.image_tag }}
+          PUSH_LATEST: ${{ steps.setup.outputs.push_latest }}
 
       - name: Build and push to enterprise GAR
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
@@ -188,11 +197,11 @@ jobs:
       - name: Compute tags
         run: |
           TAGS=$(cat <<EOF
-          us-docker.pkg.dev/moz-fx-sync-prod/sync-prod/syncstorage-rs-spanner-python-utils:${{ steps.setup.outputs.image_tag }}
-          ghcr.io/${{ github.repository }}/syncstorage-rs-spanner-python-utils:${{ steps.setup.outputs.image_tag }}
+          us-docker.pkg.dev/moz-fx-sync-prod/sync-prod/syncstorage-rs-spanner-python-utils:${IMAGE_TAG}
+          ghcr.io/${{ github.repository }}/syncstorage-rs-spanner-python-utils:${IMAGE_TAG}
           EOF
           )
-          if [[ "${{ steps.setup.outputs.push_latest }}" == "true" ]]; then
+          if [[ "${PUSH_LATEST}" == "true" ]]; then
             TAGS="$TAGS
           us-docker.pkg.dev/moz-fx-sync-prod/sync-prod/syncstorage-rs-spanner-python-utils:latest
           ghcr.io/${{ github.repository }}/syncstorage-rs-spanner-python-utils:latest"
@@ -200,6 +209,9 @@ jobs:
           echo "IMAGE_TAGS<<EOF" >> "$GITHUB_ENV"
           echo "$TAGS" >> "$GITHUB_ENV"
           echo "EOF" >> "$GITHUB_ENV"
+        env:
+          IMAGE_TAG: ${{ steps.setup.outputs.image_tag }}
+          PUSH_LATEST: ${{ steps.setup.outputs.push_latest }}
 
       - uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
         with:
@@ -232,11 +244,11 @@ jobs:
       - name: Compute tags
         run: |
           TAGS=$(cat <<EOF
-          us-docker.pkg.dev/moz-fx-sync-prod/sync-prod/syncserver-postgres-python-utils:${{ steps.setup.outputs.image_tag }}
-          ghcr.io/${{ github.repository }}/syncserver-postgres-python-utils:${{ steps.setup.outputs.image_tag }}
+          us-docker.pkg.dev/moz-fx-sync-prod/sync-prod/syncserver-postgres-python-utils:${IMAGE_TAG}
+          ghcr.io/${{ github.repository }}/syncserver-postgres-python-utils:${IMAGE_TAG}
           EOF
           )
-          if [[ "${{ steps.setup.outputs.push_latest }}" == "true" ]]; then
+          if [[ "${PUSH_LATEST}" == "true" ]]; then
             TAGS="$TAGS
           us-docker.pkg.dev/moz-fx-sync-prod/sync-prod/syncserver-postgres-python-utils:latest
           ghcr.io/${{ github.repository }}/syncserver-postgres-python-utils:latest"
@@ -244,6 +256,9 @@ jobs:
           echo "IMAGE_TAGS<<EOF" >> "$GITHUB_ENV"
           echo "$TAGS" >> "$GITHUB_ENV"
           echo "EOF" >> "$GITHUB_ENV"
+        env:
+          IMAGE_TAG: ${{ steps.setup.outputs.image_tag }}
+          PUSH_LATEST: ${{ steps.setup.outputs.push_latest }}
 
       - name: Build and push to prod GAR and ghcr
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
@@ -272,14 +287,17 @@ jobs:
 
       - name: Compute enterprise tags
         run: |
-          TAGS="us-docker.pkg.dev/moz-fx-fx-enterprise-prod/fx-enterprise-private/syncserver-postgres-python-utils:${{ steps.setup.outputs.image_tag }}"
-          if [[ "${{ steps.setup.outputs.push_latest }}" == "true" ]]; then
+          TAGS="us-docker.pkg.dev/moz-fx-fx-enterprise-prod/fx-enterprise-private/syncserver-postgres-python-utils:${IMAGE_TAG}"
+          if [[ "${PUSH_LATEST}" == "true" ]]; then
             TAGS="$TAGS
           us-docker.pkg.dev/moz-fx-fx-enterprise-prod/fx-enterprise-private/syncserver-postgres-python-utils:latest"
           fi
           echo "IMAGE_TAGS<<EOF" >> "$GITHUB_ENV"
           echo "$TAGS" >> "$GITHUB_ENV"
           echo "EOF" >> "$GITHUB_ENV"
+        env:
+          IMAGE_TAG: ${{ steps.setup.outputs.image_tag }}
+          PUSH_LATEST: ${{ steps.setup.outputs.push_latest }}
 
       - name: Build and push to enterprise GAR
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
@@ -311,11 +329,11 @@ jobs:
       - name: Compute tags
         run: |
           TAGS=$(cat <<EOF
-          us-docker.pkg.dev/moz-fx-sync-prod/sync-prod/syncserver-mysql:${{ steps.setup.outputs.image_tag }}
-          ghcr.io/${{ github.repository }}/syncserver-mysql:${{ steps.setup.outputs.image_tag }}
+          us-docker.pkg.dev/moz-fx-sync-prod/sync-prod/syncserver-mysql:${IMAGE_TAG}
+          ghcr.io/${{ github.repository }}/syncserver-mysql:${IMAGE_TAG}
           EOF
           )
-          if [[ "${{ steps.setup.outputs.push_latest }}" == "true" ]]; then
+          if [[ "${PUSH_LATEST}" == "true" ]]; then
             TAGS="$TAGS
           us-docker.pkg.dev/moz-fx-sync-prod/sync-prod/syncserver-mysql:latest
           ghcr.io/${{ github.repository }}/syncserver-mysql:latest"
@@ -323,6 +341,9 @@ jobs:
           echo "IMAGE_TAGS<<EOF" >> "$GITHUB_ENV"
           echo "$TAGS" >> "$GITHUB_ENV"
           echo "EOF" >> "$GITHUB_ENV"
+        env:
+          IMAGE_TAG: ${{ steps.setup.outputs.image_tag }}
+          PUSH_LATEST: ${{ steps.setup.outputs.push_latest }}
 
       - uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
         with:


### PR DESCRIPTION
## Description

Address misconfiguration in github actions which were reported by zizmor

## Testing

Ensure that github actions are running correctly especially the ones which use caching since zizmor recommended using the parameter `lookup-only: true` when using the cache action

## Issue(s)

Closes [STOR-540](https://mozilla-hub.atlassian.net/browse/STOR-540).


[STOR-540]: https://mozilla-hub.atlassian.net/browse/STOR-540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ