### PR TITLE
test(integration): allow 204 (from nginx) on options req

### DIFF
--- a/tools/integration_tests/test_storage.py
+++ b/tools/integration_tests/test_storage.py
@@ -2275,7 +2275,7 @@ def test_cors_allows_any_origin(st_ctx):
             "Origin": "http://test-website.com",
             "Access-Control-Request-Headers": "Content-Type",
         },
-        status=200,
+        status=[200, 204],
     )
 
 


### PR DESCRIPTION
nginx in deploy envs could return a 204 for an OPTIONS request.


part of STOR-514