### PR TITLE
feat: claude skills

### DIFF
--- a/.claude/commands/env-check.md
+++ b/.claude/commands/env-check.md
@@ -1,0 +1,70 @@
+Verify all required environment variables are set before running integration tests.
+
+You are a pre-flight assistant for syncstorage-rs integration tests. Your job is to check that the shell environment is correctly configured so tests will actually run, and surface any missing or suspicious values before the user wastes time on a failing test run.
+
+Do NOT print or log the values of any secrets. Use placeholders like `[set]` or `[not set]` when reporting on secret variables.
+
+## Variables to check
+
+### Required for all integration test runs
+
+| Variable | Expected | Notes |
+|---|---|---|
+| `SYNC_MASTER_SECRET` | any non-empty string | secret — report [set] or [not set] only |
+| `SYNC_SYNCSTORAGE__DATABASE_URL` | starts with `mysql://`, `postgresql://`, or `spanner://` | |
+| `SYNC_TOKENSERVER__DATABASE_URL` | starts with `mysql://` or `postgresql://` | |
+| `TOKENSERVER_HOST` | starts with `http://` or `https://` | default: `http://localhost:8000` |
+| `SYNC_TOKENSERVER__FXA_OAUTH_SERVER_URL` | starts with `http://` or `https://` | default: `http://localhost:6000` for local |
+| `PYTHONPATH` | contains `tools/` path | required for PyO3 and test imports |
+
+### Required only for real FxA e2e tests (`test_e2e.py`)
+
+| Variable | Notes |
+|---|---|
+| `SYNC_TOKENSERVER__FXA_OAUTH_PRIMARY_JWK__KTY` | secret — report [set] or [not set] only |
+| `SYNC_TOKENSERVER__FXA_OAUTH_PRIMARY_JWK__KID` | secret — report [set] or [not set] only |
+| `SYNC_TOKENSERVER__FXA_OAUTH_PRIMARY_JWK__N` | secret — report [set] or [not set] only |
+| `SYNC_TOKENSERVER__FXA_OAUTH_PRIMARY_JWK__E` | secret — report [set] or [not set] only |
+
+## Step 1 — Check each variable
+
+```bash
+echo "SYNC_MASTER_SECRET: $([ -n "$SYNC_MASTER_SECRET" ] && echo '[set]' || echo '[NOT SET]')"
+echo "SYNC_SYNCSTORAGE__DATABASE_URL: ${SYNC_SYNCSTORAGE__DATABASE_URL:-[NOT SET]}"
+echo "SYNC_TOKENSERVER__DATABASE_URL: ${SYNC_TOKENSERVER__DATABASE_URL:-[NOT SET]}"
+echo "TOKENSERVER_HOST: ${TOKENSERVER_HOST:-[NOT SET - default: http://localhost:8000]}"
+echo "SYNC_TOKENSERVER__FXA_OAUTH_SERVER_URL: ${SYNC_TOKENSERVER__FXA_OAUTH_SERVER_URL:-[NOT SET - default: http://localhost:6000]}"
+echo "PYTHONPATH: ${PYTHONPATH:-[NOT SET]}"
+```
+
+## Step 2 — Validate database URL format
+
+For `SYNC_SYNCSTORAGE__DATABASE_URL` and `SYNC_TOKENSERVER__DATABASE_URL`:
+- Check the scheme matches a supported backend (`mysql`, `postgresql`, `spanner`)
+- For `postgres://` prefix: note that SQLAlchemy 1.4+ requires `postgresql://` — flag this if present
+- For Spanner: confirm `SYNC_SYNCSTORAGE__SPANNER_EMULATOR_HOST` is set if the URL contains `test-project` or `emulator`
+
+## Step 3 — Check PYTHONPATH contains tools/
+
+```bash
+python3 -c "import tools.integration_tests" 2>&1
+```
+
+If this fails, the `PYTHONPATH` is not set correctly for test imports.
+
+## Step 4 — Check server reachability (if TOKENSERVER_HOST is set)
+
+```bash
+curl -sf "${TOKENSERVER_HOST:-http://localhost:8000}/__heartbeat__" && echo "server: reachable" || echo "server: NOT REACHABLE"
+```
+
+## Output format
+
+Report each variable as **OK**, **WARNING**, or **MISSING**:
+
+| Variable | Status | Detail |
+|---|---|---|
+
+Then list any blockers (MISSING required vars, unreachable server) followed by warnings (format issues, defaults in use).
+
+End with **Ready to run tests** or **N issues need to be resolved**.

--- a/.claude/commands/git-history-check.md
+++ b/.claude/commands/git-history-check.md
@@ -1,0 +1,87 @@
+Examine git history of files changed in the current branch to identify regressions, re-introduced bugs, or changes that conflict with past fixes.
+
+You are a senior engineer doing a history-aware code review. Your job is to look at what has changed in this branch, then examine the git history of those files to identify whether the current changes risk re-introducing old bugs, reverting past fixes, or conflicting with patterns established through prior work.
+
+## Step 1 — Get the current diff
+
+```bash
+git diff main...HEAD
+```
+
+## Step 2 — Get the list of changed files
+
+```bash
+git diff main...HEAD --name-only
+```
+
+## Step 3 — For each changed file, examine recent commit history
+
+```bash
+git log --oneline -20 -- <file>
+```
+
+## Step 4 — Inspect relevant commits in full
+
+For each commit that looks relevant (bug fixes, reverts, security patches, refactors on the same lines), inspect the full diff:
+
+```bash
+git show <commit-hash>
+```
+
+## Step 5 — Look for reverted or fix commits
+
+```bash
+git log --oneline --all --grep="revert" -- <file>
+git log --oneline --all --grep="fix" -- <file>
+```
+
+Use your judgment about which historical commits are worth digging into. Prioritize commits with "fix", "revert", "hotfix", "patch", "security", "regression" in their message, and any commits that touched the same functions or lines as the current changes.
+
+## Analysis checklist
+
+For each changed file, work through the following. Report findings with:
+- **Severity:** High / Medium / Low
+- **Location:** file:line
+- **Issue:** what the historical context reveals
+- **Relevant commit(s):** hash + message
+- **Recommendation:** what to verify or change
+
+### 1. Re-introduced bugs
+- Does the current diff restore code that was previously removed by a bug fix?
+- Are there commits in the history that explicitly fixed logic that the current change modifies or removes?
+
+### 2. Reverted or rolled-back patterns
+- Has this code been reverted before? If so, why — and does the current change repeat the same pattern?
+- Are there "Revert X" commits in the history that suggest a prior attempt at this change failed?
+
+### 3. Previously fixed security issues
+- Does the history show security-related fixes on these lines?
+- Does the current change touch or weaken those protections?
+- Pay particular attention to: HAWK/JWT token handling, FxA OAuth validation, gRPC error suppression logic, DB migration constraints.
+
+### 4. Repeated churn
+- Has this file or function been modified many times in a short period? High churn is a signal of instability.
+- Does the current change look like it continues a pattern of patching symptoms rather than fixing the root cause?
+
+### 5. Conflicting intent
+- Do commit messages indicate a deliberate design decision that the current change reverses without explanation?
+- Are there TODOs or FIXMEs introduced by prior commits that the current change should have addressed but didn't?
+
+### 6. Migration or deprecation conflicts
+- Does the history show a migration away from a pattern that the current change re-introduces?
+- Examples: callback → async, legacy auth → FxA OAuth, MySQL-only → multi-backend.
+
+### 7. Test regressions
+- Were tests previously added to cover a bug that the current change might invalidate?
+- Do any historical fix commits include test additions that are now at risk of being bypassed?
+
+## Output format
+
+Lead with a summary table:
+
+| Severity | File | Issue | Relevant commit |
+|---|---|---|---|
+
+Follow with per-file detail. End with a **No concerns found** list for files whose history shows no conflicts with the current changes.
+
+If the git history is shallow or sparse for a file, note that and flag it as low confidence.

--- a/.claude/commands/migration-review.md
+++ b/.claude/commands/migration-review.md
@@ -1,0 +1,63 @@
+Review database migration changes against the repo's published-migration policy.
+
+You are a database migration reviewer for syncstorage-rs. The repo has a hard rule: **never edit a published migration file**. Only new forward migrations with a corresponding rollback are allowed. Your job is to enforce this and catch violations before merge.
+
+## Migration locations
+
+```
+syncstorage-mysql/migrations/       # up.sql / down.sql per timestamped dir
+syncstorage-postgres/migrations/
+tokenserver-mysql/migrations/
+tokenserver-postgres/migrations/
+syncstorage-spanner/src/schema.ddl  # Spanner schema — treated as published
+syncstorage-spanner/src/*.sql       # inline Spanner queries
+```
+
+Each migration directory is named `YYYY-MM-DD-hhmmss_description/` and contains `up.sql` and `down.sql`.
+
+## Step 1 — Find changed migration files
+
+```bash
+git diff main...HEAD --name-only | grep -E "migrations/|schema\.ddl|\.sql"
+```
+
+## Step 2 — Classify each changed file
+
+For each changed SQL file:
+
+- **New migration directory** (path did not exist on main) → allowed, proceed to Step 3
+- **Existing migration file modified** (path existed on main and content changed) → **VIOLATION** — flag as a blocker
+- **schema.ddl modified** → **VIOLATION** — flag as a blocker
+- **Inline .sql query file modified** (non-migration) → review for intent, flag if it changes schema
+
+Check whether a file existed on main:
+```bash
+git show main:<path>
+```
+
+## Step 3 — Validate new migrations
+
+For each new migration directory:
+
+1. Confirm both `up.sql` and `down.sql` exist
+2. Confirm `down.sql` is a genuine rollback of `up.sql` (not empty, not a no-op)
+3. Check that the timestamp prefix is newer than all existing migrations in that crate
+4. Check for destructive operations in `up.sql` (`DROP TABLE`, `DROP COLUMN`, `TRUNCATE`) — flag these for explicit review
+5. Check that column types and constraints are consistent with existing schema in the same crate
+
+## Step 4 — Cross-backend consistency
+
+If migrations exist for both mysql and postgres variants of the same crate, verify the schema changes are semantically equivalent (same columns, types mapped appropriately, same constraints).
+
+## Output format
+
+**Violations (blockers):**
+List any edits to published files with file path and the nature of the change.
+
+**New migrations:**
+For each new migration: name, what it does, whether down.sql is valid, any destructive ops.
+
+**Warnings:**
+Non-blocking concerns (e.g. missing index, risky destructive op, cross-backend inconsistency).
+
+**Verdict:** Pass / Violations found

--- a/.claude/commands/pr-description.md
+++ b/.claude/commands/pr-description.md
@@ -1,0 +1,75 @@
+Generate a PR title and summary from the current branch diff, following the repo's commit and PR conventions.
+
+You are a PR description writer for syncstorage-rs. Your job is to inspect the current branch changes and produce a ready-to-use PR title and body that follows the conventions in CONTRIBUTING.md.
+
+## Step 1 — Gather branch context
+
+```bash
+git diff main...HEAD --name-only
+git log main...HEAD --oneline
+git diff main...HEAD --stat
+```
+
+## Step 2 — Read the full diff for context
+
+```bash
+git diff main...HEAD
+```
+
+Focus on understanding *what changed and why*, not just listing files.
+
+## Step 3 — Classify the change type
+
+Based on changed files, determine the primary `type`:
+
+- `feat` — new functionality added
+- `fix` — bug fix
+- `refactor` — code restructured, no behavior change
+- `test` — test additions or changes only
+- `chore` — build, CI, tooling, dependencies
+- `docs` — documentation only
+- `perf` — performance improvement
+- `style` — formatting, lint fixes only
+
+If multiple types apply, use the most significant one.
+
+## Step 4 — Determine scope (optional)
+
+If the change is clearly scoped to one subsystem, add it in parentheses:
+- `tokenserver`, `syncstorage`, `spanner`, `mysql`, `postgres`, `auth`, `migrations`, `ci`, `tools`
+
+Example: `refactor(tokenserver): ...`
+
+## Step 5 — Draft the PR title
+
+Rules from CONTRIBUTING.md:
+- Format: `type(scope): subject` or `type: subject`
+- Subject: imperative present tense, no capital first letter, no trailing period
+- Keep it under 70 characters
+
+## Step 6 — Draft the PR body
+
+```markdown
+## Summary
+
+<2–4 bullet points covering what changed and why. Lead with the motivating
+problem or context, then the solution. Skip obvious restatements of the title.>
+
+## Test plan
+
+<Bulleted checklist pre-filled based on what changed:>
+```
+
+Pre-fill the test plan based on file types changed:
+
+- Rust source changed → `- [ ] \`make clippy_<backend>\` passes`, `- [ ] Unit tests pass (\`make test\`)`
+- Python source changed → `- [ ] \`make ruff-lint\` and \`make mypy\` pass`, `- [ ] Integration tests pass (\`make run_local_e2e_tests\`)`
+- SQL migrations added → `- [ ] \`/migration-review\` passes`, `- [ ] Migration applies cleanly on a fresh DB`
+- `.github/` changed → `- [ ] CI workflow runs successfully on this branch`
+- `CLAUDE.md` or docs changed → `- [ ] Renders correctly on GitHub`
+
+## Step 7 — Output
+
+Print the final PR title and body, ready to paste into GitHub. Also include the suggested branch name if the current branch name doesn't follow `type/description-STOR-####` or `type/description-####` format.
+
+Note any breaking changes that should be called out explicitly.

--- a/.claude/commands/py-checks.md
+++ b/.claude/commands/py-checks.md
@@ -1,0 +1,69 @@
+Run all Python lint, format, type, and security checks for the tools/ directory.
+
+You are a Python code quality assistant for the syncstorage-rs tools and integration tests. Your job is to run the full suite of Python checks in the correct order, report findings clearly, and tell the user exactly what needs to be fixed before the PR can merge.
+
+All checks operate on the `tools/` directory. All commands require the root Poetry environment to be installed (`make install`).
+
+## Step 1 — Check Poetry environment
+
+```bash
+poetry env info
+```
+
+If no environment is active, tell the user to run `make install` first and stop.
+
+## Step 2 — Format check
+
+```bash
+make ruff-fmt-chk
+```
+
+If there are formatting issues, tell the user to run `make ruff-format` to auto-fix, then re-run. Do not proceed past format failures.
+
+## Step 3 — Lint
+
+```bash
+make ruff-lint
+```
+
+Report each warning/error with file:line and rule code.
+
+## Step 4 — Type checking
+
+```bash
+make mypy
+```
+
+Report type errors with file:line. Note that `# type: ignore` suppressions on changed lines should be flagged for review — they may be hiding real issues.
+
+## Step 5 — Docstring validation
+
+```bash
+make pydocstyle
+```
+
+Report missing or malformed docstrings. These are non-blocking for logic but required by the project's style standards.
+
+## Step 6 — Security scan
+
+```bash
+make bandit
+```
+
+Flag any **HIGH** severity findings as blockers. List **MEDIUM** as warnings.
+
+## Output format
+
+Report each check as **PASS**, **WARNINGS**, or **FAIL**:
+
+| Check | Status | Issues |
+|---|---|---|
+| Format (ruff) | | |
+| Lint (ruff) | | |
+| Types (mypy) | | |
+| Docstrings (pydocstyle) | | |
+| Security (bandit) | | |
+
+List all actionable findings below the table with file:line references.
+
+End with **All checks passed** or **N checks need attention** verdict.

--- a/.claude/commands/rust-backend-check.md
+++ b/.claude/commands/rust-backend-check.md
@@ -1,0 +1,54 @@
+Run Clippy, fmt check, and cargo audit for a specific Rust backend.
+
+You are a Rust build and lint assistant for the syncstorage-rs workspace. Your job is to run the correct set of checks for a given backend, report findings clearly, and flag anything that needs attention before the code is merged.
+
+## Step 1 — Determine the backend
+
+Ask the user which backend to check if not already specified: `mysql`, `postgres`, or `spanner`. If the current branch name or open files suggest a backend, infer it and confirm.
+
+## Step 2 — Run format check
+
+```bash
+cargo fmt -- --check
+```
+
+Report any files that are not formatted. If there are formatting issues, stop and tell the user to run `cargo fmt` before proceeding.
+
+## Step 3 — Run Clippy for the chosen backend
+
+Use the exact make target:
+
+```bash
+make clippy_mysql       # for mysql
+make clippy_postgres    # for postgres
+make clippy_spanner     # for spanner
+```
+
+## Step 4 — Run release-mode Clippy
+
+```bash
+make clippy_release_mysql       # for mysql
+make clippy_release_postgres    # for postgres
+make clippy_release_spanner     # for spanner
+```
+
+Release mode catches dead code and issues only visible with optimizations enabled.
+
+## Step 5 — Run cargo audit
+
+```bash
+cargo audit
+```
+
+Flag any advisories with severity **high** or **critical** as blockers. List medium/low advisories as warnings.
+
+## Output format
+
+Summarize findings in this order:
+
+1. **Format** — pass or list of unformatted files
+2. **Clippy (debug)** — pass or list of warnings/errors with file:line
+3. **Clippy (release)** — pass or list of warnings/errors with file:line
+4. **Audit** — pass or list of advisories (severity, crate, advisory ID)
+
+End with a clear **Ready to merge** / **Needs attention** verdict.

--- a/.claude/skills/multi-backend-consistency/SKILL.md
+++ b/.claude/skills/multi-backend-consistency/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: multi-backend-consistency
+description: Checks that trait method changes in syncstorage-db or tokenserver-db are consistently implemented across all backend crates (mysql, postgres, spanner). Flags missing impls, behavioral drift, and Spanner-specific assumptions leaking into shared code.
+user-invocable: true
+---
+
+# Multi-Backend Consistency Check
+
+You are a Rust trait/implementation consistency reviewer for syncstorage-rs. Changes to shared traits must be reflected in every backend. Your job is to find gaps before they reach CI.
+
+## Backend map
+
+```
+syncstorage-db/         ← trait definitions (DbPool, Db, etc.)
+  → syncstorage-mysql/
+  → syncstorage-postgres/
+  → syncstorage-spanner/
+
+tokenserver-db/         ← trait definitions
+  → tokenserver-mysql/
+  → tokenserver-postgres/
+```
+
+## Step 1 — Find changed trait files
+
+```bash
+git diff main...HEAD --name-only | grep -E "syncstorage-db/|tokenserver-db/"
+```
+
+If no trait files changed, check whether any backend implementation changed without a corresponding trait change — that may indicate the trait was bypassed or duplicated.
+
+```bash
+git diff main...HEAD --name-only | grep -E "syncstorage-(mysql|postgres|spanner)/|tokenserver-(mysql|postgres)/"
+```
+
+## Step 2 — Diff the traits
+
+For each changed trait file:
+
+```bash
+git diff main...HEAD -- <file>
+```
+
+List every added, removed, or modified method signature.
+
+## Step 3 — Check each backend for the same change
+
+For each modified method, grep for its name in every backend crate:
+
+```bash
+grep -rn "fn <method_name>" syncstorage-mysql/src/ syncstorage-postgres/src/ syncstorage-spanner/src/
+grep -rn "fn <method_name>" tokenserver-mysql/src/ tokenserver-postgres/src/
+```
+
+For each backend, determine:
+- **Present and updated** — matches the new signature ✓
+- **Present but stale** — exists but hasn't been updated to match ✗
+- **Missing** — not implemented at all ✗
+
+## Step 4 — Check for cross-backend behavioral assumptions
+
+Review the diff for patterns that are safe on one backend but wrong on another:
+
+- **Auto-increment IDs** — MySQL/Postgres use serial/auto-increment; Spanner uses explicit INT64. Code that relies on `last_insert_id()` or assumes monotonic IDs will break on Spanner.
+- **Transaction semantics** — Spanner transactions are bounded; MySQL/Postgres allow longer-lived transactions. Check for assumptions about transaction scope.
+- **NULL handling** — Spanner is stricter about NULLs in some column types than MySQL.
+- **RETURNING clause** — Postgres supports `RETURNING id`; MySQL uses `last_insert_id()`; Spanner uses a separate read. Check that insert helpers follow the per-backend pattern established in `helpers.py` / existing db impls.
+- **Timestamp precision** — Spanner uses microseconds; MySQL DATETIME has second precision unless explicitly specified.
+- **Feature flags** — confirm the change compiles under `--features=syncstorage-db/mysql`, `--features=syncstorage-db/postgres`, and `--features=syncstorage-db/spanner` independently.
+
+## Step 5 — Check shared db-common crates
+
+Changes to `syncstorage-db-common/` or `tokenserver-db-common/` affect all backends. Verify nothing in those changes makes backend-specific assumptions.
+
+```bash
+git diff main...HEAD --name-only | grep "db-common"
+```
+
+## Output format
+
+**Trait changes detected:**
+List each modified method with its new signature.
+
+**Backend coverage:**
+
+| Method | mysql | postgres | spanner |
+|---|---|---|---|
+| `method_name` | ✓ updated / ✗ stale / ✗ missing | ... | ... |
+
+**Behavioral drift warnings:**
+Any cross-backend assumptions found, with file:line.
+
+**Verdict:** All backends consistent / N gaps found

--- a/.claude/skills/pytest-fixture-review/SKILL.md
+++ b/.claude/skills/pytest-fixture-review/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: pytest-fixture-review
+description: Reviews conftest.py and helpers.py files in tools/integration_tests/ against the repo's fixture/helper separation standard. Flags helpers in conftest, missing teardown, wrong scopes, and raw DB operations outside helper functions.
+user-invocable: true
+---
+
+# Pytest Fixture Review
+
+You are a pytest code reviewer for syncstorage-rs integration tests. This repo has a deliberate structure: `conftest.py` contains only pytest fixtures, and all utility functions live in `helpers.py`. Your job is to enforce that standard and catch common fixture mistakes before they cause flaky or confusing tests.
+
+## The standard
+
+```
+tools/integration_tests/
+  conftest.py          ← fixtures ONLY (st_ctx)
+  helpers.py           ← retry helpers, auth state, switch_user, constants
+
+tools/integration_tests/tokenserver/
+  conftest.py          ← fixtures ONLY (ts_db_conn, ts_app, ts_service_id, ts_ctx, fxa_auth)
+  helpers.py           ← DB helpers, auth helpers, node/user/service helpers
+```
+
+Fixtures yield context dicts. Helpers are plain functions imported directly by test files.
+
+## Step 1 — Find changed test files
+
+```bash
+git diff main...HEAD --name-only | grep -E "tools/integration_tests"
+```
+
+Read each changed file in full.
+
+## Step 2 — conftest.py checks
+
+For each `conftest.py` in the diff:
+
+**Non-fixture code in conftest:**
+- Are there any module-level functions that are not decorated with `@pytest.fixture`?
+- Are there utility functions, helper classes, constants, or context managers defined in conftest that belong in `helpers.py`?
+- Exception: module-level side effects that must run at import time (e.g. the `SYNC_TEST_LOG_HTTP` logging patch) may stay in conftest with a comment explaining why.
+
+**Fixture scopes:**
+- `scope="function"` — default, correct for most fixtures; state is reset per test
+- `scope="session"` — only justified for expensive external calls (e.g. `fxa_auth` creates a real FxA account). Any new session-scoped fixture must have a comment explaining why.
+- `scope="module"` or `scope="class"` — flag for review; not currently used in this repo
+
+**Teardown:**
+- Does every fixture that creates state also clean it up?
+- `ts_ctx` pattern: `clear_db()` before yield AND after yield. Verify both sides are present.
+- `fxa_auth` pattern: `acct.clear()` + `client.destroy_account()` in teardown. Verify error handling wraps the teardown.
+- `st_ctx` pattern: `config.end()` + `del os.environ["MOZSVC_UUID"]`. Verify both.
+
+**Database connections:**
+- `ts_db_conn` uses `AUTOCOMMIT` isolation. If a new fixture creates a connection, verify isolation level is set explicitly.
+- Connections must be closed in teardown (`conn.close()`).
+
+## Step 3 — helpers.py checks
+
+**No fixtures in helpers:**
+- Are there any functions decorated with `@pytest.fixture` in `helpers.py`? These must move to `conftest.py`.
+
+**Raw SQL outside helper functions:**
+- Is `sqltext()` / `execute_sql()` called directly in a test file rather than through a helper?
+- Direct SQL in tests bypasses the helper layer and makes tests brittle. Flag with file:line.
+
+**Imports:**
+- Are helpers importing from `conftest`? This creates a circular dependency risk. Helpers should have no pytest imports and no conftest imports.
+
+**Constants:**
+- Are test constants (NODE_ID, NODE_URL, FXA_EMAIL_DOMAIN, etc.) defined in helpers, not scattered in test files or conftest?
+
+## Step 4 — Test file import checks
+
+For each changed test file:
+
+```bash
+grep -n "from.*conftest import" <test_file>
+```
+
+Test files should import helpers from `helpers.py`, not from `conftest.py`. Any `from tools.integration_tests.conftest import` or `from integration_tests.tokenserver.conftest import` is wrong — flag it with the correct import path.
+
+## Step 5 — New fixture pattern check
+
+If a new fixture was added, verify:
+- It follows the `yield`-based teardown pattern (not `return`)
+- It is typed or documented enough that its contents are clear
+- If it seeds database state, it cleans up after itself
+- Its scope is the narrowest possible for its purpose
+
+## Output format
+
+**conftest.py issues:**
+List each violation with file:line and what needs to move or change.
+
+**helpers.py issues:**
+List each violation with file:line.
+
+**Import violations:**
+List any test files importing from conftest instead of helpers.
+
+**New fixtures:**
+For each new fixture: name, scope, teardown present (yes/no), any concerns.
+
+**Verdict:** Follows conventions / N issues found

--- a/.claude/skills/rust-code-smell/SKILL.md
+++ b/.claude/skills/rust-code-smell/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: rust-code-smell
+description: Runs clippy, cargo audit, and all relevant multi-backend Makefile targets for files changed in the current branch. Detects code smells, anti-patterns specific to this codebase, and surfaces issues across every affected backend before CI catches them.
+user-invocable: true
+---
+
+# Rust Code Smell Detector
+
+You are a Rust code quality reviewer for syncstorage-rs. Your job is to run the full set of mechanical checks relevant to the current branch's changes, then layer on a manual smell pass for patterns that tooling misses. Run checks for every backend touched by the diff — not just the default.
+
+## Step 1 — Identify which backends are affected
+
+```bash
+git diff main...HEAD --name-only
+```
+
+Determine which backends the changes touch:
+
+- Files in `syncstorage-mysql/`, `tokenserver-mysql/`, or `syncstorage-db/` with MySQL defaults → **mysql**
+- Files in `syncstorage-postgres/`, `tokenserver-postgres/` → **postgres**
+- Files in `syncstorage-spanner/` → **spanner**
+- Files in `syncserver/`, `syncserver-common/`, `syncserver-settings/`, `syncstorage-db-common/`, `tokenserver-auth/`, `tokenserver-common/` → **all three backends**
+
+## Step 2 — Format check
+
+```bash
+cargo fmt -- --check
+```
+
+If formatting issues exist, stop and report them. Do not proceed until format is clean — other tools will produce misleading output on unformatted code.
+
+## Step 3 — Run Clippy for each affected backend
+
+Run only the backends identified in Step 1. Use the exact Makefile targets:
+
+```bash
+make clippy_mysql      # if mysql affected
+make clippy_postgres   # if postgres affected
+make clippy_spanner    # if spanner affected
+```
+
+Then run release-mode Clippy for each affected backend (catches dead code, unused imports with optimizations, and issues only visible at `--release`):
+
+```bash
+make clippy_release_mysql      # if mysql affected
+make clippy_release_postgres   # if postgres affected
+make clippy_release_spanner    # if spanner affected
+```
+
+Collect all warnings and errors. Do not deduplicate across backends — the same logical issue may manifest differently per backend due to feature flags.
+
+## Step 4 — Security audit
+
+```bash
+cargo audit
+```
+
+Flag any **critical** or **high** severity advisories as blockers. List **medium** as warnings. Note the affected crate and advisory ID for each.
+
+## Step 5 — Manual smell pass
+
+Read the diff:
+
+```bash
+git diff main...HEAD
+```
+
+Check for the following patterns that Clippy does not catch:
+
+### Async/blocking
+- `std::thread::sleep` inside an async function — use `tokio::time::sleep`
+- Blocking DB calls inside async handlers without `spawn_blocking`
+- `.unwrap()` or `.expect()` on `Result`/`Option` in production paths (test code is fine)
+
+### gRPC / Spanner-specific
+- `grpcio::RpcStatus` errors caught and silently dropped without either Sentry classification or metric emission — see `is_sentry_event()` / `is_ignored_internal()` pattern
+- Retry logic that doesn't cap attempts or uses `std::thread::sleep` instead of exponential backoff
+- Spanner mutations not batched where they could be
+
+### Error handling
+- `map_err(|_| ...)` that discards the original error without logging — information loss
+- `unwrap()` on lock acquisition (implies the lock is poisonable)
+- New `From` impls that convert specific errors into generic `InternalError` without preserving context
+
+### Trait object vs generic
+- `Box<dyn Db>` or `Arc<dyn DbPool>` allocations in hot paths where a generic would avoid the vtable overhead
+- Inconsistency with how the rest of the codebase handles the same trait (check existing usage)
+
+### Diesel / query patterns
+- N+1 query patterns: loops that issue individual DB calls instead of a single query
+- Missing index hints or queries on unindexed columns in high-traffic paths
+- Raw string SQL (`sqltext(...)`) where a typed Diesel query builder already exists
+
+### Configuration / secrets
+- Secrets or credentials hardcoded or defaulting to non-placeholder values outside of test modules
+- Environment variable reads outside of the settings structs (should go through `syncserver-settings`)
+
+### Feature flag hygiene
+- `#[cfg(feature = "...")]` on items that should be available to all backends
+- Code that compiles under one feature but silently no-ops under another without a clear comment
+
+## Output format
+
+**Format:** pass / fail (list files)
+
+**Clippy results per backend:**
+
+| Backend | Debug | Release | Issues |
+|---|---|---|---|
+| mysql | pass/fail | pass/fail | N warnings/errors |
+| postgres | pass/fail | pass/fail | |
+| spanner | pass/fail | pass/fail | |
+
+**Audit:** pass / N advisories (list crate, severity, advisory ID)
+
+**Manual smells found:**
+List each with file:line, smell type, and a one-line explanation.
+
+**Verdict:** Clean / N issues need attention — list blockers vs warnings separately.

--- a/.claude/skills/rust-error-review/SKILL.md
+++ b/.claude/skills/rust-error-review/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: rust-error-review
+description: Reviews new or modified error variants in syncstorage-rs for correct Sentry routing, HTTP status mapping, and response safety. Enforces the is_sentry_event() / maybe_emit_metrics() classification pattern.
+user-invocable: true
+---
+
+# Rust Error Review
+
+You are a Rust error handling reviewer for syncstorage-rs. This repo has a specific, non-obvious error routing pattern: every error variant must be explicitly classified as either a Sentry event or a suppressed metric. Getting this wrong causes either noisy Sentry alerts (on transient infrastructure errors) or silent failures (on real bugs). Your job is to catch misclassification before merge.
+
+## The pattern
+
+```
+SyncstorageError / DbError
+    → is_sentry_event() → true  → sent to Sentry
+    → is_sentry_event() → false → maybe_emit_metrics() → StatsD counter
+```
+
+Key files:
+- `syncstorage-spanner/src/error.rs` — `DbError`, `DbErrorKind`, `is_sentry_event()`, `is_ignored_internal()`
+- `syncstorage-db-common/src/error.rs` — shared error types
+- `syncserver/src/error.rs` — top-level `ApiError`, HTTP response mapping
+- `tokenserver-common/src/error.rs` — tokenserver error types
+
+## Step 1 — Find changed error files
+
+```bash
+git diff main...HEAD --name-only | grep -E "error\.rs"
+```
+
+Also check for new `From<>` impls that convert external errors into repo error types:
+
+```bash
+git diff main...HEAD | grep -E "impl From|Into<.*Error"
+```
+
+## Step 2 — Diff each error file
+
+```bash
+git diff main...HEAD -- <error_file>
+```
+
+## Step 3 — Review checklist
+
+For each new or modified error variant:
+
+### Sentry classification
+- Is there a new arm in `is_sentry_event()` for this variant?
+- Is the classification correct?
+  - **Should be Sentry:** logic bugs, unexpected states, data integrity issues, auth failures that indicate an attack, panics
+  - **Should be metric only:** transient infrastructure errors (gRPC RST_STREAM, connection timeouts, 503s from upstream), expected client errors (404, 409 conflict, quota exceeded)
+- For `INTERNAL` gRPC errors: is `is_ignored_internal()` doing substring matching (`.iter().any(|s| msg.contains(s))`)? Exact equality will miss real RST_STREAM messages.
+
+### HTTP status mapping
+- Does the new variant map to an appropriate HTTP status in the `From<DbError> for ApiError` or `status_code()` impl?
+- Are client errors (4xx) distinguished from server errors (5xx)?
+- Is a 500 being returned for something that should be a 409 or 404?
+
+### Response body safety
+- Does the error's `Display` or serialization leak internal state (SQL query text, file paths, internal IDs, stack traces)?
+- Check `ApiError`'s response serialization — internal error messages must not reach the client.
+
+### Backtrace
+- Is `capture_backtrace()` called for new unexpected/internal error variants?
+- Is it *not* called for expected operational errors (quota, not found, conflict)?
+
+### Metric naming
+- If the variant routes to `maybe_emit_metrics()`, is the metric name consistent with existing conventions (`storage.spanner.grpc.internal`, etc.)?
+
+## Step 4 — Check `From` impl chains
+
+New error types often get wrapped through multiple `From` impls before reaching the HTTP layer. Trace the chain to verify classification survives the conversion:
+
+```bash
+grep -rn "From<" syncstorage-spanner/src/ syncstorage-db/src/ syncserver/src/ | grep -i error
+```
+
+## Output format
+
+For each changed error variant:
+- **Variant:** name
+- **Classification:** Sentry / Metric / Unclear
+- **HTTP status:** correct / wrong (should be X) / missing
+- **Response safety:** safe / leaks internal detail at file:line
+- **Issues:** list
+
+End with **All error variants correctly classified** or **N classification issues found**.

--- a/.claude/skills/syncserver-explain-code/SKILL.md
+++ b/.claude/skills/syncserver-explain-code/SKILL.md
@@ -1,0 +1,114 @@
+---
+description: Explains code for experienced engineers working on syncstorage-rs. Covers what changed, why it works, non-obvious decisions, gotchas, and data/control flow. Defaults to git diff vs main; accepts an optional file or path argument.
+argument-hint: file-or-path
+---
+
+You are a senior engineer explaining code to another experienced engineer working on **syncstorage-rs** — Mozilla's Rust implementation of the Firefox Sync storage server and token server.
+
+Skip basics and language fundamentals. Focus on what this code does, why it was written this way, non-obvious decisions, and things that could surprise or bite someone.
+
+## Service boundary — critical context
+
+This repo owns two services:
+- **Syncstorage** — the storage node that holds encrypted user sync data (bookmarks, passwords, tabs, etc.). Database backends: MySQL, PostgreSQL, Google Cloud Spanner.
+- **Tokenserver** — the allocation service that authenticates Firefox clients via FxA OAuth and assigns them to a storage node. Database backends: MySQL, PostgreSQL.
+
+**Firefox Accounts (FxA) is an external upstream service.** This repo does not own FxA. When explaining code:
+- References to `fxa_uid`, `fxa_kid`, `client_state`, FxA OAuth tokens, JWK keys, the FxA OAuth server URL — these are **inputs from FxA that this service validates and consumes**, not code this repo owns.
+- The `mock-fxa-server` in `scripts/` is a test stub only — it is not a real FxA implementation.
+- `tokenserver-auth/src/oauth/` and `tokenserver-auth/src/crypto.rs` are **this repo's FxA token verification logic**, not FxA's own code.
+
+Make this boundary explicit whenever the code touches the FxA/tokenserver interface.
+
+## How to gather the code
+
+If `$ARGUMENTS` is provided, read that file or directory.
+
+Otherwise, run:
+
+```bash
+git diff main...HEAD
+```
+
+and read the full diff. Follow imports or read related files as needed to give accurate explanations — do not explain in isolation if context from a related file matters.
+
+## Explanation structure
+
+Work through the code and produce an explanation covering all sections below. Omit a section only if it genuinely doesn't apply.
+
+### 1. One-paragraph summary
+
+Plain English. What does this code do, and what problem does it solve? Write for someone who hasn't read the ticket.
+
+### 2. Architecture & data flow
+
+Where this fits in the broader system. Include an ASCII diagram if it clarifies the flow.
+
+Useful reference shapes for this codebase:
+
+```
+Firefox client
+    → Tokenserver (validates FxA OAuth token, assigns node)
+        → FxA OAuth server [external — validates token, not our code]
+        → tokenserver-db (MySQL/Postgres — users, nodes, services tables)
+    → Syncstorage node (stores/retrieves BSOs)
+        → syncstorage-db (MySQL / Postgres / Spanner)
+```
+
+```
+Request → Actix-web (syncserver/)
+    → Extractors (hawk_identifier, fxa_uid, token validation)
+    → Handler
+    → db trait (syncstorage-db or tokenserver-db)
+        → backend impl (mysql / postgres / spanner)
+```
+
+### 3. Annotated walkthrough
+
+Step through the key functions, types, or request paths. For each:
+- What it does
+- Why it's structured this way (if non-obvious)
+- How it connects to the next step
+
+Focus on the critical path. Don't exhaustively document trivial helpers.
+
+Note Rust-specific patterns where relevant: trait objects vs generics, `Arc<dyn DbPool>`, `actix_web::web::Data<>`, `grpcio` vs `tonic`, `diesel` query builder patterns, `serde` field renaming.
+
+### 4. Gotchas & non-obvious bits
+
+The most important section. Flag:
+
+- Implicit assumptions or preconditions the caller must satisfy
+- Surprising behavior or edge cases (off-by-one, async ordering, race conditions)
+- Why an obvious alternative wasn't taken (if inferrable)
+- Error handling that silently swallows failures or has unexpected fallback behavior
+- State mutated in non-obvious places
+- Performance characteristics worth knowing (N+1 queries, large allocations, blocking calls in async context)
+- Security-sensitive paths — especially: HAWK token validation, FxA OAuth scope checking, `client_state` / `keys_changed_at` handling, anything touching node assignment
+- gRPC-specific issues (Spanner backend): RST_STREAM handling, retry logic, emulator vs production behavioral differences
+- Migration safety: anything that changes DB schema or touches published migration files
+
+### 5. Dependencies & integrations
+
+External systems or crates this code depends on that aren't obvious from the code alone. Distinguish:
+- **Owned by this repo:** `syncstorage-*`, `tokenserver-*`, `syncserver-*` crates
+- **External upstream:** FxA OAuth server, Google Cloud Spanner, `tokenlib` (Python), `hawkauthlib`
+- **Test infrastructure only:** mock FxA server, Spanner emulator
+
+Note any version constraints or behavioral quirks.
+
+### 6. Testing notes
+
+How is this code tested? Are there gaps? Note:
+- Unit tests (Rust `#[cfg(test)]` modules)
+- Integration tests (`tools/integration_tests/` — pytest, requires a running server)
+- E2E tests (`tokenserver/test_e2e.py` — hits real FxA staging, session-scoped, slow)
+- Any known flaky behavior (Spanner emulator quirks, timing-sensitive tests, 409/503 retry paths)
+
+## Style guidelines
+
+- Be direct and dense. Skip preamble.
+- Use code formatting for identifiers, file paths, and values.
+- Use ASCII diagrams when they save more words than they cost.
+- If something is genuinely straightforward, say so in one sentence and move on.
+- When the FxA boundary is crossed, say so explicitly rather than implying this repo owns that behavior.

--- a/.claude/skills/syncserver-jira-description/SKILL.md
+++ b/.claude/skills/syncserver-jira-description/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: syncserver-jira-description
+description: Drafts a concise Jira description for a syncstorage-rs task. Gathers context via targeted interview, researches relevant patterns in the repo, then outputs a clean description ready for an engineer to hand to Claude for implementation.
+user-invocable: true
+---
+
+# Syncserver Jira Description
+
+Draft a Jira description for a syncstorage-rs task. Output the description only — do not create, edit, or suggest changes to any source files.
+
+## Step 1: Gather context
+
+If a planning doc, epic description, or tech spec was provided, read it first and infer what, why, crates, and constraints before asking anything.
+
+Required information:
+- **What:** What is being built or changed, in one sentence
+- **Why:** Motivation — user need, requirement, bug, or tech debt
+- **Crates:** Which specific crate(s) will be modified (e.g. `syncstorage-spanner`, `tokenserver-auth`, `syncserver`, `tokenserver-postgres`)
+- **Constraints:** DB migration required, multi-backend impact (MySQL/Postgres/Spanner), breaking API change, feature flag, FxA contract change — or none
+
+If all four are clear from provided context, proceed directly to Step 2. Otherwise ask for only what is missing in a single message. Also invite related PRs, tickets, existing approach notes, or architecture notes that would add useful context.
+
+## Step 2: Research
+
+Search only the crates identified in Step 1. Find the most relevant existing patterns: similar feature, nearby handler, equivalent DB query, related error type. Expand to the broader workspace only if nothing relevant is found there.
+
+Identify:
+- Key files an implementer will need to touch
+- The closest existing reference implementation to follow
+- Which database backends are affected and whether the change must be replicated across MySQL, PostgreSQL, and/or Spanner
+- Whether new migrations are required (and which crates: `syncstorage-mysql`, `syncstorage-postgres`, `tokenserver-mysql`, `tokenserver-postgres`)
+- Whether tests, metrics (Glean/StatsD), or Sentry error handling apply
+
+Incorporate findings directly into the draft — do not list them separately or ask for confirmation. Surface genuine blockers as Open Questions.
+
+## Step 3: Output
+
+**Background:**
+Why this is needed and what it enables. 2–4 sentences. Note which service is affected — Syncstorage (storage node), Tokenserver (node allocation + FxA auth), or both.
+
+**Acceptance Criteria:**
+Observable, testable outcomes. Each item verifiable without reading the code. Include criteria for tests, metrics emission, and Sentry error classification where applicable.
+
+**Implementation Steps:**
+Numbered steps with crate paths, file paths, trait/function names, and structural guidance. Reference the nearest existing pattern for each step. For multi-backend changes, call out which backends need matching implementations. No code snippets — file locations, types, and patterns only.
+
+**Database Migrations:** *(omit if no schema changes)*
+Which migration crates need new files (`syncstorage-mysql/migrations/`, `tokenserver-postgres/migrations/`, etc.). Reminder: never edit published migrations — add new `up.sql`/`down.sql` pairs only.
+
+**Tests:**
+What needs to be tested. Unit (`#[cfg(test)]` in the relevant crate), integration (`tools/integration_tests/` pytest — requires running server), and E2E (`tokenserver/test_e2e.py` — hits FxA staging, session-scoped) coverage expectations. Reference the nearest existing test file as a pattern.
+
+**Metrics & Error Handling:** *(omit if not applicable)*
+Any Glean metrics, StatsD counters, or Sentry event classifications that should be emitted or updated. Note whether new error variants should be routed to Sentry or suppressed as metrics (see `is_sentry_event()` pattern in `syncstorage-spanner/src/error.rs`).
+
+**Key Reference Files:**
+Specific files the implementer should read before starting. One line each.
+
+**Out of Scope:** *(omit if not needed)*
+
+**Open Questions:** *(omit if none)*
+
+## Guidelines
+
+- Output the description only — no source file changes
+- Implementation Steps should give enough detail to start work without follow-up questions — crate paths, file paths, and patterns, not prose
+- Multi-backend tasks: always explicitly name which backends (MySQL / PostgreSQL / Spanner) need matching changes; do not say "all backends" without listing them
+- Migration tasks: always reference the no-edit-published-migrations rule
+- Omit redundant or obvious acceptance criteria
+- Include Database Migrations, Metrics & Error Handling only when relevant
+- If motivation or scope remain unclear after asking, flag as an Open Question rather than assuming
+- Branch naming reminder for the assignee: Mozilla engineers use `type/description-STOR-####`; community contributors use `type/description-####`


### PR DESCRIPTION
## Description

Add Claude Code skills and commands for AI-assisted development workflows

Adds project-level `.claude/commands/` and `.claude/skills/` with task-specific
prompts covering the most common development workflows in this repo:

**Commands** (slash commands, manually invoked):
- `/rust-backend-check` — fmt + clippy (debug + release) + audit for a chosen backend
- `/migration-review` — enforces no-edit-published-migrations rule, validates new up/down pairs
- `/py-checks` — full Python lint/format/type/security suite in one shot
- `/git-history-check` — history-aware review flagging re-introduced bugs and reverted fixes
- `/env-check` — pre-flight check for integration test environment variables
- `/pr-description` — generates PR title and body following CONTRIBUTING.md conventions

**Skills** (context-aware, can also auto-invoke):
- `syncserver-explain-code` — explains diffs or files for experienced engineers with syncstorage-rs-specific architecture context and FxA boundary awareness
- `syncserver-jira-description` — drafts Jira tickets via targeted interview, researches relevant crate patterns, outputs implementation-ready descriptions
- `multi-backend-consistency` — checks trait changes are reflected across mysql/postgres/spanner backends
- `rust-error-review` — enforces the `is_sentry_event()` classification pattern on new error variants
- `pytest-fixture-review` — enforces the conftest/helpers split standard
- `rust-code-smell` — runs all Makefile clippy targets for affected backends + manual smell pass


## Issue(s)

Closes [STOR-551](https://mozilla-hub.atlassian.net/browse/STOR-551).


[STOR-551]: https://mozilla-hub.atlassian.net/browse/STOR-551?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ