### PR TITLE
feat: lazily resolve Backtrace symbols

### DIFF
--- a/syncserver-common/src/lib.rs
+++ b/syncserver-common/src/lib.rs
@@ -73,7 +73,7 @@ pub trait ReportableError: std::fmt::Display + std::fmt::Debug {
         None
     }
 
-    /// Return a `Backtrace` for this Error if one was captured
+    /// Return an unresolved `Backtrace` for this Error if one was captured
     fn backtrace(&self) -> Option<&Backtrace>;
 
     /// Whether this error is reported to Sentry

--- a/syncserver-common/src/middleware/sentry.rs
+++ b/syncserver-common/src/middleware/sentry.rs
@@ -4,6 +4,7 @@ use actix_web::{
     Error,
     dev::{Service, ServiceRequest, ServiceResponse, Transform},
 };
+use backtrace::Backtrace;
 use cadence::{CountedExt, StatsdClient};
 use futures::{FutureExt, future::LocalBoxFuture};
 use futures_util::future::{Ready, ok};
@@ -286,8 +287,8 @@ pub fn exception_from_reportable_error(err: &dyn ReportableError) -> sentry::pro
     sentry::protocol::Exception {
         ty: sentry::parse_type_from_debug(&dbg).to_owned(),
         value: Some(err.to_string()),
-        stacktrace: err
-            .backtrace()
+        stacktrace: resolved_backtrace(err)
+            .as_ref()
             .map(sentry_backtrace::backtrace_to_stacktrace)
             .unwrap_or_default(),
         ..Default::default()
@@ -311,7 +312,7 @@ fn log_event<E>(
     let backtrace = if backtrace_enabled {
         error
             .as_error::<E>()
-            .and_then(|e| e.backtrace())
+            .and_then(|e| resolved_backtrace(e))
             .map(|bt| format!("\n{bt:?}"))
             .unwrap_or_default()
     } else {
@@ -331,4 +332,15 @@ fn log_event<E>(
             .and_then(|r| r.method.as_deref())
             .unwrap_or(""),
     );
+}
+
+/// Return a resolved `Backtrace` from `ReportableError`.
+///
+/// `Backtrace::resolve` requires mutability so this clones the original `Backtrace`.
+fn resolved_backtrace(err: &dyn ReportableError) -> Option<Backtrace> {
+    let mut backtrace = err.backtrace().cloned();
+    if let Some(backtrace) = &mut backtrace {
+        backtrace.resolve();
+    }
+    backtrace
 }

--- a/syncserver-db-common/src/error.rs
+++ b/syncserver-db-common/src/error.rs
@@ -41,7 +41,7 @@ impl From<SqlErrorKind> for SqlError {
         Self {
             kind,
             status: StatusCode::INTERNAL_SERVER_ERROR,
-            backtrace: Backtrace::new(),
+            backtrace: Backtrace::new_unresolved(),
         }
     }
 }

--- a/syncserver/src/error.rs
+++ b/syncserver/src/error.rs
@@ -180,7 +180,7 @@ impl From<ApiErrorKind> for ApiError {
 
         Self {
             kind,
-            backtrace: Box::new(Backtrace::new()),
+            backtrace: Box::new(Backtrace::new_unresolved()),
             status,
         }
     }

--- a/syncstorage-db-common/src/diesel.rs
+++ b/syncstorage-db-common/src/diesel.rs
@@ -71,7 +71,7 @@ impl From<DbErrorKind> for DbError {
             _ => Self {
                 kind,
                 status: StatusCode::INTERNAL_SERVER_ERROR,
-                backtrace: Box::new(Backtrace::new()),
+                backtrace: Box::new(Backtrace::new_unresolved()),
             },
         }
     }

--- a/syncstorage-db-common/src/error.rs
+++ b/syncstorage-db-common/src/error.rs
@@ -158,7 +158,7 @@ impl From<SyncstorageDbErrorKind> for SyncstorageDbError {
         Self {
             kind,
             status,
-            backtrace: Backtrace::new(),
+            backtrace: Backtrace::new_unresolved(),
         }
     }
 }

--- a/syncstorage-spanner/src/error.rs
+++ b/syncstorage-spanner/src/error.rs
@@ -92,7 +92,7 @@ impl From<DbErrorKind> for DbError {
         Self {
             kind,
             status,
-            backtrace: Box::new(Backtrace::new()),
+            backtrace: Box::new(Backtrace::new_unresolved()),
         }
     }
 }

--- a/tokenserver-common/src/error.rs
+++ b/tokenserver-common/src/error.rs
@@ -59,7 +59,7 @@ impl Default for TokenserverError {
             description: "Unauthorized".to_owned(),
             http_status: StatusCode::UNAUTHORIZED,
             context: "Unauthorized".to_owned(),
-            backtrace: Box::new(Backtrace::new()),
+            backtrace: Box::new(Backtrace::new_unresolved()),
             tags: None,
             source: None,
         }

--- a/tokenserver-db-common/src/error.rs
+++ b/tokenserver-db-common/src/error.rs
@@ -80,7 +80,7 @@ impl From<DbErrorKind> for DbError {
             _ => Self {
                 kind,
                 status: StatusCode::INTERNAL_SERVER_ERROR,
-                backtrace: Box::new(Backtrace::new()),
+                backtrace: Box::new(Backtrace::new_unresolved()),
             },
         }
     }


### PR DESCRIPTION
## Description

This lazily resolves backtraces symbols.

A local cargo nextest run on current master:
```     Summary [  77.386s] 96 tests run: 96 passed, 0 skipped```
On this branch:
```     Summary [   8.840s] 96 tests run: 96 passed, 0 skipped```

Though I'm not sure this helps very much on a busy server, as only the first time resolving a unique frame seems to be the slowest (at least in tests) and this change incurs an extra clone of Backtrace when we emit Sentry events. 

## Issue(s)

Closes STOR-560
