### PR TITLE
chore(build): use 8.4-lts's libmysqlclient-dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,9 +24,9 @@ RUN apt-get -q update && \
         MYSQL_PKG="$MYSQLCLIENT_PKG"; \
         if [ "$MYSQLCLIENT_PKG" = libmysqlclient-dev ] ; then \
             # First install gnupg and setup MySQL repo
-            # Key ID A8D3785C from https://dev.mysql.com/doc/refman/8.0/en/checking-gpg-signature.html
+            # Key ID A8D3785C from https://dev.mysql.com/doc/refman/8.4/en/checking-gpg-signature.html
             apt-get -q install -y --no-install-recommends gnupg ca-certificates && \
-            echo "deb https://repo.mysql.com/apt/debian/ trixie mysql-8.0" >> /etc/apt/sources.list && \
+            echo "deb https://repo.mysql.com/apt/debian/ trixie mysql-8.4-lts" >> /etc/apt/sources.list && \
             # Fetch and install the MySQL public key
             gpg --batch --keyserver hkp://keyserver.ubuntu.com --recv-keys A8D3785C && \
             gpg --batch --armor --export A8D3785C | tee /etc/apt/trusted.gpg.d/mysql.asc && \
@@ -117,9 +117,9 @@ RUN apt-get -q update && \
     if [ "$MYSQLCLIENT_PKG" = libmysqlclient-dev ] ; then \
         # First install gnupg and setup MySQL repo
         apt-get install -y --no-install-recommends gnupg ca-certificates wget && \
-        echo "deb https://repo.mysql.com/apt/debian/ trixie mysql-8.0" >> /etc/apt/sources.list && \
+        echo "deb https://repo.mysql.com/apt/debian/ trixie mysql-8.4-lts" >> /etc/apt/sources.list && \
         # Fetch and install the MySQL public key
-        # Key ID A8D3785C from https://dev.mysql.com/doc/refman/8.0/en/checking-gpg-signature.html
+        # Key ID A8D3785C from https://dev.mysql.com/doc/refman/8.4/en/checking-gpg-signature.html
         gpg --batch --keyserver hkp://keyserver.ubuntu.com --recv-keys A8D3785C && \
         gpg --batch --armor --export A8D3785C | tee /etc/apt/trusted.gpg.d/mysql.asc && \
         apt-get -q update ; \


### PR DESCRIPTION
This commit removes libmysqlclient-dev and defaults to the metapackage of default-libmysqlclient-dev because libmysqlclient-dev isn't available for Trixie.  It effectively uses libmariadb-dev-compat, which was the default in Dockerfile.

The original reason of switching to the MySQL lib was that the MariaDB lib did not support TLS.  That doesn't appear to be the case anymore.
