### PR TITLE
perf: drop unused ORDER BY in old-user-record pruning queries

### DIFF
--- a/tools/tokenserver/database.py
+++ b/tools/tokenserver/database.py
@@ -86,6 +86,10 @@ where
 """)
 
 
+# No ORDER BY: pruning is destructive and `purge_old_records.py` uses a random
+# offset for sharding, so stable pagination is not required. Avoiding the sort
+# lets this stop after LIMIT+OFFSET qualifying rows instead of
+# sorting the entire matching set.
 _GET_OLD_USER_RECORDS_FOR_SERVICE = sqltext("""\
 select
     uid, email, generation, keys_changed_at, client_state,
@@ -96,14 +100,14 @@ where
     users.service = :service
 and
     replaced_at is not null and replaced_at < :timestamp
-order by
-    replaced_at desc, uid desc
 limit
     :limit
 offset
     :offset
 """)
 
+# See note on _GET_OLD_USER_RECORDS_FOR_SERVICE for why this query intentionally
+# has no ORDER BY.
 _GET_OLD_USER_RECORDS_FOR_SERVICE_RANGE = """\
 select
     uid, email, generation, keys_changed_at, client_state,
@@ -116,8 +120,6 @@ and
     ::RANGE::
 and
     replaced_at is not null and replaced_at < :timestamp
-order by
-    replaced_at desc, uid desc
 limit
     :limit
 offset

--- a/tools/tokenserver/purge_old_records.py
+++ b/tools/tokenserver/purge_old_records.py
@@ -64,7 +64,7 @@ def purge_old_records(
     logger.info("Purging old user records")
     try:
         database = Database()
-        previous_list = []
+        previous_uids = set()
         # Process batches of <max_per_loop> items, until we run out.
         while True:
             offset = random.randint(0, max_offset)
@@ -78,9 +78,10 @@ def purge_old_records(
             if not rows:
                 logger.info("No more data")
                 break
-            if rows == previous_list:
+            current_uids = {row.uid for row in rows}
+            if current_uids == previous_uids:
                 raise Exception("Loop detected")
-            previous_list = rows
+            previous_uids = current_uids
             range_msg = ""
             if uid_range:
                 range_msg = (

--- a/tools/tokenserver/test_purge_old_records.py
+++ b/tools/tokenserver/test_purge_old_records.py
@@ -135,8 +135,11 @@ def test_purging_of_old_user_records(purge_db, mock_service_server):
     assert len(service_requests) == 2
 
     # Check that the proper delete requests were made to the service.
-    expected_kids = ["0000000000450-uw", "0000000000123-qg"]
-    for i, environ in enumerate(service_requests):
+    # Order is not asserted: the underlying query intentionally has no ORDER BY
+    # (see _GET_OLD_USER_RECORDS_FOR_SERVICE), so kids are compared as a set.
+    expected_kids = {"0000000000450-uw", "0000000000123-qg"}
+    actual_kids = set()
+    for environ in service_requests:
         # They must be to the correct path.
         assert environ["REQUEST_METHOD"] == "DELETE"
         assert re.match("/1.5/[0-9]+", environ["PATH_INFO"])
@@ -148,7 +151,8 @@ def test_purging_of_old_user_records(purge_db, mock_service_server):
         assert "uid" in userdata
         assert "node" in userdata
         assert userdata["fxa_uid"] == "test"
-        assert userdata["fxa_kid"] == expected_kids[i]
+        actual_kids.add(userdata["fxa_kid"])
+    assert actual_kids == expected_kids
 
     # Check that the user's current state is unaffected
     user = database.get_user(email)


### PR DESCRIPTION
## Description

  The two `_GET_OLD_USER_RECORDS_FOR_SERVICE` queries in [database.py]( https://github.com/mozilla-services/syncstorage-rs/blob/391addb02e0775de89f50113afcabccd75e313aa/tools/tokenserver/database.py#L89) are used by
  `purge_old_records.py` sort their entire matching set by
  `(replaced_at DESC, uid DESC)` before applying LIMIT/OFFSET. In production
  the matching set is a lot of rows, so the planner must sort them
  all to hand back 10, repeated on every iteration of the purge loop, which is very much suboptimal.
  
  This removes that `ORDER BY` from both queries.
  
Also had to update relevant tests in `test_purge_old_records`since the  test enumerated service_requests by index and compared each fxa_kid positionally,  relying on the dropped ORDER BY replaced_at DESC to make the order deterministic. The test's actual intent is "both replaced records were purged with valid HAWK-signed DELETE
requests against the storage node"  order isn't part of it. Comparing as a set makes that intent explicit and keeps the test stable regardless of scan order.

## Testing

How should reviewers test?

## Issue(s)

Closes [STOR-117](https://mozilla-hub.atlassian.net/browse/STOR-117).


[STOR-117]: https://mozilla-hub.atlassian.net/browse/STOR-117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ