### PR TITLE
perf: stop count(*) when count is not used

### DIFF
--- a/syncstorage-spanner/src/db/mod.rs
+++ b/syncstorage-spanner/src/db/mod.rs
@@ -354,12 +354,12 @@ impl SpannerDb {
              AND collection_id = @collection_id
            GROUP BY fxa_uid"
         } else {
-            "SELECT COUNT(*)
+            "SELECT 1
             FROM bsos
            WHERE fxa_uid = @fxa_uid
              AND fxa_kid = @fxa_kid
              AND collection_id = @collection_id
-           GROUP BY fxa_uid"
+           LIMIT 1"
         };
 
         let result = {


### PR DESCRIPTION
For the Spanner backend we count the number of bsos for a given uid+kid+collection_id, but then we ingore the actual value.  This patch updates the query to see if there are any rows.


## Issue(s)

Closes STOR-215
