### PR TITLE
chore(deps): upgrade diesel to 2.3.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1051,7 +1051,7 @@ dependencies = [
  "downcast-rs",
  "itoa",
  "pq-sys",
- "uuid 0.8.2",
+ "uuid 1.22.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1040,9 +1040,9 @@ dependencies = [
 
 [[package]]
 name = "diesel"
-version = "2.3.6"
+version = "2.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b6c2fc184a6fb6ebcf5f9a5e3bbfa84d8fd268cdfcce4ed508979a6259494d"
+checksum = "9940fb8467a0a06312218ed384185cb8536aa10d8ec017d0ce7fad2c1bd882d5"
 dependencies = [
  "bitflags 2.11.0",
  "byteorder",
@@ -1051,7 +1051,7 @@ dependencies = [
  "downcast-rs",
  "itoa",
  "pq-sys",
- "uuid 1.22.0",
+ "uuid 0.8.2",
 ]
 
 [[package]]


### PR DESCRIPTION
https://github.com/mozilla-services/syncstorage-rs/pull/2280 but with a newer version of uuid for diesel.