### PR TITLE
chore: remove references to the long gone batch expiry index

### DIFF
--- a/syncstorage-spanner/src/batch_index.sql
+++ b/syncstorage-spanner/src/batch_index.sql
@@ -1,8 +1,0 @@
-CREATE INDEX BatchExpireId
-ON batches (
-	fxa_uid,
-	fxa_kid,
-	collection_id,
-	expiry
-), INTERLEAVE IN user_collections
-

--- a/syncstorage-spanner/src/schema.ddl
+++ b/syncstorage-spanner/src/schema.ddl
@@ -60,10 +60,6 @@ CREATE TABLE batches (
 )    PRIMARY KEY(fxa_uid, fxa_kid, collection_id, batch_id),
   INTERLEAVE IN PARENT user_collections ON DELETE CASCADE;
 
-    CREATE INDEX BatchExpireId
-        ON batches(fxa_uid, fxa_kid, collection_id, expiry),
-INTERLEAVE IN user_collections;
-
 CREATE TABLE batch_bsos (
   fxa_uid STRING(MAX)      NOT NULL,
   fxa_kid STRING(MAX)      NOT NULL,


### PR DESCRIPTION
its original version caused a hot spot, this updated version didn't help so it was ultimately removed:
https://github.com/mozilla-services/syncstorage-rs/issues/706

## Issue(s)

Closes STOR-566
