### PR TITLE
chore: add Spanner ttl based deletion policy DDL to schema.ddl

### DIFF
--- a/syncstorage-spanner/src/batch_index.sql
+++ b/syncstorage-spanner/src/batch_index.sql
@@ -1,8 +1,0 @@
-CREATE INDEX BatchExpireId
-ON batches (
-	fxa_uid,
-	fxa_kid,
-	collection_id,
-	expiry
-), INTERLEAVE IN user_collections
-

--- a/syncstorage-spanner/src/schema.ddl
+++ b/syncstorage-spanner/src/schema.ddl
@@ -60,10 +60,6 @@ CREATE TABLE batches (
 )    PRIMARY KEY(fxa_uid, fxa_kid, collection_id, batch_id),
   INTERLEAVE IN PARENT user_collections ON DELETE CASCADE;
 
-    CREATE INDEX BatchExpireId
-        ON batches(fxa_uid, fxa_kid, collection_id, expiry),
-INTERLEAVE IN user_collections;
-
 CREATE TABLE batch_bsos (
   fxa_uid STRING(MAX)      NOT NULL,
   fxa_kid STRING(MAX)      NOT NULL,

--- a/syncstorage-spanner/src/schema.ddl
+++ b/syncstorage-spanner/src/schema.ddl
@@ -81,3 +81,11 @@ CREATE TABLE batch_bsos (
 -- *NOTE*:
 -- Newly created Spanner instances should pre-populate the `collections` table by
 -- running the content of `insert_standard_collections.sql `
+
+
+-- Have Spanner manage ttl based deletion.
+ALTER TABLE bsos
+    ADD ROW DELETION POLICY (OLDER_THAN(expiry, INTERVAL 0 DAY));
+ALTER TABLE batches
+    ADD ROW DELETION POLICY (OLDER_THAN(expiry, INTERVAL 0 DAY));
+


### PR DESCRIPTION
Part of STOR-121, where we want to use Spanner's managed TTL feature.

The change itself follows https://github.com/mozilla-services/syncstorage-rs/pull/2310 since that edits schema.ddl as well.

