### PR TITLE
chore(settings): fail fast when DATABASE_URL is unset

### DIFF
--- a/config/local.example.toml
+++ b/config/local.example.toml
@@ -4,6 +4,8 @@ master_secret = "INSERT_SECRET_KEY_HERE"
 human_logs = 1
 
 # Example Syncstorage settings:
+# database_url is required when syncstorage is enabled; there is no default,
+# and the server fails to start if it is unset.
 # Example MySQL DSN:
 syncstorage.database_url = "mysql://sample_user:sample_password@localhost/syncstorage_rs"
 # Example Spanner DSN:
@@ -16,6 +18,8 @@ syncstorage.enabled = true
 syncstorage.limits.max_total_records = 1666 # See issues #298/#333
 
 # Example Tokenserver settings:
+# database_url is required when tokenserver is enabled; there is no default,
+# and the server fails to start if it is unset.
 tokenserver.database_url = "mysql://sample_user:sample_password@localhost/tokenserver_rs"
 tokenserver.enabled = true
 tokenserver.fxa_email_domain = "api-accounts.stage.mozaws.net"

--- a/syncserver-settings/src/lib.rs
+++ b/syncserver-settings/src/lib.rs
@@ -148,6 +148,19 @@ impl Settings {
     }
 
     pub fn validate(&self) -> Result<(), ConfigError> {
+        // Fail fast if an enabled service has no DATABASE_URL configured,
+        // rather than silently falling back to a default connection string.
+        if self.syncstorage.enabled && self.syncstorage.database_url.is_empty() {
+            return Err(ConfigError::Message(
+                "SYNC_SYNCSTORAGE__DATABASE_URL must be set".to_owned(),
+            ));
+        }
+        if self.tokenserver.enabled && self.tokenserver.database_url.is_empty() {
+            return Err(ConfigError::Message(
+                "SYNC_TOKENSERVER__DATABASE_URL must be set".to_owned(),
+            ));
+        }
+
         if let Some(init_node_url) = &self.tokenserver.init_node_url {
             let url = Url::parse(init_node_url).map_err(|e| {
                 ConfigError::Message(format!("Invalid SYNC_TOKENSERVER__INIT_NODE_URL: {e}"))
@@ -307,24 +320,106 @@ impl<'d> Deserialize<'d> for Secrets {
 mod test {
     use super::*;
 
+    // A syncstorage DATABASE_URL is required to pass validation, since
+    // syncstorage is enabled by default. Tests that exercise unrelated config
+    // must supply one explicitly so they don't depend on the ambient env.
+    const TEST_SYNCSTORAGE_DATABASE_URL: &str = "mysql://root@127.0.0.1/syncstorage";
+    const TEST_TOKENSERVER_DATABASE_URL: &str = "mysql://root@127.0.0.1/tokenserver";
+
     #[test]
     fn test_environment_variable_prefix() {
         // Setting an environment variable with the correct prefix correctly sets the setting
         // (note that the default value for the settings.tokenserver.enabled setting is false)
-        temp_env::with_var("SYNC_TOKENSERVER__ENABLED", Some("true"), || {
-            let settings = Settings::with_env_and_config_file(None).unwrap();
-            assert!(settings.tokenserver.enabled);
-        });
+        temp_env::with_vars(
+            [
+                (
+                    "SYNC_SYNCSTORAGE__DATABASE_URL",
+                    Some(TEST_SYNCSTORAGE_DATABASE_URL),
+                ),
+                (
+                    "SYNC_TOKENSERVER__DATABASE_URL",
+                    Some(TEST_TOKENSERVER_DATABASE_URL),
+                ),
+                ("SYNC_TOKENSERVER__ENABLED", Some("true")),
+            ],
+            || {
+                let settings = Settings::with_env_and_config_file(None).unwrap();
+                assert!(settings.tokenserver.enabled);
+            },
+        );
 
         // Setting an environment variable with the incorrect prefix does not set the setting
         temp_env::with_vars(
             [
+                (
+                    "SYNC_SYNCSTORAGE__DATABASE_URL",
+                    Some(TEST_SYNCSTORAGE_DATABASE_URL),
+                ),
                 ("SYNC_TOKENSERVER__ENABLED", None),
                 ("SYNC__TOKENSERVER__ENABLED", Some("true")),
             ],
             || {
                 let settings = Settings::with_env_and_config_file(None).unwrap();
                 assert!(!settings.tokenserver.enabled);
+            },
+        );
+    }
+
+    #[test]
+    fn test_missing_syncstorage_database_url_fails_fast() {
+        // syncstorage is enabled by default, so an unset DATABASE_URL must
+        // produce an error rather than fall back to a default value.
+        temp_env::with_vars(
+            [
+                ("SYNC_SYNCSTORAGE__DATABASE_URL", None::<&str>),
+                ("SYNC_TOKENSERVER__DATABASE_URL", None),
+                ("SYNC_TOKENSERVER__ENABLED", None),
+            ],
+            || {
+                let err = Settings::with_env_and_config_file(None)
+                    .expect_err("an unset syncstorage DATABASE_URL should fail validation");
+                assert!(err.to_string().contains("SYNC_SYNCSTORAGE__DATABASE_URL"));
+            },
+        );
+    }
+
+    #[test]
+    fn test_missing_tokenserver_database_url_fails_fast_when_enabled() {
+        // An enabled Tokenserver with no DATABASE_URL must fail fast.
+        temp_env::with_vars(
+            [
+                (
+                    "SYNC_SYNCSTORAGE__DATABASE_URL",
+                    Some(TEST_SYNCSTORAGE_DATABASE_URL),
+                ),
+                ("SYNC_TOKENSERVER__DATABASE_URL", None),
+                ("SYNC_TOKENSERVER__ENABLED", Some("true")),
+            ],
+            || {
+                let err = Settings::with_env_and_config_file(None)
+                    .expect_err("an unset tokenserver DATABASE_URL should fail when enabled");
+                assert!(err.to_string().contains("SYNC_TOKENSERVER__DATABASE_URL"));
+            },
+        );
+    }
+
+    #[test]
+    fn test_disabled_tokenserver_does_not_require_database_url() {
+        // A disabled Tokenserver should not require a DATABASE_URL.
+        temp_env::with_vars(
+            [
+                (
+                    "SYNC_SYNCSTORAGE__DATABASE_URL",
+                    Some(TEST_SYNCSTORAGE_DATABASE_URL),
+                ),
+                ("SYNC_TOKENSERVER__DATABASE_URL", None),
+                ("SYNC_TOKENSERVER__ENABLED", Some("false")),
+            ],
+            || {
+                let settings = Settings::with_env_and_config_file(None)
+                    .expect("a disabled tokenserver should not require a DATABASE_URL");
+                assert!(!settings.tokenserver.enabled);
+                assert!(settings.tokenserver.database_url.is_empty());
             },
         );
     }

--- a/syncstorage-settings/src/lib.rs
+++ b/syncstorage-settings/src/lib.rs
@@ -69,6 +69,11 @@ impl From<&Settings> for Deadman {
 #[derive(Clone, Debug, Deserialize)]
 #[serde(default)]
 pub struct Settings {
+    /// The syncstorage database connection string.
+    ///
+    /// Has no usable default: when unset this is left empty so the server
+    /// fails fast at startup (see `syncserver_settings::Settings::validate`)
+    /// rather than silently connecting to a default host.
     pub database_url: String,
     pub database_pool_max_size: u32,
     /// Pool timeout when waiting for a slot to become available, in seconds
@@ -109,7 +114,9 @@ pub struct Settings {
 impl Default for Settings {
     fn default() -> Settings {
         Settings {
-            database_url: "mysql://root@127.0.0.1/syncstorage".to_string(),
+            // Intentionally empty: a missing DATABASE_URL must fail fast at
+            // startup rather than fall back to a default connection string.
+            database_url: String::new(),
             database_pool_max_size: 10,
             database_pool_connection_lifespan: None,
             database_pool_connection_max_idle: None,

--- a/tokenserver-settings/src/lib.rs
+++ b/tokenserver-settings/src/lib.rs
@@ -6,6 +6,11 @@ use tokenserver_common::NodeType;
 #[serde(default)]
 pub struct Settings {
     /// The URL of the Tokenserver MySQL database.
+    ///
+    /// Has no usable default: when unset (and Tokenserver is enabled) this is
+    /// left empty so the server fails fast at startup (see
+    /// `syncserver_settings::Settings::validate`) rather than silently
+    /// connecting to a default host.
     pub database_url: String,
     /// The max size of the database connection pool.
     pub database_pool_max_size: u32,
@@ -71,7 +76,9 @@ pub struct Settings {
 impl Default for Settings {
     fn default() -> Settings {
         Settings {
-            database_url: "mysql://root@127.0.0.1/tokenserver".to_owned(),
+            // Intentionally empty: a missing DATABASE_URL must fail fast at
+            // startup rather than fall back to a default connection string.
+            database_url: String::new(),
             database_pool_max_size: 10,
             database_pool_connection_timeout: Some(30),
             database_request_timeout: None,


### PR DESCRIPTION
Previously the syncstorage and tokenserver settings defaulted database_url to "mysql://root@127.0.0.1/syncstorage" and "mysql://root@127.0.0.1/tokenserver" respectively. A missing SYNC_SYNCSTORAGE__DATABASE_URL or SYNC_TOKENSERVER__DATABASE_URL would therefore silently fall back to a local default rather than surfacing the misconfiguration.

The defaults are now empty, and Settings::validate() returns an error at startup when an enabled service has no database_url configured, naming the exact environment variable that must be set. A disabled service does not require its database_url.

Closes [STOR-545](hhttps://mozilla-hub.atlassian.net/browse/STOR-545)


[STOR-545]: https://mozilla-hub.atlassian.net/browse/STOR-545?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ