### PR TITLE
fix: use ms for generation value in account webhook event

### DIFF
--- a/syncserver/src/tokenserver/handlers.rs
+++ b/syncserver/src/tokenserver/handlers.rs
@@ -308,7 +308,7 @@ pub async fn handle_fxa_events(
                     db.update_user_generation(UpdateUserGeneration {
                         service_id,
                         email,
-                        generation: Some(change_time_ms / 1000 - 1),
+                        generation: Some(change_time_ms - 1),
                         keys_changed_at: None,
                     })
                     .await?;
@@ -612,7 +612,7 @@ mod tests {
         );
         assert_eq!(
             update_user_generation_calls[0].generation,
-            Some(change_time_ms / 1000 - 1)
+            Some(change_time_ms - 1)
         );
         assert_eq!(update_user_generation_calls[0].keys_changed_at, None);
 


### PR DESCRIPTION
## Description

The account event webhook handler has a bug where a timestamp value was necessarily divided by 1000.

## Issue(s)

follow-up to / fixes bug from https://github.com/mozilla-services/syncstorage-rs/pull/2108
