### PR TITLE
chore(ci): add ssdlc sbom workflow

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,0 +1,22 @@
+name: ssdlc-sbom
+
+on:
+  release:
+    types: [published]
+  push:
+    branches:
+      - 'release/**'
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  sbom:
+    uses: mozilla/ssdlc-actions/.github/workflows/ssdlc-sbom.yml@5cc2b20e42d53d1643853f12244fbec9ed2f2e0c
+    with:
+      sbom_name: ${{ github.event.release.tag_name || github.sha }}
+    permissions:
+      actions: read       # required by anchore/sbom-action to read workflow run context
+      contents: write     # required to upload the SBOM as a release asset

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -5,18 +5,26 @@ on:
     types: [published]
   push:
     branches:
-      - 'release/**'
+      - "release/**"
     tags:
-      - '[0-9]+.[0-9]+.[0-9]+'
+      - "[0-9]+.[0-9]+.[0-9]+"
   workflow_dispatch:
 
 permissions: {}
+
+# Coalesce duplicate runs for the same ref. A GitHub-UI release publish on a
+# fresh tag fires both `release: published` and `push: tags`
+# so the workflow runs twice in parallel for the same tag and uploads the SBOM
+# twice. Grouping by ref_name keeps a single run per release.
+concurrency:
+  group: ssdlc-sbom-${{ github.ref_name }}
+  cancel-in-progress: true
 
 jobs:
   sbom:
     uses: mozilla/ssdlc-actions/.github/workflows/ssdlc-sbom.yml@5cc2b20e42d53d1643853f12244fbec9ed2f2e0c
     with:
-      sbom_name: ${{ github.event.release.tag_name || github.sha }}
+      sbom_name: ${{ github.ref_name }}
     permissions:
-      actions: read       # required by anchore/sbom-action to read workflow run context
-      contents: write     # required to upload the SBOM as a release asset
+      actions: read # required by anchore/sbom-action to read workflow run context
+      contents: write # required to upload the SBOM as a release asset


### PR DESCRIPTION
## Description

Adds a Mozilla SSDLC SBOM (Software Bill of Materials) GitHub Actions workflow. Supersedes #2339 (by @clouserw), reconciling the review feedback left on that PR.

Jira: [STOR-591](https://mozilla-hub.atlassian.net/browse/STOR-591) 

## Changes reconciled from review of #2339

- **Reusable workflow path** — call `mozilla/ssdlc-actions/.github/workflows/ssdlc-sbom.yml` (was `mozilla/actions/.../sbom.yml`).
- **`with` block** — pass the required `sbom_name: ${{ github.event.release.tag_name || github.sha }}` input.
- **Triggers** — add a bare semver tag trigger (`[0-9]+.[0-9]+.[0-9]+`) alongside `release/**` branch pushes, matching our actual release/tag convention (tags and branch filters are independent in GHA).
- **Permissions** — scope `actions: read` / `contents: write` to the job, leaving the top-level workflow `permissions: {}`.

## Triggers

- `release: [published]`
- `push` to `release/**` branches and bare semver tags
- `workflow_dispatch`

See the Jira ticket for a like to the Google Drive SBOM plan
Closes STOR-591

[STOR-591]: https://mozilla-hub.atlassian.net/browse/STOR-591?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[STOR-535]: https://mozilla-hub.atlassian.net/browse/STOR-535?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ