### PR TITLE
feat: combine dependabot PRs via github/combine-prs

### DIFF
--- a/.github/workflows/combine-dependabot-prs.yml
+++ b/.github/workflows/combine-dependabot-prs.yml
@@ -1,0 +1,43 @@
+name: Combine Dependabot PRs
+
+# Folds the month's open Dependabot PRs into a single "Combined PRs" PR to cut
+# review noise. Dependabot grouping already merges within each ecosystem, but it
+# cannot merge across groups (cargo dev vs prod), across directories (pip), or
+# across ecosystems -- this sweeps up that remainder.
+#
+# NOTE on CI: the combined PR is opened with the default GITHUB_TOKEN, so by
+# GitHub's anti-recursion rule it does NOT trigger the pull_request workflows.
+# `ci_required: true` guarantees each source PR already passed CI individually;
+# to validate the *combination*, close and reopen the combined PR (a human
+# reopen fires pull_request) so the Main Workflow runs before merge.
+
+on:
+  # Dependabot runs monthly (see .github/dependabot.yml); run a few days later
+  # to sweep up that batch. No-op unless >= min_combine_number PRs are open.
+  schedule:
+    - cron: "0 6 8 * *"
+  workflow_dispatch:
+
+# Don't let a manual run race a scheduled run.
+concurrency:
+  group: combine-dependabot-prs
+  cancel-in-progress: false
+
+jobs:
+  combine-prs:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Combine Dependabot PRs
+        uses: github/combine-prs@2909f404763c3177a456e052bdb7f2e85d3a7cb3 # v5.2.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # All Dependabot branches share the "dependabot" prefix.
+          branch_prefix: dependabot
+          # Only combine PRs that have already passed CI individually.
+          ci_required: "true"
+          pr_title: "chore(deps): combine dependabot pull requests"
+          # Carry the same label Dependabot applies, so filters keep working.
+          labels: dependencies


### PR DESCRIPTION
## Summary

Adds `.github/workflows/combine-dependabot-prs.yml`, which uses [`github/combine-prs`](https://github.com/github/combine-prs) (SHA-pinned to `v5.2.0`) to fold the month's remaining open Dependabot PRs into a single combined PR.

Dependabot grouping already merges updates *within* each ecosystem, but it cannot merge:
- across groups — cargo `dev-deps` vs `prod-deps`
- across directories — pip is grouped per-directory across the 8 listed dirs
- across ecosystems — cargo / pip / github-actions

This sweeps up that remainder. It **complements** `dependabot.yml`, no change to the existing config.

**Behavior:** runs monthly (`0 6 8 * *`, a few days after Dependabot's monthly batch) plus manual `workflow_dispatch`; a no-op when fewer than 2 PRs are open. Combined PR is labeled `dependencies` to match Dependabot.

## Caveats on why we may choose not to land this

1. **No CI on the combined PR.** It's opened with the default `GITHUB_TOKEN`, so GitHub's anti-recursion rule prevents it from triggering the `pull_request` workflows — the combined PR gets no CI of its own. `ci_required: true` ensures each *source* PR passed CI individually, but the *combination* isn't tested until a human **closes and reopens** the combined PR (a human reopen fires `pull_request`). Auto-CI would require a GitHub App token or PAT i.e. new secrets, which this repo deliberately minimizes. Could be a separate follow-up if desired.
2. **Dependabot-prefix only.** Only branches with the `dependabot` prefix are combined; any future non-dependabot bot PRs won't be swept in.
3. **Live verification needed.** YAML validated locally, but behavior against real PRs can only be confirmed on GitHub. After merge, trigger manually via the Actions tab while ≥2 Dependabot PRs are open.

Closes STOR-577