### PR TITLE
fix: do not validate `exp` on FxA event tokens

### DIFF
--- a/syncserver/src/tokenserver/extractors.rs
+++ b/syncserver/src/tokenserver/extractors.rs
@@ -1381,7 +1381,6 @@ mod tests {
             "quux",
             "testo",
             serde_json::json!({"https://schemas.accounts.firefox.com/event/delete-user": {}}),
-            3600,
             TEST_PRIVATE_KEY_PEM,
         );
         let req = TestRequest::default()
@@ -1404,7 +1403,6 @@ mod tests {
             "quux",
             "testo",
             serde_json::json!({}),
-            3600,
             OTHER_PRIVATE_KEY_PEM,
         );
         let req = TestRequest::default()
@@ -1425,13 +1423,7 @@ mod tests {
     #[actix_rt::test]
     async fn test_fxa_webhook_no_verifiers() {
         let state = make_webhook_state(vec![]);
-        let token = make_set(
-            "quux",
-            "testo",
-            serde_json::json!({}),
-            3600,
-            TEST_PRIVATE_KEY_PEM,
-        );
+        let token = make_set("quux", "testo", serde_json::json!({}), TEST_PRIVATE_KEY_PEM);
         let req = TestRequest::default()
             .app_data(Data::new(state))
             .insert_header(("Authorization", format!("Bearer {token}")))

--- a/syncserver/src/tokenserver/handlers.rs
+++ b/syncserver/src/tokenserver/handlers.rs
@@ -504,28 +504,7 @@ mod tests {
             "quux",
             "testo",
             json!({"https://schemas.accounts.firefox.com/event/delete-user": {}}),
-            3600,
             OTHER_PRIVATE_KEY_PEM,
-        );
-        let req = TestRequest::post()
-            .uri("/1.0/webhooks/fxa/events")
-            .insert_header(("Authorization", format!("Bearer {token}")))
-            .to_request();
-        let resp = test::call_service(&app, req).await;
-        assert_eq!(resp.status(), 401);
-    }
-
-    #[actix_web::test]
-    async fn test_expired_token() {
-        let verifier =
-            SETVerifierImpl::new(&test_jwk(), "testo", "https://accounts.firefox.com/").unwrap();
-        let app = make_app(vec![verifier]).await;
-        let token = make_set(
-            "quux",
-            "testo",
-            json!({"https://schemas.accounts.firefox.com/event/delete-user": {}}),
-            -3600,
-            TEST_PRIVATE_KEY_PEM,
         );
         let req = TestRequest::post()
             .uri("/1.0/webhooks/fxa/events")
@@ -544,7 +523,6 @@ mod tests {
             "quux",
             "some-other-RP",
             json!({"https://schemas.accounts.firefox.com/event/delete-user": {}}),
-            3600,
             TEST_PRIVATE_KEY_PEM,
         );
         let req = TestRequest::post()
@@ -562,7 +540,6 @@ mod tests {
             "quux",
             "testo",
             json!({"https://schemas.accounts.firefox.com/event/delete-user": {}}),
-            3600,
             TEST_PRIVATE_KEY_PEM,
         );
         let req = TestRequest::post()
@@ -584,7 +561,6 @@ mod tests {
             "quux",
             "testo",
             json!({"https://schemas.accounts.firefox.com/event/delete-user": {}}),
-            3600,
             TEST_PRIVATE_KEY_PEM,
         );
         let req = TestRequest::post()
@@ -610,7 +586,6 @@ mod tests {
             "quux",
             "testo",
             json!({"https://schemas.accounts.firefox.com/event/delete-user": {}}),
-            3600,
             TEST_PRIVATE_KEY_PEM,
         );
         let req = TestRequest::post()
@@ -638,7 +613,6 @@ mod tests {
             "quux",
             "testo",
             json!({"https://schemas.accounts.firefox.com/event/password-change": {"changeTime": change_time_ms}}),
-            3600,
             TEST_PRIVATE_KEY_PEM,
         );
         let req = TestRequest::post()
@@ -673,7 +647,6 @@ mod tests {
             "quux",
             "testo",
             json!({"https://schemas.accounts.firefox.com/event/unknown-event": {}}),
-            3600,
             TEST_PRIVATE_KEY_PEM,
         );
         let req = TestRequest::post()

--- a/tokenserver-auth/src/crypto.rs
+++ b/tokenserver-auth/src/crypto.rs
@@ -196,7 +196,8 @@ impl SETVerifierImpl {
         let mut validation = Validation::new(Algorithm::RS256);
         validation.set_audience(&[client_id]);
         validation.set_issuer(&[issuer_url]);
-        validation.validate_exp = true;
+        // jsonwebtoken validates `exp` by default
+        validation.required_spec_claims.remove("exp");
         Ok(Self {
             key: decoding_key,
             validation,
@@ -223,7 +224,6 @@ mod tests {
             "quux",
             "testo",
             json!({"https://schemas.accounts.firefox.com/event/delete-user": {}}),
-            3600,
             TEST_PRIVATE_KEY_PEM,
         );
         let claims: FxaWebhookClaims = verifier.verify(&token).unwrap();
@@ -232,19 +232,27 @@ mod tests {
     }
 
     #[test]
-    fn test_verify_expired_set() {
+    fn test_verify_wrong_audience_set() {
         let verifier =
             SETVerifierImpl::new(&test_jwk(), "testo", "https://accounts.firefox.com/").unwrap();
-        let token = make_set("quux", "testo", json!({}), -3600, TEST_PRIVATE_KEY_PEM);
-        let err = verifier.verify::<FxaWebhookClaims>(&token).unwrap_err();
-        assert!(matches!(err, JWTVerifyError::ExpiredSignature));
+        let token = make_set("quux", "wrong-client-id", json!({}), TEST_PRIVATE_KEY_PEM);
+        assert!(verifier.verify::<FxaWebhookClaims>(&token).is_err());
+    }
+
+    #[test]
+    fn test_verify_wrong_issuer_set() {
+        let verifier =
+            SETVerifierImpl::new(&test_jwk(), "testo", "https://accounts.stage.mozaws.net")
+                .unwrap();
+        let token = make_set("quux", "testo", json!({}), TEST_PRIVATE_KEY_PEM);
+        assert!(verifier.verify::<FxaWebhookClaims>(&token).is_err());
     }
 
     #[test]
     fn test_verify_wrong_key_set() {
         let verifier =
             SETVerifierImpl::new(&test_jwk(), "testo", "https://accounts.firefox.com/").unwrap();
-        let token = make_set("quux", "testo", json!({}), 3600, OTHER_PRIVATE_KEY_PEM);
+        let token = make_set("quux", "testo", json!({}), OTHER_PRIVATE_KEY_PEM);
         let err = verifier.verify::<FxaWebhookClaims>(&token).unwrap_err();
         assert!(matches!(err, JWTVerifyError::InvalidSignature));
     }

--- a/tokenserver-auth/src/test_utils.rs
+++ b/tokenserver-auth/src/test_utils.rs
@@ -74,14 +74,9 @@ pub fn test_jwk() -> Jwk {
     serde_json::from_str(TEST_JWK).unwrap()
 }
 
-/// Sign a SET with the given PEM.
-pub fn make_set(
-    sub: &str,
-    aud: &str,
-    events: serde_json::Value,
-    exp_offset_secs: i64,
-    private_key_pem: &[u8],
-) -> String {
+/// Sign a SET with the given PEM. Mirrors the claims the FxA Event Broker emits: {iss, aud, sub,
+/// iat, jti, events}
+pub fn make_set(sub: &str, aud: &str, events: serde_json::Value, private_key_pem: &[u8]) -> String {
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap()
@@ -91,7 +86,6 @@ pub fn make_set(
         "sub": sub,
         "aud": aud,
         "iat": now,
-        "exp": now + exp_offset_secs,
         "jti": "wibble",
         "events": events,
     });


### PR DESCRIPTION
SETs from FxA Event Broker do not include a `exp`.  Meanwhile the `jsonwebtoken` crate validates `exp` by default.  This patch disables the `exp` validation.