### PR TITLE
feat: add optional per-collection storage limit overrides

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4931,6 +4931,7 @@ version = "0.23.3"
 dependencies = [
  "rand 0.10.1",
  "serde",
+ "serde_json",
  "syncserver-common",
 ]
 

--- a/docs/src/config.md
+++ b/docs/src/config.md
@@ -73,6 +73,7 @@ The following configuration options are available.
 | <span id="SYNC_SYNCSTORAGE__LIMITS__MAX_TOTAL_BYTES"></span>SYNC_SYNCSTORAGE__LIMITS__MAX_TOTAL_BYTES | 262,144,000 | Max BSO payload size per batch |
 | <span id="SYNC_SYNCSTORAGE__LIMITS__MAX_TOTAL_RECORDS"></span>SYNC_SYNCSTORAGE__LIMITS__MAX_TOTAL_RECORDS | 10,000 | Max BSO count per batch |
 | <span id="SYNC_SYNCSTORAGE__LIMITS__MAX_QUOTA_LIMIT"></span>SYNC_SYNCSTORAGE__LIMITS__MAX_QUOTA_LIMIT | 2,147,483,648 | Max storage quota per user (2 GB) |
+| <span id="SYNC_SYNCSTORAGE__LIMITS__COLLECTIONS"></span>SYNC_SYNCSTORAGE__LIMITS__COLLECTIONS | unset | Optional per-collection limit overrides, as a JSON object mapping collection name -> limits object (e.g. `{"tabs":{"max_record_payload_bytes":202020}}`). Only `max_record_payload_bytes` is supported currently. |
 
 ### Syncstorage Features
 

--- a/syncserver-settings/src/lib.rs
+++ b/syncserver-settings/src/lib.rs
@@ -168,6 +168,16 @@ impl Settings {
             ));
         }
 
+        // overriding limits must be > 0.
+        for (name, overrides) in &self.syncstorage.limits.collections {
+            if overrides.max_record_payload_bytes == Some(0) {
+                return Err(ConfigError::Message(format!(
+                    "Invalid SYNC_SYNCSTORAGE__LIMITS__COLLECTIONS: \
+                     \"{name}\" max_record_payload_bytes must be greater than 0"
+                )));
+            }
+        }
+
         if let Some(init_node_url) = &self.tokenserver.init_node_url {
             let url = Url::parse(init_node_url).map_err(|e| {
                 ConfigError::Message(format!("Invalid SYNC_TOKENSERVER__INIT_NODE_URL: {e}"))
@@ -406,6 +416,60 @@ mod test {
                 let err = Settings::with_env_and_config_file(None)
                     .expect_err("an unset tokenserver DATABASE_URL should fail when enabled");
                 assert!(err.to_string().contains("SYNC_TOKENSERVER__DATABASE_URL"));
+            },
+        );
+    }
+
+    #[test]
+    fn test_collection_limits_override_validates() {
+        temp_env::with_vars(
+            [
+                (
+                    "SYNC_SYNCSTORAGE__DATABASE_URL",
+                    Some(TEST_SYNCSTORAGE_DATABASE_URL),
+                ),
+                ("SYNC_TOKENSERVER__DATABASE_URL", None),
+                ("SYNC_TOKENSERVER__ENABLED", None),
+                (
+                    "SYNC_SYNCSTORAGE__LIMITS__COLLECTIONS",
+                    Some(r#"{"newtab-images":{"max_record_payload_bytes":20971520}}"#),
+                ),
+            ],
+            || {
+                let settings = Settings::with_env_and_config_file(None)
+                    .expect("a collection limits override should validate");
+                assert_eq!(
+                    settings
+                        .syncstorage
+                        .limits
+                        .collections
+                        .get("newtab-images")
+                        .and_then(|o| o.max_record_payload_bytes),
+                    Some(20_971_520)
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn test_zero_collection_override_fails() {
+        temp_env::with_vars(
+            [
+                (
+                    "SYNC_SYNCSTORAGE__DATABASE_URL",
+                    Some(TEST_SYNCSTORAGE_DATABASE_URL),
+                ),
+                ("SYNC_TOKENSERVER__DATABASE_URL", None),
+                ("SYNC_TOKENSERVER__ENABLED", None),
+                (
+                    "SYNC_SYNCSTORAGE__LIMITS__COLLECTIONS",
+                    Some(r#"{"tabs":{"max_record_payload_bytes":0}}"#),
+                ),
+            ],
+            || {
+                let err = Settings::with_env_and_config_file(None)
+                    .expect_err("a zero override should fail");
+                assert!(err.to_string().contains("must be greater than 0"));
             },
         );
     }

--- a/syncserver/src/server/mod.rs
+++ b/syncserver/src/server/mod.rs
@@ -399,8 +399,7 @@ impl Server {
         let worker_thread_count =
             calculate_worker_max_blocking_threads(settings.worker_max_blocking_threads);
         let limits = Arc::new(settings.syncstorage.limits);
-        let limits_json =
-            serde_json::to_string(&*limits).expect("ServerLimits failed to serialize");
+        let limits_json = build_limits_json(&limits);
         let secrets = Arc::new(settings.master_secret);
         let quota_enabled = settings.syncstorage.enable_quota;
         let actix_keep_alive = settings.actix_keep_alive;
@@ -527,6 +526,21 @@ impl Server {
 fn calculate_worker_max_blocking_threads(count: usize) -> usize {
     let parallelism = std::thread::available_parallelism().map_or(2, NonZeroUsize::get);
     std::cmp::max(count / parallelism, 1)
+}
+
+/// Serializes `ServerLimits`, then injects a `collections` section for any overrides.
+pub(crate) fn build_limits_json(limits: &ServerLimits) -> String {
+    let mut value = serde_json::to_value(limits).expect("ServerLimits failed to serialize");
+    if !limits.collections.is_empty()
+        && let Some(obj) = value.as_object_mut()
+    {
+        obj.insert(
+            "collections".to_owned(),
+            serde_json::to_value(&limits.collections)
+                .expect("collection overrides failed to serialize"),
+        );
+    }
+    serde_json::to_string(&value).expect("ServerLimits failed to serialize")
 }
 
 fn build_cors(settings: &Settings) -> Cors {

--- a/syncserver/src/server/test.rs
+++ b/syncserver/src/server/test.rs
@@ -979,3 +979,32 @@ async fn put_bso_offloads_to_gcs() {
         resp.response()
     );
 }
+
+fn limits_with_override(name: &str, max_record_payload_bytes: u32) -> ServerLimits {
+    let mut limits = ServerLimits::default();
+    limits.collections.insert(
+        name.to_owned(),
+        syncstorage_settings::CollectionLimitOverride {
+            max_record_payload_bytes: Some(max_record_payload_bytes),
+        },
+    );
+    limits
+}
+
+#[::core::prelude::v1::test]
+fn limits_json_advertises_collection_overrides() {
+    let limits = limits_with_override("newtab-images", 20_971_520);
+    let json: Value = serde_json::from_str(&build_limits_json(&limits)).unwrap();
+    assert_eq!(
+        json["collections"]["newtab-images"]["max_record_payload_bytes"],
+        json!(20_971_520)
+    );
+    assert!(json.get("max_record_payload_bytes").is_some());
+}
+
+#[::core::prelude::v1::test]
+fn limits_json_omits_collections_when_none_overridden() {
+    let json: Value = serde_json::from_str(&build_limits_json(&ServerLimits::default())).unwrap();
+    assert!(json.get("collections").is_none());
+    assert!(json.get("max_record_payload_bytes").is_some());
+}

--- a/syncserver/src/web/extractors/bso_bodies.rs
+++ b/syncserver/src/web/extractors/bso_bodies.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
 use actix_web::{
-    Error, FromRequest, HttpRequest,
+    Error, FromRequest, HttpMessage, HttpRequest,
     dev::Payload,
     http::header::{ContentType, Header},
     web::Data,
@@ -13,7 +13,7 @@ use futures::{
 use serde::Deserialize;
 use serde_json::Value;
 
-use super::{ACCEPTED_CONTENT_TYPES, BatchBsoBody, RequestErrorLocation};
+use super::{ACCEPTED_CONTENT_TYPES, BatchBsoBody, CollectionParam, RequestErrorLocation};
 use crate::{server::ServerState, web::error::ValidationErrorKind};
 
 #[derive(Default, Deserialize)]
@@ -110,7 +110,17 @@ impl FromRequest for BsoBodies {
             }
         };
 
-        let max_payload_size = state.limits.max_record_payload_bytes as usize;
+        // `max_record_payload_bytes` can be overridden per collection
+        let max_payload_size = {
+            let collection = CollectionParam::extrude(req.uri(), &mut req.extensions_mut())
+                .ok()
+                .flatten()
+                .map(|c| c.collection);
+            match collection {
+                Some(collection) => state.limits.max_record_payload_bytes_for(&collection),
+                None => state.limits.max_record_payload_bytes,
+            }
+        } as usize;
         let max_post_bytes = state.limits.max_post_bytes as usize;
 
         let fut = fut.and_then(move |body| {

--- a/syncserver/src/web/extractors/bso_body.rs
+++ b/syncserver/src/web/extractors/bso_body.rs
@@ -1,5 +1,5 @@
 use actix_web::{
-    Error, FromRequest, HttpRequest,
+    Error, FromRequest, HttpMessage, HttpRequest,
     dev::Payload,
     http::header::{ContentType, Header},
     web::Data,
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize, de::IgnoredAny};
 use validator::Validate;
 
 use super::{
-    ACCEPTED_CONTENT_TYPES, RequestErrorLocation, validate_body_bso_id,
+    ACCEPTED_CONTENT_TYPES, CollectionParam, RequestErrorLocation, validate_body_bso_id,
     validate_body_bso_sortindex, validate_body_bso_ttl,
 };
 use crate::{server::ServerState, web::error::ValidationErrorKind};
@@ -82,7 +82,17 @@ impl FromRequest for BsoBody {
                 }
             };
 
-            let max_payload_size = state.limits.max_record_payload_bytes as usize;
+            // `max_record_payload_bytes` can be overridden per collection
+            let max_payload_size = {
+                let collection = CollectionParam::extrude(req.uri(), &mut req.extensions_mut())
+                    .ok()
+                    .flatten()
+                    .map(|c| c.collection);
+                match collection {
+                    Some(collection) => state.limits.max_record_payload_bytes_for(&collection),
+                    None => state.limits.max_record_payload_bytes,
+                }
+            } as usize;
 
             let bso = <actix_web::web::Json<BsoBody>>::from_request(&req, &mut payload)
                 .await

--- a/syncstorage-settings/Cargo.toml
+++ b/syncstorage-settings/Cargo.toml
@@ -8,5 +8,6 @@ edition.workspace=true
 [dependencies]
 rand.workspace=true
 serde.workspace=true
+serde_json.workspace=true
 
 syncserver-common = { path = "../syncserver-common" }

--- a/syncstorage-settings/src/lib.rs
+++ b/syncstorage-settings/src/lib.rs
@@ -2,10 +2,11 @@
 
 use std::{
     cmp::min,
+    collections::HashMap,
     time::{Duration, Instant},
 };
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use syncserver_common::{self, MAX_SPANNER_LOAD_SIZE};
 
 static KILOBYTE: u32 = 1024;
@@ -221,6 +222,49 @@ pub struct ServerLimits {
     /// Maximum BSO count across a batch upload.
     pub max_total_records: u32,
     pub max_quota_limit: u64,
+
+    /// Optional per-collection overrides of the limits above by collection name.
+    ///
+    /// Configured as a JSON string mapping each collection name to an overrides object, e.g.
+    /// `SYNC_SYNCSTORAGE__LIMITS__COLLECTIONS='{"tabs":{"max_record_payload_bytes":202020}}'`.
+    #[serde(
+        default,
+        deserialize_with = "deserialize_collection_limits",
+        skip_serializing
+    )]
+    pub collections: HashMap<String, CollectionLimitOverride>,
+}
+
+/// Optional per-collection overrides of ServerLimits by collection name.
+///
+/// `None` means the collection inherits the global limit.  Currently only
+/// `max_record_payload_bytes` is supported.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct CollectionLimitOverride {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_record_payload_bytes: Option<u32>,
+}
+
+/// Deserialize the per-collection overrides from a JSON string.
+fn deserialize_collection_limits<'de, D>(
+    deserializer: D,
+) -> Result<HashMap<String, CollectionLimitOverride>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let s = String::deserialize(deserializer)?;
+    serde_json::from_str(&s).map_err(serde::de::Error::custom)
+}
+
+impl ServerLimits {
+    /// The effective `max_record_payload_bytes` for `collection`.
+    pub fn max_record_payload_bytes_for(&self, collection: &str) -> u32 {
+        self.collections
+            .get(collection)
+            .and_then(|o| o.max_record_payload_bytes)
+            .unwrap_or(self.max_record_payload_bytes)
+    }
 }
 
 impl Default for ServerLimits {
@@ -234,6 +278,52 @@ impl Default for ServerLimits {
             max_total_bytes: DEFAULT_MAX_TOTAL_BYTES,
             max_total_records: DEFAULT_MAX_TOTAL_RECORDS,
             max_quota_limit: DEFAULT_MAX_QUOTA_LIMIT,
+            collections: HashMap::new(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn deserialize(
+        value: serde_json::Value,
+    ) -> Result<HashMap<String, CollectionLimitOverride>, serde_json::Error> {
+        deserialize_collection_limits(value)
+    }
+
+    #[test]
+    fn collections_parses_json_string() {
+        let parsed = deserialize(serde_json::json!(
+            r#"{"newtab-images":{"max_record_payload_bytes":20971520}}"#
+        ))
+        .unwrap();
+        assert_eq!(
+            parsed
+                .get("newtab-images")
+                .and_then(|o| o.max_record_payload_bytes),
+            Some(20_971_520)
+        );
+        assert_eq!(parsed.len(), 1);
+    }
+
+    #[test]
+    fn max_record_payload_bytes_overrides() {
+        let mut limits = ServerLimits::default();
+        limits.collections.insert(
+            "newtab-images".to_owned(),
+            CollectionLimitOverride {
+                max_record_payload_bytes: Some(20_971_520),
+            },
+        );
+        assert_eq!(
+            limits.max_record_payload_bytes_for("newtab-images"),
+            20_971_520
+        );
+        assert_eq!(
+            limits.max_record_payload_bytes_for("tabs"),
+            DEFAULT_MAX_RECORD_PAYLOAD_BYTES
+        );
     }
 }


### PR DESCRIPTION
This commit:
 - adds an optional `limits.collections` map in settings that overrides
   the default global limits
 - enforces the per-collection max_record_payload_bytes limit

Closes STOR-587