### PR TITLE
feat: restrict gcs offload to spanner

### DIFF
--- a/docs/src/config.md
+++ b/docs/src/config.md
@@ -87,6 +87,19 @@ The following configuration options are available.
 | <span id="SYNC_SYNCSTORAGE__LBHEARTBEAT_TTL_JITTER"></span>SYNC_SYNCSTORAGE__LBHEARTBEAT_TTL_JITTER | 25 | Jitter percentage for the load balancer heartbeat period |
 | <span id="SYNC_SYNCSTORAGE__STATSD_LABEL"></span>SYNC_SYNCSTORAGE__STATSD_LABEL | syncstorage | StatsD metrics label prefix |
 
+### Syncstorage Payload Off-load
+
+Off-loads large BSO payloads to a Google Cloud Storage bucket, storing the
+object URL in the `payload_link` column instead of the inline `payload`
+column. Supported on the Spanner backend only: setting either variable on a
+mysql or postgres backend fails startup, since those backends have no
+`payload_link` column and would silently drop the payload.
+
+| Env Var | Default Value | Description |
+| --- | --- | --- |
+| <span id="SYNC_SYNCSTORAGE__GCS_PAYLOAD_BUCKET"></span>SYNC_SYNCSTORAGE__GCS_PAYLOAD_BUCKET | unset | GCS bucket for off-loaded payloads. Unset disables off-load. |
+| <span id="SYNC_SYNCSTORAGE__GCS_PAYLOAD_OFFLOAD_COLLECTIONS"></span>SYNC_SYNCSTORAGE__GCS_PAYLOAD_OFFLOAD_COLLECTIONS | unset | Comma-separated collection names whose payloads are off-loaded. Empty disables off-load for all collections. |
+
 ### Tokenserver Database
 
 | Env Var | Default Value | Description |

--- a/syncserver-settings/src/lib.rs
+++ b/syncserver-settings/src/lib.rs
@@ -186,6 +186,24 @@ impl Settings {
             }
         }
 
+        // GCS payload off-load is only wired up for the Spanner backend. On
+        // mysql/postgres the payload_link column does not exist, so an
+        // off-loaded write would upload to GCS, clear the inline payload, then
+        // persist a row with no link and lose the payload. Refuse to boot when
+        // it's configured against a non-Spanner backend.
+        if self.syncstorage.enabled
+            && !self.syncstorage.uses_spanner()
+            && (self.syncstorage.gcs_payload_bucket.is_some()
+                || !self.syncstorage.gcs_payload_offload_collections.is_empty())
+        {
+            return Err(ConfigError::Message(
+                "GCS payload off-load (SYNC_SYNCSTORAGE__GCS_PAYLOAD_BUCKET / \
+                 SYNC_SYNCSTORAGE__GCS_PAYLOAD_OFFLOAD_COLLECTIONS) is only \
+                 supported on the Spanner backend"
+                    .to_owned(),
+            ));
+        }
+
         if let Some(init_node_url) = &self.tokenserver.init_node_url {
             let url = Url::parse(init_node_url).map_err(|e| {
                 ConfigError::Message(format!("Invalid SYNC_TOKENSERVER__INIT_NODE_URL: {e}"))

--- a/syncserver-settings/src/lib.rs
+++ b/syncserver-settings/src/lib.rs
@@ -501,6 +501,91 @@ mod test {
     }
 
     #[test]
+    fn test_gcs_offload_bucket_on_non_spanner_fails() {
+        // The default test DATABASE_URL is mysql, which has no payload_link
+        // column, so a configured off-load bucket must fail validation.
+        temp_env::with_vars(
+            [
+                (
+                    "SYNC_SYNCSTORAGE__DATABASE_URL",
+                    Some(TEST_SYNCSTORAGE_DATABASE_URL),
+                ),
+                ("SYNC_TOKENSERVER__DATABASE_URL", None),
+                ("SYNC_TOKENSERVER__ENABLED", None),
+                (
+                    "SYNC_SYNCSTORAGE__GCS_PAYLOAD_BUCKET",
+                    Some("sync-payloads"),
+                ),
+            ],
+            || {
+                let err = Settings::with_env_and_config_file(None)
+                    .expect_err("an off-load bucket on a non-spanner backend should fail");
+                assert!(err.to_string().contains("Spanner backend"));
+            },
+        );
+    }
+
+    #[test]
+    fn test_gcs_offload_collections_on_non_spanner_fails() {
+        // Opting collections into off-load without a bucket must also fail on
+        // a non-spanner backend.
+        temp_env::with_vars(
+            [
+                (
+                    "SYNC_SYNCSTORAGE__DATABASE_URL",
+                    Some(TEST_SYNCSTORAGE_DATABASE_URL),
+                ),
+                ("SYNC_TOKENSERVER__DATABASE_URL", None),
+                ("SYNC_TOKENSERVER__ENABLED", None),
+                (
+                    "SYNC_SYNCSTORAGE__GCS_PAYLOAD_OFFLOAD_COLLECTIONS",
+                    Some("tabs,history"),
+                ),
+            ],
+            || {
+                let err = Settings::with_env_and_config_file(None)
+                    .expect_err("off-load collections on a non-spanner backend should fail");
+                assert!(err.to_string().contains("Spanner backend"));
+            },
+        );
+    }
+
+    #[test]
+    fn test_gcs_offload_on_spanner_validates() {
+        // The same off-load config validates against a spanner DATABASE_URL.
+        temp_env::with_vars(
+            [
+                (
+                    "SYNC_SYNCSTORAGE__DATABASE_URL",
+                    Some("spanner://projects/test/instances/test/databases/test"),
+                ),
+                ("SYNC_TOKENSERVER__DATABASE_URL", None),
+                ("SYNC_TOKENSERVER__ENABLED", None),
+                (
+                    "SYNC_SYNCSTORAGE__GCS_PAYLOAD_BUCKET",
+                    Some("sync-payloads"),
+                ),
+                (
+                    "SYNC_SYNCSTORAGE__GCS_PAYLOAD_OFFLOAD_COLLECTIONS",
+                    Some("tabs,history"),
+                ),
+            ],
+            || {
+                let settings = Settings::with_env_and_config_file(None)
+                    .expect("off-load config should validate on spanner");
+                assert_eq!(
+                    settings.syncstorage.gcs_payload_bucket.as_deref(),
+                    Some("sync-payloads")
+                );
+                assert_eq!(
+                    settings.syncstorage.gcs_payload_offload_collections,
+                    vec!["tabs".to_owned(), "history".to_owned()]
+                );
+            },
+        );
+    }
+
+    #[test]
     fn test_disabled_tokenserver_does_not_require_database_url() {
         // A disabled Tokenserver should not require a DATABASE_URL.
         temp_env::with_vars(

--- a/syncserver/src/server/mod.rs
+++ b/syncserver/src/server/mod.rs
@@ -391,6 +391,9 @@ impl Server {
             app_channel: settings.environment.clone(),
         });
         let glean_enabled = settings.syncstorage.glean_enabled;
+        // TODO(STOR-650): gate this behind the spanner build feature so
+        // non-spanner builds can't carry offload config at all. Startup
+        // validation (STOR-627) rejects it at runtime in the meantime.
         let gcs_payload_bucket = settings.syncstorage.gcs_payload_bucket.clone();
         let gcs_payload_offload_collections =
             Arc::new(settings.syncstorage.gcs_payload_offload_collections.clone());


### PR DESCRIPTION
## Description

payload_link only exists on spanner. On mysql or postgres an offloaded write uploads to gcs, clears the inline payload, then stores a row with no link and loses the payload. This fails startup when gcs offload is configured on a non spanner backend. 

Runtime check for now. STOR-650 tracks the compile time guard as a follow up should we want it. I didn't want to go too far with a feature flag as we develop this.

Added the new configs to docs too 👍 

## Issue(s)

Closes [STOR-627](https://mozilla-hub.atlassian.net/browse/STOR-627)

[STOR-627]: https://mozilla-hub.atlassian.net/browse/STOR-627?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ