### PR TITLE
feat: upload/download to/from gcs concurrently

### DIFF
--- a/syncserver/src/server/mod.rs
+++ b/syncserver/src/server/mod.rs
@@ -29,7 +29,7 @@ use syncstorage_db::{DbError, DbPool, DbPoolImpl};
 use syncstorage_settings::{Deadman, ServerLimits};
 
 use crate::{
-    error::{ApiError, ApiErrorKind},
+    error::ApiError,
     tokenserver,
     web::{
         handlers, middleware,

--- a/syncserver/src/server/mod.rs
+++ b/syncserver/src/server/mod.rs
@@ -2,7 +2,6 @@
 
 use std::{convert::Infallible, num::NonZeroUsize, sync::Arc, time::Duration};
 
-use crate::error::ApiError;
 use actix_cors::Cors;
 use actix_web::{
     App, FromRequest, HttpRequest, HttpResponse, HttpServer,
@@ -15,6 +14,11 @@ use actix_web::{
 use cadence::{Gauged, StatsdClient};
 use futures::future::{self, Ready};
 use glean::server_events::GleanEventsLogger;
+use google_cloud_storage::client::{Storage, StorageControl};
+use tokio::{sync::RwLock, time};
+use utoipa::OpenApi;
+use utoipa_swagger_ui::SwaggerUi;
+
 use syncserver_common::{
     BlockingThreadpool, BlockingThreadpoolMetrics, Metrics, Taggable,
     middleware::sentry::SentryWrapper,
@@ -23,12 +27,15 @@ use syncserver_db_common::GetPoolStatus;
 use syncserver_settings::Settings;
 use syncstorage_db::{DbError, DbPool, DbPoolImpl};
 use syncstorage_settings::{Deadman, ServerLimits};
-use tokio::{sync::RwLock, time};
-use utoipa::OpenApi;
-use utoipa_swagger_ui::SwaggerUi;
 
-use crate::tokenserver;
-use crate::web::{handlers, middleware};
+use crate::{
+    error::{ApiError, ApiErrorKind},
+    tokenserver,
+    web::{
+        handlers, middleware,
+        payload_offload::{build_client, build_control_client},
+    },
+};
 
 pub const BSO_ID_REGEX: &str = r"[ -~]{1,64}";
 pub const COLLECTION_ID_REGEX: &str = r"[a-zA-Z0-9._-]{1,32}";
@@ -74,11 +81,35 @@ pub struct ServerState {
     /// Collections whose BSO payloads are off-loaded to GCS.
     pub gcs_payload_offload_collections: Arc<Vec<String>>,
 
-    /// Override the GCS endpoint URL (for testing). When set the GCS client
-    /// is built with `.with_endpoint(...)` + anonymous credentials.
-    /// Unset in prod; opt-in via `SYNC_SYNCSTORAGE__GCS_ENDPOINT` for
-    /// local/e2e testing against a fake-gcs-server or httptest mock.
-    pub gcs_endpoint: Option<String>,
+    /// Shared GCS client built at startup. `None` when GCS off-load is disabled.
+    pub gcs_client: Option<Storage>,
+
+    /// Shared GCS control-plane client built at startup.  `None` when GCS off-load is disabled.
+    pub gcs_control_client: Option<StorageControl>,
+
+    /// Maximum GCS uploads/downloads to run concurrently.
+    pub gcs_payload_max_concurrency: usize,
+}
+
+impl ServerState {
+    /// Shared GCS client to use when [`crate::web::payload_offload::offload_bucket`] returns Some
+    /// bucket.
+    pub fn gcs_client(&self) -> Result<&Storage, ApiError> {
+        self.gcs_client.as_ref().ok_or_else(|| {
+            ApiErrorKind::Internal("GCS off-load enabled but client not initialized".to_owned())
+                .into()
+        })
+    }
+
+    /// Shared GCS control-plane client.  Available when GCS off-load is enabled.
+    pub fn gcs_control_client(&self) -> Result<&StorageControl, ApiError> {
+        self.gcs_control_client.as_ref().ok_or_else(|| {
+            ApiErrorKind::Internal(
+                "GCS off-load enabled but control client not initialized".to_owned(),
+            )
+            .into()
+        })
+    }
 }
 
 pub fn cfg_path(path: &str) -> String {
@@ -397,7 +428,17 @@ impl Server {
         let gcs_payload_bucket = settings.syncstorage.gcs_payload_bucket.clone();
         let gcs_payload_offload_collections =
             Arc::new(settings.syncstorage.gcs_payload_offload_collections.clone());
-        let gcs_endpoint = settings.syncstorage.gcs_endpoint.clone();
+        let gcs_payload_max_concurrency = settings.syncstorage.gcs_payload_max_concurrency.max(1);
+        let (gcs_client, gcs_control_client) = match gcs_payload_bucket {
+            Some(_) => {
+                let endpoint = settings.syncstorage.gcs_endpoint.as_deref();
+                (
+                    Some(build_client(endpoint).await?),
+                    Some(build_control_client(endpoint).await?),
+                )
+            }
+            None => (None, None),
+        };
         let worker_thread_count =
             calculate_worker_max_blocking_threads(settings.worker_max_blocking_threads);
         let limits = Arc::new(settings.syncstorage.limits);
@@ -446,7 +487,9 @@ impl Server {
                 glean_enabled,
                 gcs_payload_bucket: gcs_payload_bucket.clone(),
                 gcs_payload_offload_collections: Arc::clone(&gcs_payload_offload_collections),
-                gcs_endpoint: gcs_endpoint.clone(),
+                gcs_client: gcs_client.clone(),
+                gcs_control_client: gcs_control_client.clone(),
+                gcs_payload_max_concurrency,
             };
 
             build_app!(

--- a/syncserver/src/server/mod.rs
+++ b/syncserver/src/server/mod.rs
@@ -95,9 +95,9 @@ impl ServerState {
     /// Shared GCS client to use when [`crate::web::payload_offload::offload_bucket`] returns Some
     /// bucket.
     pub fn gcs_client(&self) -> Result<&Storage, ApiError> {
-        self.gcs_client.as_ref().ok_or_else(|| {
-            ApiError::internal("GCS off-load enabled but client not initialized")
-        })
+        self.gcs_client
+            .as_ref()
+            .ok_or_else(|| ApiError::internal("GCS off-load enabled but client not initialized"))
     }
 
     /// Shared GCS control-plane client.  Available when GCS off-load is enabled.

--- a/syncserver/src/server/mod.rs
+++ b/syncserver/src/server/mod.rs
@@ -88,7 +88,7 @@ pub struct ServerState {
     pub gcs_control_client: Option<StorageControl>,
 
     /// Maximum GCS uploads/downloads to run concurrently.
-    pub gcs_payload_max_concurrency: usize,
+    pub gcs_payload_max_concurrency: NonZeroUsize,
 }
 
 impl ServerState {
@@ -424,7 +424,7 @@ impl Server {
         let gcs_payload_bucket = settings.syncstorage.gcs_payload_bucket.clone();
         let gcs_payload_offload_collections =
             Arc::new(settings.syncstorage.gcs_payload_offload_collections.clone());
-        let gcs_payload_max_concurrency = settings.syncstorage.gcs_payload_max_concurrency.max(1);
+        let gcs_payload_max_concurrency = settings.syncstorage.gcs_payload_max_concurrency;
         let (gcs_client, gcs_control_client) = if gcs_payload_bucket.is_some() {
             let endpoint = settings.syncstorage.gcs_endpoint.as_deref();
             (

--- a/syncserver/src/server/mod.rs
+++ b/syncserver/src/server/mod.rs
@@ -96,18 +96,14 @@ impl ServerState {
     /// bucket.
     pub fn gcs_client(&self) -> Result<&Storage, ApiError> {
         self.gcs_client.as_ref().ok_or_else(|| {
-            ApiErrorKind::Internal("GCS off-load enabled but client not initialized".to_owned())
-                .into()
+            ApiError::internal("GCS off-load enabled but client not initialized")
         })
     }
 
     /// Shared GCS control-plane client.  Available when GCS off-load is enabled.
     pub fn gcs_control_client(&self) -> Result<&StorageControl, ApiError> {
         self.gcs_control_client.as_ref().ok_or_else(|| {
-            ApiErrorKind::Internal(
-                "GCS off-load enabled but control client not initialized".to_owned(),
-            )
-            .into()
+            ApiError::internal("GCS off-load enabled but control client not initialized")
         })
     }
 }
@@ -429,15 +425,14 @@ impl Server {
         let gcs_payload_offload_collections =
             Arc::new(settings.syncstorage.gcs_payload_offload_collections.clone());
         let gcs_payload_max_concurrency = settings.syncstorage.gcs_payload_max_concurrency.max(1);
-        let (gcs_client, gcs_control_client) = match gcs_payload_bucket {
-            Some(_) => {
-                let endpoint = settings.syncstorage.gcs_endpoint.as_deref();
-                (
-                    Some(build_client(endpoint).await?),
-                    Some(build_control_client(endpoint).await?),
-                )
-            }
-            None => (None, None),
+        let (gcs_client, gcs_control_client) = if gcs_payload_bucket.is_some() {
+            let endpoint = settings.syncstorage.gcs_endpoint.as_deref();
+            (
+                Some(build_client(endpoint).await?),
+                Some(build_control_client(endpoint).await?),
+            )
+        } else {
+            (None, None)
         };
         let worker_thread_count =
             calculate_worker_max_blocking_threads(settings.worker_max_blocking_threads);

--- a/syncserver/src/server/test.rs
+++ b/syncserver/src/server/test.rs
@@ -32,9 +32,14 @@ use syncstorage_db::{
 use syncstorage_settings::ServerLimits;
 
 use super::*;
-use crate::build_app;
-use crate::tokenserver;
-use crate::web::{auth::HawkPayload, extractors::BsoBody};
+use crate::{
+    build_app, tokenserver,
+    web::{
+        auth::HawkPayload,
+        extractors::BsoBody,
+        payload_offload::{build_client, build_control_client},
+    },
+};
 
 lazy_static! {
     static ref SERVER_LIMITS: Arc<ServerLimits> = Arc::new(ServerLimits::default());
@@ -122,7 +127,23 @@ async fn get_test_state(settings: &Settings) -> ServerState {
         gcs_payload_offload_collections: Arc::new(
             settings.syncstorage.gcs_payload_offload_collections.clone(),
         ),
-        gcs_endpoint: settings.syncstorage.gcs_endpoint.clone(),
+        gcs_client: match settings.syncstorage.gcs_payload_bucket {
+            Some(_) => Some(
+                build_client(settings.syncstorage.gcs_endpoint.as_deref())
+                    .await
+                    .expect("Could not build GCS client in get_test_state"),
+            ),
+            None => None,
+        },
+        gcs_control_client: match settings.syncstorage.gcs_payload_bucket {
+            Some(_) => Some(
+                build_control_client(settings.syncstorage.gcs_endpoint.as_deref())
+                    .await
+                    .expect("Could not build GCS control client in get_test_state"),
+            ),
+            None => None,
+        },
+        gcs_payload_max_concurrency: settings.syncstorage.gcs_payload_max_concurrency.max(1),
     }
 }
 
@@ -976,6 +997,69 @@ async fn put_bso_offloads_to_gcs() {
     assert!(
         resp.response().status().is_success(),
         "put_bso failed: {:?}",
+        resp.response()
+    );
+}
+
+#[actix_rt::test]
+async fn post_collection_offloads_to_gcs() {
+    let mut settings = get_test_settings();
+    if !settings.syncstorage.uses_spanner() {
+        // TODO: should be Spanner only (for now)
+        return;
+    }
+
+    // Mock GCS: expect one multipart upload per BSO in the batch. `times(3)` asserts all three
+    // BSOs were uploaded.
+    const BSO_COUNT: usize = 3;
+    let server = Server::run();
+    server.expect(
+        Expectation::matching(all_of![
+            request::method_path("POST", "/upload/storage/v1/b/test-bucket/o"),
+            request::query(url_decoded(contains(("uploadType", "multipart")))),
+            request::body(matches(r#""committed""#)),
+            request::body(matches(r#""false""#)),
+            request::body(matches(r#""customTime""#)),
+        ])
+        .times(BSO_COUNT)
+        .respond_with(
+            status_code(200)
+                .append_header("content-type", "application/json")
+                .body(
+                    serde_json::json!({
+                        "name": "test-object",
+                        "bucket": "test-bucket",
+                    })
+                    .to_string(),
+                ),
+        ),
+    );
+
+    settings.syncstorage.gcs_payload_bucket = Some("test-bucket".to_owned());
+    settings.syncstorage.gcs_payload_offload_collections = vec!["bookmarks".to_owned()];
+    settings.syncstorage.gcs_endpoint = Some(format!("http://{}", server.addr()));
+
+    let app = init_app!(settings).await;
+
+    let body = json!(
+        (0..BSO_COUNT)
+            .map(|i| json!({ "id": format!("bso{i}"), "payload": format!("payload-{i}") }))
+            .collect::<Vec<_>>()
+    );
+    let req = create_request(
+        http::Method::POST,
+        "/1.5/42/storage/bookmarks",
+        None,
+        Some(body),
+    )
+    .to_request();
+    let resp = app
+        .call(req)
+        .await
+        .expect("Could not get resp in post_collection_offloads_to_gcs");
+    assert!(
+        resp.response().status().is_success(),
+        "post_collection failed: {:?}",
         resp.response()
     );
 }

--- a/syncserver/src/server/test.rs
+++ b/syncserver/src/server/test.rs
@@ -143,7 +143,7 @@ async fn get_test_state(settings: &Settings) -> ServerState {
             ),
             None => None,
         },
-        gcs_payload_max_concurrency: settings.syncstorage.gcs_payload_max_concurrency.max(1),
+        gcs_payload_max_concurrency: settings.syncstorage.gcs_payload_max_concurrency,
     }
 }
 

--- a/syncserver/src/web/extractors/test_utils.rs
+++ b/syncserver/src/web/extractors/test_utils.rs
@@ -68,10 +68,11 @@ pub fn make_state() -> ServerState {
         deadman: Arc::new(RwLock::new(Deadman::default())),
         glean_logger,
         glean_enabled: syncstorage_settings.glean_enabled,
+        gcs_client: None,
+        gcs_control_client: None,
         gcs_payload_bucket: None,
+        gcs_payload_max_concurrency: syncstorage_settings.gcs_payload_max_concurrency,
         gcs_payload_offload_collections: Arc::new(Vec::new()),
-        #[cfg(debug_assertions)]
-        gcs_endpoint: None,
     }
 }
 

--- a/syncserver/src/web/handlers.rs
+++ b/syncserver/src/web/handlers.rs
@@ -10,6 +10,7 @@ use actix_web::{
     http::{StatusCode, header},
     web::Data,
 };
+use futures::stream::{self, StreamExt, TryStreamExt};
 use serde::Serialize;
 use serde_json::{Value, json};
 use syncserver_common::{X_LAST_MODIFIED, X_WEAVE_NEXT_OFFSET, X_WEAVE_RECORDS};
@@ -27,7 +28,9 @@ use crate::{
             BsoPutRequest, BsoRequest, CollectionPostRequest, CollectionRequest, EmitApiMetric,
             HeartbeatRequest, MetaRequest, ReplyFormat, TestErrorRequest,
         },
-        payload_offload::{delete_payload, download_payload, offload_bucket, upload_payload},
+        payload_offload::{
+            delete_payload, download_payload, offload_bucket, reattach_by_index, upload_payload,
+        },
         transaction::DbTransactionPool,
     },
 };
@@ -337,10 +340,28 @@ pub async fn get_collection(
                 handle_not_found(db.get_bsos(params).await).map_err(Into::into)
             },
             async |mut bsos: Paginated<results::GetBso>| {
-                for bso in bsos.items.iter_mut() {
-                    if let Some(link) = bso.payload_link.take() {
-                        bso.payload = download_payload(&state, &link).await?;
-                    }
+                if let Some(client) = state.gcs_client.as_ref() {
+                    // Links for concurrent downloads with index to bind the payload back to the
+                    // bso
+                    let links: Vec<(usize, String)> = bsos
+                        .items
+                        .iter_mut()
+                        .enumerate()
+                        .filter_map(|(i, bso)| bso.payload_link.take().map(|link| (i, link)))
+                        .collect();
+
+                    let payloads: Vec<(usize, String)> = stream::iter(links)
+                        .map(|(i, link)| {
+                            let client = client.clone();
+                            async move { download_payload(&client, &link).await.map(|p| (i, p)) }
+                        })
+                        .buffer_unordered(state.gcs_payload_max_concurrency)
+                        .try_collect()
+                        .await?;
+
+                    reattach_by_index(&mut bsos.items, payloads, |bso, payload| {
+                        bso.payload = payload
+                    });
                 }
                 Ok(finish_get_collection(&coll, bsos).await)
             },
@@ -422,23 +443,39 @@ pub async fn post_collection(
     // entry's payload/payload_link have already been swapped.
     let mut offload_urls: Vec<String> = Vec::new();
     if let Some(bucket) = offload_bucket(&state, &coll.collection) {
-        for bso in coll.bsos.valid.iter_mut() {
-            if let Some(payload) = bso.payload.take() {
-                let url = upload_payload(
-                    &state,
-                    bucket,
-                    &coll.user_id,
-                    &coll.collection,
-                    &bso.id,
-                    payload,
-                )
-                .await?;
-                offload_urls.push(url.clone()); // might need to delete on transaction failure
-                // payload was taken above; leave it None so only
-                // payload_link is set on the offloaded BSO.
-                bso.payload_link = Some(url);
-            }
-        }
+        let client = state.gcs_client()?;
+        // Take the payloads for concurrent uploads, with index to bind the payload url back to
+        // the bso
+        let pending: Vec<(usize, String, String)> = coll
+            .bsos
+            .valid
+            .iter_mut()
+            .enumerate()
+            .filter_map(|(i, bso)| bso.payload.take().map(|p| (i, bso.id.clone(), p)))
+            .collect();
+
+        let user_id = &coll.user_id;
+        let collection = coll.collection.as_str();
+        let uploads: Vec<(usize, String)> = stream::iter(pending)
+            .map(|(i, bso_id, payload)| {
+                let client = client.clone();
+                async move {
+                    upload_payload(&client, bucket, user_id, collection, &bso_id, payload)
+                        .await
+                        .map(|url| (i, url))
+                }
+            })
+            .buffer_unordered(state.gcs_payload_max_concurrency)
+            .try_collect()
+            .await?;
+
+        // Track uploaded URLs so they can be cleaned up from GCS if the DB
+        // transaction below fails.
+        offload_urls.extend(uploads.iter().map(|(_, url)| url.clone()));
+
+        reattach_by_index(&mut coll.bsos.valid, uploads, |bso, url| {
+            bso.payload_link = Some(url)
+        });
     }
 
     let resp = db_pool
@@ -484,9 +521,12 @@ pub async fn post_collection(
         })
         .await;
 
-    if resp.is_err() {
+    if resp.is_err()
+        && !offload_urls.is_empty()
+        && let Ok(client) = state.gcs_control_client()
+    {
         for url in offload_urls {
-            let _ = delete_payload(&url).await;
+            let _ = delete_payload(client, &url).await;
         }
     }
 
@@ -742,7 +782,7 @@ pub async fn get_bso(
                 if let Some(ref mut bso) = maybe_bso
                     && let Some(link) = bso.payload_link.take()
                 {
-                    bso.payload = download_payload(&state, &link).await?;
+                    bso.payload = download_payload(state.gcs_client()?, &link).await?;
                 }
                 Ok(maybe_bso.map_or_else(
                     || HttpResponse::NotFound().finish(),
@@ -781,7 +821,7 @@ pub async fn put_bso(
         && let Some(payload) = bso_req.body.payload.take()
     {
         let url = upload_payload(
-            &state,
+            state.gcs_client()?,
             bucket,
             &bso_req.user_id,
             &bso_req.collection,
@@ -816,8 +856,9 @@ pub async fn put_bso(
 
     if resp.is_err()
         && let Some(gcs_url) = &payload_link
+        && let Ok(client) = state.gcs_control_client()
     {
-        let _ = delete_payload(gcs_url).await;
+        let _ = delete_payload(client, gcs_url).await;
     }
     resp
 }

--- a/syncserver/src/web/handlers.rs
+++ b/syncserver/src/web/handlers.rs
@@ -456,6 +456,8 @@ pub async fn post_collection(
 
         let user_id = &coll.user_id;
         let collection = coll.collection.as_str();
+        // fail-fast on first failure uploads; successful, orphaned uploads rely on GCS lifecyle
+        // policy for clean-up.
         let uploads: Vec<(usize, String)> = stream::iter(pending)
             .map(|(i, bso_id, payload)| {
                 let client = client.clone();

--- a/syncserver/src/web/handlers.rs
+++ b/syncserver/src/web/handlers.rs
@@ -340,16 +340,15 @@ pub async fn get_collection(
                 handle_not_found(db.get_bsos(params).await).map_err(Into::into)
             },
             async |mut bsos: Paginated<results::GetBso>| {
-                if let Some(client) = state.gcs_client.as_ref() {
-                    // Links for concurrent downloads with index to bind the payload back to the
-                    // bso
-                    let links: Vec<(usize, String)> = bsos
-                        .items
-                        .iter_mut()
-                        .enumerate()
-                        .filter_map(|(i, bso)| bso.payload_link.take().map(|link| (i, link)))
-                        .collect();
+                let links: Vec<(usize, String)> = bsos
+                    .items
+                    .iter_mut()
+                    .enumerate()
+                    .filter_map(|(i, bso)| bso.payload_link.take().map(|link| (i, link)))
+                    .collect();
 
+                if !links.is_empty() {
+                    let client = state.gcs_client()?;
                     let payloads: Vec<(usize, String)> = stream::iter(links)
                         .map(|(i, link)| {
                             let client = client.clone();

--- a/syncserver/src/web/handlers.rs
+++ b/syncserver/src/web/handlers.rs
@@ -355,7 +355,7 @@ pub async fn get_collection(
                             let client = client.clone();
                             async move { download_payload(&client, &link).await.map(|p| (i, p)) }
                         })
-                        .buffer_unordered(state.gcs_payload_max_concurrency)
+                        .buffer_unordered(state.gcs_payload_max_concurrency.get())
                         .try_collect()
                         .await?;
 
@@ -467,7 +467,7 @@ pub async fn post_collection(
                         .map(|url| (i, url))
                 }
             })
-            .buffer_unordered(state.gcs_payload_max_concurrency)
+            .buffer_unordered(state.gcs_payload_max_concurrency.get())
             .try_collect()
             .await?;
 

--- a/syncserver/src/web/payload_offload.rs
+++ b/syncserver/src/web/payload_offload.rs
@@ -39,16 +39,16 @@ pub fn offload_bucket<'a>(state: &'a ServerState, collection: &str) -> Option<&'
         .then_some(bucket)
 }
 
-/// Build a GCS client honoring the endpoint override stored on
-/// [`ServerState`]. When the override is set we additionally use anonymous
-/// credentials so the SDK does not attempt to acquire Application Default
-/// Credentials against a mock server. This is opt-in via the
-/// `SYNC_SYNCSTORAGE__GCS_ENDPOINT` setting (unset in prod deployments);
-/// setting it to the wrong value in prod would immediately break offload,
-/// so the opt-in is self-defeating as a stealth-security-degradation vector.
-async fn gcs_client(state: &ServerState) -> Result<Storage, ApiError> {
+/// Build a GCS client honoring the `endpoint` override. When the override is
+/// set we additionally use anonymous credentials so the SDK does not attempt
+/// to acquire Application Default Credentials against a mock server. This is
+/// opt-in via the `SYNC_SYNCSTORAGE__GCS_ENDPOINT` setting (unset in prod
+/// deployments); setting it to the wrong value in prod would immediately break
+/// offload, so the opt-in is self-defeating as a stealth-security-degradation
+/// vector.
+pub async fn build_client(endpoint: Option<&str>) -> Result<Storage, ApiError> {
     let mut builder = Storage::builder();
-    if let Some(endpoint) = state.gcs_endpoint.as_deref() {
+    if let Some(endpoint) = endpoint {
         builder = builder
             .with_endpoint(endpoint)
             .with_credentials(anonymous::Builder::new().build());
@@ -65,7 +65,7 @@ async fn gcs_client(state: &ServerState) -> Result<Storage, ApiError> {
 /// The object is written with custom metadata `committed=false` and a
 /// `customTime` of the upload moment.
 pub async fn upload_payload(
-    state: &ServerState,
+    client: &Storage,
     bucket: &str,
     user_id: &UserIdentifier,
     collection: &str,
@@ -79,7 +79,6 @@ pub async fn upload_payload(
         bso_id,
         Uuid::new_v4().hyphenated()
     );
-    let client = gcs_client(state).await?;
 
     let custom_time: wkt::Timestamp = SystemTime::now()
         .try_into()
@@ -97,9 +96,8 @@ pub async fn upload_payload(
 
 /// Download payload bytes from a `gs://{bucket}/{object}` URL produced by
 /// [`upload_payload`] and return them as a UTF-8 string.
-pub async fn download_payload(state: &ServerState, gs_url: &str) -> Result<String, ApiError> {
+pub async fn download_payload(client: &Storage, gs_url: &str) -> Result<String, ApiError> {
     let (bucket, object) = parse_gs_url(gs_url)?;
-    let client = gcs_client(state).await?;
 
     let mut response = client
         .read_object(bucket_path(bucket), object.to_string())
@@ -115,20 +113,20 @@ pub async fn download_payload(state: &ServerState, gs_url: &str) -> Result<Strin
         .map_err(|e| ApiErrorKind::Internal(format!("invalid utf-8 in GCS payload: {e}")).into())
 }
 
-async fn gcs_control_client() -> Result<StorageControl, ApiError> {
-    StorageControl::builder()
+pub async fn build_control_client(endpoint: Option<&str>) -> Result<StorageControl, ApiError> {
+    let mut builder = StorageControl::builder();
+    if let Some(endpoint) = endpoint {
+        builder = builder
+            .with_endpoint(endpoint)
+            .with_credentials(anonymous::Builder::new().build());
+    }
+    builder
         .build()
         .await
         .map_err(|e| ApiErrorKind::Internal(format!("GCS builder error: {e}")).into())
 }
 
-pub async fn delete_payload(gs_url: &str) -> Result<(), ApiError> {
-    let client = gcs_control_client().await?;
-    delete_payload_with(&client, gs_url).await
-}
-
-/// Allowed a provided control client so a stub can be injected for testing.
-async fn delete_payload_with(client: &StorageControl, gs_url: &str) -> Result<(), ApiError> {
+pub async fn delete_payload(client: &StorageControl, gs_url: &str) -> Result<(), ApiError> {
     let (bucket, object) = parse_gs_url(gs_url)?;
     client
         .delete_object()
@@ -148,6 +146,17 @@ fn parse_gs_url(url: &str) -> Result<(&str, &str), ApiError> {
     url.strip_prefix("gs://")
         .and_then(|p| p.split_once('/'))
         .ok_or_else(|| ApiErrorKind::Internal(format!("invalid GCS URL: {url}")).into())
+}
+
+/// Reattach GCS results to their corresponding entries in `items` by index.
+pub fn reattach_by_index<T, V>(
+    items: &mut [T],
+    results: impl IntoIterator<Item = (usize, V)>,
+    mut apply: impl FnMut(&mut T, V),
+) {
+    for (i, value) in results {
+        apply(&mut items[i], value);
+    }
 }
 
 #[cfg(test)]
@@ -209,9 +218,9 @@ mod tests {
             deletes: deletes.clone(),
         });
 
-        delete_payload_with(&client, "gs://test-bucket/uid/bookmarks/bid/uuid")
+        delete_payload(&client, "gs://test-bucket/uid/bookmarks/bid/uuid")
             .await
-            .expect("delete_payload_with should succeed");
+            .expect("delete_payload should succeed");
 
         let recorded = deletes.lock().unwrap();
         assert_eq!(
@@ -227,11 +236,58 @@ mod tests {
     async fn delete_payload_surfaces_delete_error() {
         let client = StorageControl::from_stub(FailingStub);
 
-        let result = delete_payload_with(&client, "gs://test-bucket/uid/bookmarks/bid/uuid").await;
+        let result = delete_payload(&client, "gs://test-bucket/uid/bookmarks/bid/uuid").await;
 
         assert!(
             result.is_err(),
             "a failed GCS delete should surface as an error"
         );
+    }
+
+    #[test]
+    fn reattach_results_to_correct_slots() {
+        let mut items: Vec<Option<String>> = vec![None, None, None, None];
+        let results = vec![
+            (2, "two".to_owned()),
+            (0, "zero".to_owned()),
+            (3, "three".to_owned()),
+            (1, "one".to_owned()),
+        ];
+        reattach_by_index(&mut items, results, |slot, payload| *slot = Some(payload));
+        assert_eq!(
+            items,
+            vec![
+                Some("zero".to_owned()),
+                Some("one".to_owned()),
+                Some("two".to_owned()),
+                Some("three".to_owned()),
+            ]
+        );
+    }
+
+    #[test]
+    fn reattach_only_indexed_slots() {
+        let mut items = vec![
+            "keep-0".to_owned(),
+            "keep-1".to_owned(),
+            "keep-2".to_owned(),
+        ];
+        let results = vec![(1, "replaced-1".to_owned())];
+        reattach_by_index(&mut items, results, |slot, v| *slot = v);
+        assert_eq!(
+            items,
+            vec![
+                "keep-0".to_owned(),
+                "replaced-1".to_owned(),
+                "keep-2".to_owned(),
+            ]
+        );
+    }
+
+    #[test]
+    fn reattach_empty_results_is_noop() {
+        let mut items = vec![1, 2, 3];
+        reattach_by_index(&mut items, Vec::<(usize, i32)>::new(), |slot, v| *slot = v);
+        assert_eq!(items, vec![1, 2, 3]);
     }
 }

--- a/syncstorage-settings/src/lib.rs
+++ b/syncstorage-settings/src/lib.rs
@@ -3,6 +3,7 @@
 use std::{
     cmp::min,
     collections::HashMap,
+    num::NonZeroUsize,
     time::{Duration, Instant},
 };
 
@@ -10,6 +11,9 @@ use serde::{Deserialize, Deserializer, Serialize};
 use syncserver_common::{self, MAX_SPANNER_LOAD_SIZE};
 
 static KILOBYTE: u32 = 1024;
+
+/// Default for [`Settings::gcs_payload_max_concurrency`].
+const DEFAULT_GCS_PAYLOAD_MAX_CONCURRENCY: NonZeroUsize = NonZeroUsize::new(4).unwrap();
 static MEGABYTE: u32 = KILOBYTE * KILOBYTE;
 static GIGABYTE: u32 = MEGABYTE * 1_000;
 // Current limit of 2.5 MB
@@ -135,7 +139,7 @@ pub struct Settings {
 
     /// Maximum number of GCS payload uploads/downloads to run concurrently
     /// within a single batch request.
-    pub gcs_payload_max_concurrency: usize,
+    pub gcs_payload_max_concurrency: NonZeroUsize,
 
     /// Override the GCS endpoint URL for testing (e.g. an httptest mock or
     /// fake-gcs-server instance). When set, anonymous credentials are used.
@@ -170,7 +174,7 @@ impl Default for Settings {
             lbheartbeat_ttl_jitter: 25,
             gcs_payload_bucket: None,
             gcs_payload_offload_collections: Vec::new(),
-            gcs_payload_max_concurrency: 4,
+            gcs_payload_max_concurrency: DEFAULT_GCS_PAYLOAD_MAX_CONCURRENCY,
             gcs_endpoint: None,
         }
     }

--- a/syncstorage-settings/src/lib.rs
+++ b/syncstorage-settings/src/lib.rs
@@ -133,6 +133,10 @@ pub struct Settings {
     /// off-load path for all collections.
     pub gcs_payload_offload_collections: Vec<String>,
 
+    /// Maximum number of GCS payload uploads/downloads to run concurrently
+    /// within a single batch request.
+    pub gcs_payload_max_concurrency: usize,
+
     /// Override the GCS endpoint URL for testing (e.g. an httptest mock or
     /// fake-gcs-server instance). When set, anonymous credentials are used.
     /// Unset in prod deployments; setting it to a wrong value in prod would
@@ -166,6 +170,7 @@ impl Default for Settings {
             lbheartbeat_ttl_jitter: 25,
             gcs_payload_bucket: None,
             gcs_payload_offload_collections: Vec::new(),
+            gcs_payload_max_concurrency: 4,
             gcs_endpoint: None,
         }
     }


### PR DESCRIPTION
This commit
 - performs uploads and downloads against gcs concurrently, up to some configured number of concurrent requests, when offloading is enabled
 - builds shared singletons of the Storage and StorageControl clients

Closes STOR-633, STOR-651