### PR TITLE
test: stop skipping the offload usage tests

### DIFF
--- a/docker/docker-compose.e2e.reconciliation.yaml
+++ b/docker/docker-compose.e2e.reconciliation.yaml
@@ -130,6 +130,9 @@ services:
       # Collections used by test_storage.py -- opts them all into offload
       # so test_storage.py exercises the offload path as regression
       # coverage. Extend if new collections appear in the test suite.
+      # Deliberately excludes xxx_usage: the /info/quota and
+      # /info/collection_usage tests need a non-offloaded collection since
+      # byte accounting reads the inline Spanner payload. Do not add it here.
       SYNC_SYNCSTORAGE__GCS_PAYLOAD_OFFLOAD_COLLECTIONS: >-
         apis-1,crypto,meta,passwords,xxx_col,xxx_col1,xxx_col2,xxx_meh,xxxx,nonexistent
 

--- a/tools/integration_tests/test_storage.py
+++ b/tools/integration_tests/test_storage.py
@@ -14,7 +14,6 @@ consider it a bug.
 
 import pytest
 
-import os
 import re
 import json
 import time
@@ -70,6 +69,14 @@ def json_loads(value):
 
 _PLD = "*" * 500
 _ASCII = string.ascii_letters + string.digits
+
+# Collection deliberately kept OUT of GCS_PAYLOAD_OFFLOAD_COLLECTIONS in the
+# offload e2e stack. Byte-size accounting (/info/quota, /info/collection_usage)
+# sums the inline Spanner payload, which is NULL for offloaded BSOs, so those
+# endpoints only make sense against a non-offloaded collection. Metering of
+# offloaded/GCS data is tracked separately (STOR-372). Do not add this name to
+# the offload list in docker/docker-compose.e2e.reconciliation.yaml.
+_NON_OFFLOAD_COL = "xxx_usage"
 
 
 def randtext(size=10):
@@ -618,12 +625,12 @@ def test_app_newlines_when_payloads_contain_newlines(st_ctx):
     assert items[1]["payload"] == bsos[1]["payload"]
 
 
-@pytest.mark.skipif(
-    "GCS_PAYLOAD_BUCKET" in os.environ,
-    reason="Currently broken on GCS payload offload",
-)
 def test_collection_usage(st_ctx):
-    """Test collection usage."""
+    """Test collection usage.
+
+    Uses a non-offloaded collection: collection_usage sums the inline Spanner
+    payload, which is not populated for offloaded BSOs.
+    """
     app = st_ctx["app"]
     root = st_ctx["root"]
     retry_delete(app, root + "/storage")
@@ -631,13 +638,13 @@ def test_collection_usage(st_ctx):
     bso1 = {"id": "13", "payload": "XyX"}
     bso2 = {"id": "14", "payload": _PLD}
     bsos = [bso1, bso2]
-    retry_post_json(app, root + "/storage/xxx_col2", bsos)
+    retry_post_json(app, root + "/storage/" + _NON_OFFLOAD_COL, bsos)
 
     res = app.get(root + "/info/collection_usage")
     usage = res.json
-    xxx_col2_size = usage["xxx_col2"]
+    col_size = usage[_NON_OFFLOAD_COL]
     wanted = (len(bso1["payload"]) + len(bso2["payload"])) / 1024.0
-    assert round(xxx_col2_size, 2) == round(wanted, 2)
+    assert round(col_size, 2) == round(wanted, 2)
 
 
 def test_delete_collection_items(st_ctx):
@@ -859,21 +866,41 @@ def test_ifunmodifiedsince(st_ctx):
     )
 
 
-@pytest.mark.skipif(
-    "GCS_PAYLOAD_BUCKET" in os.environ,
-    reason="Currently broken on GCS payload offload",
-)
 def test_quota(st_ctx):
-    """Test quota."""
+    """Test quota.
+
+    Uses a non-offloaded collection so the written payload is stored inline and
+    counted by /info/quota; offloaded BSOs leave the Spanner payload NULL.
+    """
     app = st_ctx["app"]
     root = st_ctx["root"]
     res = app.get(root + "/info/quota")
     old_used = res.json[0]
     bso = {"payload": _PLD}
-    retry_put_json(app, root + "/storage/xxx_col2/12345", bso)
+    retry_put_json(app, root + "/storage/" + _NON_OFFLOAD_COL + "/12345", bso)
     res = app.get(root + "/info/quota")
     used = res.json[0]
     assert used - old_used == len(_PLD) / 1024.0
+
+
+def test_offloaded_payload_round_trip(st_ctx):
+    """A payload written to an offload-enabled collection reads back intact.
+
+    In the offload e2e stack xxx_col2 is offloaded to GCS, so this drives the
+    upload then download path. In non-offload runs it's a plain round trip.
+    Either way the client only ever sees the payload, never the payload_link
+    the server uses internally.
+    """
+    app = st_ctx["app"]
+    root = st_ctx["root"]
+    retry_delete(app, root + "/storage")
+
+    payload = "round-trip-" + ("z" * 2048)
+    retry_put_json(app, root + "/storage/xxx_col2/rt1", {"payload": payload})
+
+    item = app.get(root + "/storage/xxx_col2/rt1").json
+    assert item["payload"] == payload
+    assert "payload_link" not in item
 
 
 def test_get_collection_ttl(st_ctx):


### PR DESCRIPTION
The quota and collection_usage tests were skipped under GCS offload because they sum the inline Spanner payload, which is null once a payload lives in GCS. Pointed both at a non-offloaded collection so they run again, and added a round-trip test that a payload offloaded to GCS reads back intact.

Green locally in both the plain spanner e2e and the reconciliation e2e.

Closes STOR-638