### PR TITLE
chore: quiet reconciliation e2e emulator logging

### DIFF
--- a/docker/docker-compose.e2e.reconciliation.yaml
+++ b/docker/docker-compose.e2e.reconciliation.yaml
@@ -20,6 +20,17 @@ services:
         gcloud beta emulators pubsub start
         --host-port=0.0.0.0:8085
         --project=test-project
+    # The emulator is a JVM process; JAVA_TOOL_OPTIONS points it at a
+    # java.util.logging config that raises its level to WARNING so it
+    # stops logging every RPC at INFO. leakDetection=disabled silences
+    # netty's SEVERE ByteBuf-leak stack traces, which are an emulator
+    # internal quirk we don't care about in a throwaway test. STOR-654.
+    environment:
+      JAVA_TOOL_OPTIONS: >-
+        -Djava.util.logging.config.file=/pubsub-logging.properties
+        -Dio.netty.leakDetection.level=disabled
+    volumes:
+      - ./pubsub-emulator-logging.properties:/pubsub-logging.properties:ro
     ports:
       - "8085:8085"
     healthcheck:
@@ -36,6 +47,10 @@ services:
       - -host=0.0.0.0
       - -port=4443
       - -public-host=fake-gcs:4443
+      # Default level logs every storage request; the reconciler and
+      # syncserver hammer it, so drop to warn to keep the CI output
+      # readable. Override with FAKE_GCS_LOG_LEVEL=info to debug. STOR-654.
+      - -log-level=${FAKE_GCS_LOG_LEVEL:-warn}
     ports:
       - "4443:4443"
     healthcheck:

--- a/docker/pubsub-emulator-logging.properties
+++ b/docker/pubsub-emulator-logging.properties
@@ -1,0 +1,11 @@
+# java.util.logging config for the Cloud Pub/Sub emulator in the
+# reconciliation e2e stack. The emulator is a JVM process spawned by
+# `gcloud beta emulators pubsub start`; it logs every RPC at INFO, which
+# floods the docker-compose CI output. Raising the level to WARNING drops
+# the per-request chatter while keeping real warnings and errors.
+#
+# Wired in via JAVA_TOOL_OPTIONS in docker-compose.e2e.reconciliation.yaml
+# (the JVM reads that env var automatically). See STOR-654.
+handlers=java.util.logging.ConsoleHandler
+.level=WARNING
+java.util.logging.ConsoleHandler.level=WARNING


### PR DESCRIPTION
The reconciliation e2e stack dumps a ton of emulator noise into the CI log, mostly per-request lines from fake-gcs and the pub/sub emulator, which buries the logs you actually want to read.

This quiets both emulators without touching what the tests do:

- **fake-gcs**: drop to `-log-level=warn`. Override with `FAKE_GCS_LOG_LEVEL=info` when you need the per-request output back.
- **pub/sub emulator**: it's a JVM process, so point it at a `java.util.logging` config at `WARNING` via `JAVA_TOOL_OPTIONS`, and disable netty's leak detector (it spits SEVERE ByteBuf-leak stack traces that are just an emulator quirk).

Pretty sure this is the cleanest way to do this from what I looked at 🤞 

Checked locally against the two emulators with the same traffic:
- fake-gcs: ~one line per request-ish, 0 lines at warn
- pub/sub: holds at its 7 startup lines even under load (was flooding a ton of INFO + leak traces before)

Closes [STOR-654]()https://mozilla-hub.atlassian.net/browse/STOR-654


[STOR-654]: https://mozilla-hub.atlassian.net/browse/STOR-654?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ