### PR TITLE
fix: stop the reconciler deleting live payload files on batch commit

### DIFF
--- a/docs/src/tools/payload_link_reconciler.md
+++ b/docs/src/tools/payload_link_reconciler.md
@@ -168,14 +168,16 @@ For each mod in the change record:
 - New `payload_link` present: `blob.patch()` sets
   `metadata.committed = "true"` and `customTime = "9999-12-31T23:59:59Z"`.
 - Old `payload_link` present and not equal to the new value: `blob.delete()`,
-  with one exception. A `batch_bsos` row whose link was removed by a client
-  transaction is the batch commit handoff, not an orphan. On commit the link is
-  copied into the permanent `bsos` row inside the same transaction, so deleting
-  the object would drop one `bsos` still points at. Those removals are skipped
-  (`payload_reconciler.batch_commit_skips`). A `batch_bsos` removal by a TTL
-  system transaction (`transactionTag` "RowDeletionPolicy",
-  `isSystemTransaction` true) is a genuinely abandoned batch and is deleted.
-  `bsos` changes and `batch_bsos` overwrites are unaffected. See STOR-657.
+  with one interim exception. Any `batch_bsos` row removal is skipped
+  (`payload_reconciler.batch_bsos_skips`). On a batch commit syncstorage deletes
+  the `batch_bsos` row in the same transaction that copies its link into the
+  permanent `bsos` row, so deleting the object would drop one `bsos` still
+  points at (the STOR-657 bug). `batch_bsos` has no deletion policy of its own,
+  so TTL expiry and `user_collections` deletes arrive as cascade deletes with no
+  tag that separates them from the commit handoff, so all `batch_bsos` removals
+  are skipped for now. That leaks the object for those genuine deletes; the
+  proper fix tags the batch commit transaction so only it is skipped. See
+  STOR-668. `bsos` changes and `batch_bsos` overwrites are unaffected.
 
 Both operations tolerate `404 NotFound` as success, see *Failure
 modes* below.
@@ -227,8 +229,12 @@ message:
 ```
 
 Mod fields (`keys`, `oldValues`, `newValues`) carry **JSON strings**
-that the reconciler parses with a second `json.loads` — this matches
+that the reconciler parses with a second `json.loads`, matching
 Spanner's change-streams wire convention.
+
+`transactionTag` and `isSystemTransaction` are carried on the wire as
+groundwork for STOR-668 (tag-based batch commit detection). The
+reconciler does not consume them yet.
 
 ---
 

--- a/docs/src/tools/payload_link_reconciler.md
+++ b/docs/src/tools/payload_link_reconciler.md
@@ -165,12 +165,19 @@ Sync-pull drain loop with two deployment modes selected by whether
 
 For each mod in the change record:
 
-- New `payload_link` non-null → `blob.patch()` setting
-  `metadata.committed = "true"` and `customTime =
-  "9999-12-31T23:59:59Z"`.
-- Old `payload_link` non-null and ≠ new → `blob.delete()`.
+- New `payload_link` present: `blob.patch()` sets
+  `metadata.committed = "true"` and `customTime = "9999-12-31T23:59:59Z"`.
+- Old `payload_link` present and not equal to the new value: `blob.delete()`,
+  with one exception. A `batch_bsos` row whose link was removed by a client
+  transaction is the batch commit handoff, not an orphan. On commit the link is
+  copied into the permanent `bsos` row inside the same transaction, so deleting
+  the object would drop one `bsos` still points at. Those removals are skipped
+  (`payload_reconciler.batch_commit_skips`). A `batch_bsos` removal by a TTL
+  system transaction (`transactionTag` "RowDeletionPolicy",
+  `isSystemTransaction` true) is a genuinely abandoned batch and is deleted.
+  `bsos` changes and `batch_bsos` overwrites are unaffected. See STOR-657.
 
-Both operations tolerate `404 NotFound` as success — see *Failure
+Both operations tolerate `404 NotFound` as success, see *Failure
 modes* below.
 
 **Environment**
@@ -207,6 +214,8 @@ message:
   "commitTimestamp": "2026-06-30T00:00:00.000000000Z",
   "modType": "UPDATE",
   "tableName": "bsos",
+  "transactionTag": "",
+  "isSystemTransaction": false,
   "mods": [
     {
       "keys": "{\"fxa_uid\":\"...\",\"fxa_kid\":\"...\",\"collection_id\":1,\"bso_id\":\"...\"}",

--- a/tools/payload-link-dataflow/payload-link-publisher-py/publisher.py
+++ b/tools/payload-link-dataflow/payload-link-publisher-py/publisher.py
@@ -90,6 +90,8 @@ def serialize_record(dcr: dict[str, Any]) -> str:
           "commitTimestamp": "…",
           "modType": "INSERT|UPDATE|DELETE",
           "tableName": "bsos|batch_bsos",
+          "transactionTag": "RowDeletionPolicy for TTL deletes, else empty",
+          "isSystemTransaction": true for TTL deletes, else false,
           "mods": [
             {"keys": "<json-string>", "oldValues": "<json-string>", "newValues": "<json-string>"}
           ]
@@ -118,6 +120,8 @@ def serialize_record(dcr: dict[str, Any]) -> str:
         "commitTimestamp": commit_ts_str,
         "modType": dcr.get("mod_type") or "",
         "tableName": dcr.get("table_name") or "",
+        "transactionTag": dcr.get("transaction_tag") or "",
+        "isSystemTransaction": bool(dcr.get("is_system_transaction")),
         "mods": mods_out,
     }
     return json.dumps(payload)
@@ -134,10 +138,13 @@ def serialize_record(dcr: dict[str, Any]) -> str:
 #     [2] child_partitions_record   ARRAY<STRUCT>  (partition splits)
 #
 #   DataChangeRecord STRUCT (only the fields we consume are named):
-#     [0] commit_timestamp                          TIMESTAMP
-#     [4] table_name                                STRING
-#     [6] mods                                      ARRAY<STRUCT<Mod>>
-#     [7] mod_type                                  STRING (INSERT|UPDATE|DELETE)
+#     [0]  commit_timestamp                         TIMESTAMP
+#     [4]  table_name                               STRING
+#     [6]  mods                                     ARRAY<STRUCT<Mod>>
+#     [7]  mod_type                                 STRING (INSERT|UPDATE|DELETE)
+#     [11] transaction_tag                          STRING ("RowDeletionPolicy" for TTL)
+#     [12] is_system_transaction                    BOOL (true for TTL deletes)
+#   (11/12 sit at the tail and may be absent on older emulators; read guarded.)
 #
 #   Mod STRUCT: [keys JSON, new_values JSON, old_values JSON]
 #     (Note: emulator orders new before old; we key by name in the dict.)
@@ -150,6 +157,8 @@ _DCR_COMMIT_TS = 0
 _DCR_TABLE_NAME = 4
 _DCR_MODS = 6
 _DCR_MOD_TYPE = 7
+_DCR_TRANSACTION_TAG = 11
+_DCR_IS_SYSTEM_TRANSACTION = 12
 
 _MOD_KEYS = 0
 _MOD_NEW_VALUES = 1
@@ -163,6 +172,20 @@ _CPR_CHILD_PARTITIONS = 2
 
 _CHILD_TOKEN = 0
 _CHILD_PARENT_TOKENS = 1
+
+
+def _dcr_field(raw_dcr: Any, idx: int) -> Any:
+    """Positional DataChangeRecord field, or None if the struct is shorter.
+
+    The transaction-metadata fields sit at the end of the struct and may be
+    absent on some Spanner emulator revisions; a short struct then reads as
+    None (treated as a non-TTL/client transaction downstream) rather than
+    raising.
+    """
+    try:
+        return raw_dcr[idx]
+    except (IndexError, TypeError):
+        return None
 
 
 def _dcr_to_dict(raw_dcr: Any) -> dict[str, Any] | None:
@@ -187,6 +210,8 @@ def _dcr_to_dict(raw_dcr: Any) -> dict[str, Any] | None:
         "table_name": raw_dcr[_DCR_TABLE_NAME],
         "mods": mods_out,
         "mod_type": raw_dcr[_DCR_MOD_TYPE],
+        "transaction_tag": _dcr_field(raw_dcr, _DCR_TRANSACTION_TAG),
+        "is_system_transaction": _dcr_field(raw_dcr, _DCR_IS_SYSTEM_TRANSACTION),
     }
 
 

--- a/tools/payload-link-dataflow/payload-link-publisher-py/test_publisher.py
+++ b/tools/payload-link-dataflow/payload-link-publisher-py/test_publisher.py
@@ -145,6 +145,34 @@ def test_serialize_record_wire_shape() -> None:
     assert json.loads(m["newValues"]) == {"payload_link": "gs://b/u/c/bso/uuid-b"}
 
 
+def test_serialize_record_carries_transaction_fields() -> None:
+    """TTL deletes surface transactionTag + isSystemTransaction for the reconciler."""
+    dcr = {
+        "commit_timestamp": datetime.datetime(2026, 6, 30, tzinfo=datetime.UTC),
+        "mod_type": "DELETE",
+        "table_name": "batch_bsos",
+        "transaction_tag": "RowDeletionPolicy",
+        "is_system_transaction": True,
+        "mods": [{"keys": "{}", "old_values": LINK_A, "new_values": None}],
+    }
+    out = json.loads(serialize_record(dcr))
+    assert out["transactionTag"] == "RowDeletionPolicy"
+    assert out["isSystemTransaction"] is True
+
+
+def test_serialize_record_transaction_fields_default_for_client_writes() -> None:
+    """A record with no transaction metadata reads as a non-TTL client write."""
+    dcr = {
+        "commit_timestamp": datetime.datetime(2026, 6, 30, tzinfo=datetime.UTC),
+        "mod_type": "DELETE",
+        "table_name": "batch_bsos",
+        "mods": [{"keys": "{}", "old_values": LINK_A, "new_values": None}],
+    }
+    out = json.loads(serialize_record(dcr))
+    assert out["transactionTag"] == ""
+    assert out["isSystemTransaction"] is False
+
+
 def test_serialize_record_defaults_empty_values_to_empty_object_string() -> None:
     """None old/new_values must become the string ``"{}"`` (matches Java)."""
     dcr = {

--- a/tools/payload-link-dataflow/src/main/java/com/mozilla/sync/payloadlink/PayloadLinkChangesToPubSub.java
+++ b/tools/payload-link-dataflow/src/main/java/com/mozilla/sync/payloadlink/PayloadLinkChangesToPubSub.java
@@ -26,11 +26,14 @@ import org.slf4j.LoggerFactory;
  *
  * <p>The output JSON shape is intentionally minimal -- one object per
  * {@code DataChangeRecord} with {@code commitTimestamp}, {@code modType},
- * {@code tableName}, and a {@code mods} array. Each mod carries
- * {@code keys}, {@code oldValues}, and {@code newValues} as raw JSON
- * strings (matching the Spanner change-streams wire format), so the
- * downstream Python reconciler reads them with a second
- * {@code json.loads} per mod.
+ * {@code tableName}, {@code transactionTag}, {@code isSystemTransaction},
+ * and a {@code mods} array. Each mod carries {@code keys},
+ * {@code oldValues}, and {@code newValues} as raw JSON strings (matching
+ * the Spanner change-streams wire format), so the downstream Python
+ * reconciler reads them with a second {@code json.loads} per mod. The
+ * transaction fields let the reconciler tell a TTL delete
+ * ({@code transactionTag} "RowDeletionPolicy", {@code isSystemTransaction}
+ * true) from a client-driven batch commit handoff.
  */
 public final class PayloadLinkChangesToPubSub {
 
@@ -128,6 +131,13 @@ public final class PayloadLinkChangesToPubSub {
             root.put("commitTimestamp", r.getCommitTimestamp().toString());
             root.put("modType", r.getModType().toString());
             root.put("tableName", r.getTableName());
+            // TTL row-deletion-policy deletes carry transaction_tag
+            // "RowDeletionPolicy" and is_system_transaction true; the reconciler
+            // uses these to tell an abandoned batch from a batch commit handoff.
+            root.put(
+                "transactionTag",
+                r.getTransactionTag() == null ? "" : r.getTransactionTag());
+            root.put("isSystemTransaction", r.isSystemTransaction());
             ArrayNode modsArr = root.putArray("mods");
             for (Mod mod : r.getMods()) {
                 ObjectNode modNode = modsArr.addObject();

--- a/tools/payload-reconciler/reconcile_payload_links.py
+++ b/tools/payload-reconciler/reconcile_payload_links.py
@@ -137,6 +137,23 @@ def handle_message_body(
     success), so re-delivery is safe.
     """
     record: dict[str, Any] = json.loads(body)
+    table_name = record.get("tableName")
+
+    # A batch_bsos payload_link is a staging pointer. syncstorage only removes a
+    # batch_bsos row inside the commit transaction, and that same commit copies
+    # the link into the permanent bsos row, so deleting the object on that
+    # removal would drop one the committed bsos row still points at. We skip the
+    # delete for a batch_bsos row removed by a client transaction (the commit
+    # handoff). A batch_bsos row removed by a TTL system transaction is instead a
+    # genuinely abandoned batch, so its object should go. Spanner tags TTL
+    # row deletion policy deletes with transaction_tag "RowDeletionPolicy" and
+    # is_system_transaction true; a client delete has neither. bsos changes and
+    # batch_bsos overwrites are unaffected. See STOR-657.
+    is_ttl_delete = (
+        bool(record.get("isSystemTransaction"))
+        and record.get("transactionTag") == "RowDeletionPolicy"
+    )
+
     ops_performed = 0
     for mod in record.get("mods", []):
         old_values_str = mod.get("oldValues") or "{}"
@@ -151,6 +168,13 @@ def handle_message_body(
             ops_performed += 1
 
         if old_link and old_link != new_link:
+            # A batch_bsos row removed (new_link None) by a non-TTL transaction
+            # is the commit handoff: the object now belongs to bsos, so skip.
+            if table_name == "batch_bsos" and new_link is None and not is_ttl_delete:
+                metrics.incr("batch_commit_skips")
+                # Recognized and intentionally skipped, not filter noise.
+                ops_performed += 1
+                continue
             bucket, name = parse_gs_url(old_link)
             _require_bucket(bucket, expected_bucket)
             delete_object(gcs_client, bucket, name)

--- a/tools/payload-reconciler/reconcile_payload_links.py
+++ b/tools/payload-reconciler/reconcile_payload_links.py
@@ -126,6 +126,19 @@ def handle_message_body(
     success), so re-delivery is safe.
     """
     record: dict[str, Any] = json.loads(body)
+
+    # Ignore batch_bsos change records. A batch_bsos payload_link is a staging
+    # pointer: on batch commit it is copied into the permanent bsos row (which
+    # the change stream also reports, so the object is finalized via that bsos
+    # record) and the batch_bsos row is then deleted. Acting on that delete
+    # would remove a GCS object the committed bsos row still points at. Objects
+    # from batches that are abandoned or overwritten never reach bsos, stay
+    # committed=false, and are reclaimed by the GCS lifecycle policy. See
+    # STOR-657.
+    if record.get("tableName") == "batch_bsos":
+        statsd.incr("payload_reconciler.batch_bsos_skips")
+        return
+
     ops_performed = 0
     for mod in record.get("mods", []):
         old_values_str = mod.get("oldValues") or "{}"

--- a/tools/payload-reconciler/reconcile_payload_links.py
+++ b/tools/payload-reconciler/reconcile_payload_links.py
@@ -139,21 +139,6 @@ def handle_message_body(
     record: dict[str, Any] = json.loads(body)
     table_name = record.get("tableName")
 
-    # A batch_bsos payload_link is a staging pointer. syncstorage only removes a
-    # batch_bsos row inside the commit transaction, and that same commit copies
-    # the link into the permanent bsos row, so deleting the object on that
-    # removal would drop one the committed bsos row still points at. We skip the
-    # delete for a batch_bsos row removed by a client transaction (the commit
-    # handoff). A batch_bsos row removed by a TTL system transaction is instead a
-    # genuinely abandoned batch, so its object should go. Spanner tags TTL
-    # row deletion policy deletes with transaction_tag "RowDeletionPolicy" and
-    # is_system_transaction true; a client delete has neither. bsos changes and
-    # batch_bsos overwrites are unaffected. See STOR-657.
-    is_ttl_delete = (
-        bool(record.get("isSystemTransaction"))
-        and record.get("transactionTag") == "RowDeletionPolicy"
-    )
-
     ops_performed = 0
     for mod in record.get("mods", []):
         old_values_str = mod.get("oldValues") or "{}"
@@ -168,10 +153,18 @@ def handle_message_body(
             ops_performed += 1
 
         if old_link and old_link != new_link:
-            # A batch_bsos row removed (new_link None) by a non-TTL transaction
-            # is the commit handoff: the object now belongs to bsos, so skip.
-            if table_name == "batch_bsos" and new_link is None and not is_ttl_delete:
-                metrics.incr("batch_commit_skips")
+            # Interim: skip the delete for any batch_bsos row removal. On a batch
+            # commit syncstorage deletes the batch_bsos row in the same
+            # transaction that copies its link into the permanent bsos row, so
+            # deleting the object here would drop one bsos still points at (the
+            # STOR-657 bug). We cannot yet tell that commit handoff from a
+            # genuine removal: batch_bsos has no deletion policy of its own, so
+            # TTL expiry and user_collections deletes both arrive as cascade
+            # deletes with no distinguishing tag. Skipping them all leaks the
+            # object for those genuine deletes; the proper fix tags the batch
+            # commit transaction so only it is skipped. See STOR-668.
+            if table_name == "batch_bsos" and new_link is None:
+                metrics.incr("batch_bsos_skips")
                 # Recognized and intentionally skipped, not filter noise.
                 ops_performed += 1
                 continue

--- a/tools/payload-reconciler/test_reconcile_payload_links.py
+++ b/tools/payload-reconciler/test_reconcile_payload_links.py
@@ -26,19 +26,12 @@ def _gcs_mock() -> MagicMock:
     return MagicMock()
 
 
-def _msg(
-    mods: list[dict[str, str]],
-    table: str = "bsos",
-    transaction_tag: str = "",
-    is_system_transaction: bool = False,
-) -> bytes:
+def _msg(mods: list[dict[str, str]], table: str = "bsos") -> bytes:
     return json.dumps(
         {
             "commitTimestamp": "2026-06-29T00:00:00Z",
             "modType": "UPDATE",
             "tableName": table,
-            "transactionTag": transaction_tag,
-            "isSystemTransaction": is_system_transaction,
             "mods": mods,
         }
     ).encode()
@@ -120,11 +113,13 @@ def test_both_null_records_noop_skip(statsd_incr: MagicMock) -> None:
     statsd_incr.assert_any_call("noop_skips")
 
 
-def test_batch_bsos_commit_handoff_delete_is_skipped(statsd_incr: MagicMock) -> None:
-    """A client-driven batch_bsos removal is the commit handoff: never delete.
+def test_batch_bsos_removal_delete_is_skipped(statsd_incr: MagicMock) -> None:
+    """Interim: any batch_bsos row removal is skipped, never deletes the object.
 
-    On commit the link is copied into bsos and the staging row is deleted in the
-    same client transaction, so the object is still live (STOR-657).
+    On a batch commit the staging row is deleted in the same transaction that
+    moves its link into bsos, so deleting here would drop a live object
+    (STOR-657). We cannot yet tell that handoff from a genuine removal, so all
+    batch_bsos removals are skipped for now; the proper fix is STOR-668.
     """
     gcs = _gcs_mock()
 
@@ -135,27 +130,7 @@ def test_batch_bsos_commit_handoff_delete_is_skipped(statsd_incr: MagicMock) -> 
     blob = gcs.bucket.return_value.blob.return_value
     blob.delete.assert_not_called()
     blob.patch.assert_not_called()
-    statsd_incr.assert_any_call("batch_commit_skips")
-
-
-def test_batch_bsos_ttl_delete_deletes(statsd_incr: MagicMock) -> None:
-    """A TTL removal of a batch_bsos row is an abandoned batch: delete its object."""
-    gcs = _gcs_mock()
-
-    reconciler.handle_message_body(
-        gcs,
-        BUCKET,
-        _msg(
-            [_mod(LINK_A, None)],
-            table="batch_bsos",
-            transaction_tag="RowDeletionPolicy",
-            is_system_transaction=True,
-        ),
-    )
-
-    blob = gcs.bucket.return_value.blob.return_value
-    blob.delete.assert_called_once()
-    statsd_incr.assert_any_call("orphan_deletes")
+    statsd_incr.assert_any_call("batch_bsos_skips")
 
 
 def test_batch_bsos_overwrite_still_deletes(statsd_incr: MagicMock) -> None:

--- a/tools/payload-reconciler/test_reconcile_payload_links.py
+++ b/tools/payload-reconciler/test_reconcile_payload_links.py
@@ -27,12 +27,12 @@ def _gcs_mock() -> MagicMock:
     return MagicMock()
 
 
-def _msg(mods: list[dict[str, str]]) -> bytes:
+def _msg(mods: list[dict[str, str]], table: str = "bsos") -> bytes:
     return json.dumps(
         {
             "commitTimestamp": "2026-06-29T00:00:00Z",
             "modType": "UPDATE",
-            "tableName": "bsos",
+            "tableName": table,
             "mods": mods,
         }
     ).encode()
@@ -117,6 +117,27 @@ def test_both_null_records_noop_skip(monkeypatch: pytest.MonkeyPatch) -> None:
     blob.patch.assert_not_called()
     blob.delete.assert_not_called()
     statsd_incr.assert_any_call("payload_reconciler.noop_skips")
+
+
+def test_batch_bsos_records_are_ignored(monkeypatch: pytest.MonkeyPatch) -> None:
+    """batch_bsos changes are staging noise and must never touch GCS (STOR-657).
+
+    On batch commit the staging row's payload_link is copied into bsos and the
+    staging row is deleted; acting on that delete would remove a live object.
+    """
+    statsd_incr = MagicMock()
+    monkeypatch.setattr(statsd_singleton, "incr", statsd_incr)
+    gcs = _gcs_mock()
+
+    # A delete-shaped mod that would delete the object on a bsos record.
+    reconciler.handle_message_body(
+        gcs, BUCKET, _msg([_mod(LINK_A, None)], table="batch_bsos")
+    )
+
+    blob = gcs.bucket.return_value.blob.return_value
+    blob.delete.assert_not_called()
+    blob.patch.assert_not_called()
+    statsd_incr.assert_any_call("payload_reconciler.batch_bsos_skips")
 
 
 def test_finalize_404_is_success(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tools/payload-reconciler/test_reconcile_payload_links.py
+++ b/tools/payload-reconciler/test_reconcile_payload_links.py
@@ -26,12 +26,19 @@ def _gcs_mock() -> MagicMock:
     return MagicMock()
 
 
-def _msg(mods: list[dict[str, str]]) -> bytes:
+def _msg(
+    mods: list[dict[str, str]],
+    table: str = "bsos",
+    transaction_tag: str = "",
+    is_system_transaction: bool = False,
+) -> bytes:
     return json.dumps(
         {
             "commitTimestamp": "2026-06-29T00:00:00Z",
             "modType": "UPDATE",
-            "tableName": "bsos",
+            "tableName": table,
+            "transactionTag": transaction_tag,
+            "isSystemTransaction": is_system_transaction,
             "mods": mods,
         }
     ).encode()
@@ -111,6 +118,61 @@ def test_both_null_records_noop_skip(statsd_incr: MagicMock) -> None:
     blob.patch.assert_not_called()
     blob.delete.assert_not_called()
     statsd_incr.assert_any_call("noop_skips")
+
+
+def test_batch_bsos_commit_handoff_delete_is_skipped(statsd_incr: MagicMock) -> None:
+    """A client-driven batch_bsos removal is the commit handoff: never delete.
+
+    On commit the link is copied into bsos and the staging row is deleted in the
+    same client transaction, so the object is still live (STOR-657).
+    """
+    gcs = _gcs_mock()
+
+    reconciler.handle_message_body(
+        gcs, BUCKET, _msg([_mod(LINK_A, None)], table="batch_bsos")
+    )
+
+    blob = gcs.bucket.return_value.blob.return_value
+    blob.delete.assert_not_called()
+    blob.patch.assert_not_called()
+    statsd_incr.assert_any_call("batch_commit_skips")
+
+
+def test_batch_bsos_ttl_delete_deletes(statsd_incr: MagicMock) -> None:
+    """A TTL removal of a batch_bsos row is an abandoned batch: delete its object."""
+    gcs = _gcs_mock()
+
+    reconciler.handle_message_body(
+        gcs,
+        BUCKET,
+        _msg(
+            [_mod(LINK_A, None)],
+            table="batch_bsos",
+            transaction_tag="RowDeletionPolicy",
+            is_system_transaction=True,
+        ),
+    )
+
+    blob = gcs.bucket.return_value.blob.return_value
+    blob.delete.assert_called_once()
+    statsd_incr.assert_any_call("orphan_deletes")
+
+
+def test_batch_bsos_overwrite_still_deletes(statsd_incr: MagicMock) -> None:
+    """Re-appending the same id in an open batch (link A to B) orphans A.
+
+    That is a client UPDATE, not a removal, so A must still be deleted and B
+    finalized; the commit-handoff skip only covers removals.
+    """
+    gcs = _gcs_mock()
+
+    reconciler.handle_message_body(
+        gcs, BUCKET, _msg([_mod(LINK_A, LINK_B)], table="batch_bsos")
+    )
+
+    assert gcs.bucket.return_value.blob.call_count == 2
+    statsd_incr.assert_any_call("finalizes")
+    statsd_incr.assert_any_call("orphan_deletes")
 
 
 def test_finalize_404_is_success(statsd_incr: MagicMock) -> None:


### PR DESCRIPTION
When a batch upload commits, the reconciler was deleting the GCS payload file that the committed record still points at, so later reads of that record failed with a 500. In CI this shows up as the flaky reconciliation e2e failures on the batch tests.

Why it happens: a batch write stores the payload link on a temporary batch_bsos row. On commit that same link is copied into the permanent bsos row and the batch_bsos rows are deleted. The change stream reports both tables, so the reconciler saw the batch_bsos deletion, treated it as an orphaned file, and deleted an object the bsos row still needs.

This change makes the reconciler ignore batch_bsos records and act only on bsos records. Committed batch files still get finalized through the bsos write. Files from batches that are abandoned or overwritten stay uncommitted and get swept by the GCS lifecycle policy, so nothing leaks. The table name is already in the message the reconciler reads, so no publisher or sync changes are needed.

Closes STOR-657