### PR TITLE
fix(ci): publish payload-link spec as the dedicated tmpl-pub SA

### DIFF
--- a/.github/workflows/mozcloud-publish.yaml
+++ b/.github/workflows/mozcloud-publish.yaml
@@ -303,7 +303,7 @@ jobs:
         with:
           token_format: access_token
           workload_identity_provider: ${{ vars.GCPV2_GITHUB_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ vars.PAYLOAD_LINK_DATAFLOW_DEPLOY_SA || 'sync-nonprod-dev-payload-link@moz-fx-sync-nonprod.iam.gserviceaccount.com' }}
+          service_account: ${{ vars.PAYLOAD_LINK_DATAFLOW_DEPLOY_SA || 'sync-nonprod-dev-tmpl-pub@moz-fx-sync-nonprod.iam.gserviceaccount.com' }}
 
       - uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
 


### PR DESCRIPTION
The spec-publish job (from #2491) defaults to impersonating the runtime Dataflow SA. webservices-infra set up a dedicated publisher SA (sync-nonprod-dev-tmpl-pub) with bucket write scoped to templates/ and a WIF binding for this repo, so CI can publish the spec without holding runtime privileges. Point the default at it.

Closes [STOR-667](https://mozilla-hub.atlassian.net/browse/STOR-667)

[STOR-667]: https://mozilla-hub.atlassian.net/browse/STOR-667?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ