### PR TITLE
feat: support assuming a spanner database role in payload-link-dataflow

### DIFF
--- a/tools/payload-link-dataflow/README.md
+++ b/tools/payload-link-dataflow/README.md
@@ -80,6 +80,35 @@ The Dataflow job's service account needs:
 - `roles/pubsub.publisher` on the destination topic
 - `roles/dataflow.worker`
 
+### Fine-grained access control (optional)
+
+Pass `spannerDatabaseRole` to read the change stream under a Spanner
+database role instead of a database-wide IAM grant. `payload_link_reader`
+in `syncstorage-spanner/src/schema.ddl` is that role: it holds `SELECT`
+on `payload_link_changes` and `EXECUTE` on the generated
+`READ_payload_link_changes` table function, and nothing else.
+
+The role applies to the change stream read only. Beam's
+`MetadataSpannerConfigFactory` deliberately does not copy `databaseRole`
+onto the connector's metadata database config, so that connection still
+uses the service account's own IAM grants. Two consequences, both from
+[Spanner's FGAC guidance](https://docs.cloud.google.com/spanner/docs/fgac-change-streams):
+
+- `spannerMetadataDatabase` **must** be a different database than
+  `spannerDatabase`. The connector needs database-level write access for
+  its partition state, and that grant would override the role's
+  restrictions on the database being read.
+- the service account must **not** hold `roles/spanner.databaseUser` on
+  `spannerDatabase` -- it bypasses fine-grained access control outright.
+  Grant `roles/spanner.fineGrainedAccessUser`, plus
+  `roles/spanner.databaseRoleUser` conditioned on the role resource,
+  instead.
+
+If the metadata tables share the syncstorage database, setting
+`spannerDatabaseRole` buys nothing security-wise: the role is assumed,
+but the database-level grant the connector needs supersedes it.
+Provision a dedicated metadata database first.
+
 ## Filter behaviour
 
 `PayloadLinkChangesToPubSub.isPayloadLinkActionable` keeps a
@@ -117,12 +146,16 @@ differences are:
   registrar for flex-template metadata. We register via
   `metadata.json` + `gcloud dataflow flex-template build` instead --
   simpler, no annotation-processor dependency.
-- **No support for these upstream options:** `spannerDatabaseRole`,
+- **No support for these upstream options:**
   `useSpannerEmulatorHost`, `spannerHost`, `spannerMetadataTableName`,
   `spannerChangeStreamTvfNameList`, `outputMessageMetadata`,
   `outputDataFormat` (JSON/Avro switch), `pubsubAPI`. Our
-  `PayloadLinkOptions` deliberately has a smaller surface (~10
-  options vs. upstream's ~25).
+  `PayloadLinkOptions` deliberately has a smaller surface (~11
+  options vs. upstream's ~25). `spannerDatabaseRole` was ported over
+  from upstream in STOR-661 -- see "Fine-grained access control" above.
+  Note we default it to `""` and guard on empty, where upstream leaves
+  it null and guards on null; this matches how `startTimestamp` /
+  `endTimestamp` are already handled here.
 - **No ValueProvider indirection on options.** Upstream wraps
   several config fields in `ValueProvider` for template
   parameterisation; we take plain strings.

--- a/tools/payload-link-dataflow/metadata.json
+++ b/tools/payload-link-dataflow/metadata.json
@@ -21,6 +21,13 @@
       "paramType": "TEXT"
     },
     {
+      "name": "spannerDatabaseRole",
+      "label": "Spanner database role",
+      "helpText": "Spanner database role to assume when reading the change stream, for fine-grained access control (e.g. payload_link_reader). The role needs SELECT on the change stream and EXECUTE on its read function. Requires spannerMetadataDatabase to be a different database than spannerDatabase, and the job service account must not hold roles/spanner.databaseUser on spannerDatabase. Omit to rely on IAM-level access.",
+      "paramType": "TEXT",
+      "isOptional": true
+    },
+    {
       "name": "spannerMetadataInstanceId",
       "label": "Spanner metadata instance ID",
       "helpText": "Spanner instance where the change stream's metadata table lives. May be the same as spannerInstanceId.",

--- a/tools/payload-link-dataflow/src/main/java/com/mozilla/sync/payloadlink/PayloadLinkChangesToPubSub.java
+++ b/tools/payload-link-dataflow/src/main/java/com/mozilla/sync/payloadlink/PayloadLinkChangesToPubSub.java
@@ -13,6 +13,7 @@ import org.apache.beam.sdk.io.gcp.spanner.SpannerIO;
 import org.apache.beam.sdk.io.gcp.spanner.changestreams.model.DataChangeRecord;
 import org.apache.beam.sdk.io.gcp.spanner.changestreams.model.Mod;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.options.ValueProvider.StaticValueProvider;
 import org.apache.beam.sdk.transforms.Filter;
 import org.apache.beam.sdk.transforms.MapElements;
 import org.apache.beam.sdk.values.TypeDescriptors;
@@ -53,11 +54,7 @@ public final class PayloadLinkChangesToPubSub {
     static PipelineResult run(PayloadLinkOptions options) {
         Pipeline pipeline = Pipeline.create(options);
 
-        SpannerConfig spannerConfig = SpannerConfig.create()
-            .withProjectId(options.getSpannerProjectId())
-            .withInstanceId(options.getSpannerInstanceId())
-            .withDatabaseId(options.getSpannerDatabase())
-            .withRpcPriority(options.getRpcPriority());
+        SpannerConfig spannerConfig = buildSpannerConfig(options);
 
         Timestamp startTimestamp = options.getStartTimestamp().isEmpty()
             ? Timestamp.now()
@@ -89,6 +86,34 @@ public final class PayloadLinkChangesToPubSub {
                 PubsubIO.writeStrings().to(options.getPubsubTopic()));
 
         return pipeline.run();
+    }
+
+    /**
+     * Builds the change stream reader's {@link SpannerConfig}, optionally
+     * assuming a Spanner database role for fine-grained access control.
+     *
+     * <p>The role scopes the change stream read only. Beam's
+     * {@code MetadataSpannerConfigFactory} deliberately does not copy
+     * {@code databaseRole} onto the connector's metadata database config, so
+     * that connection still authenticates with the job service account's own
+     * IAM grants. Per Spanner's FGAC guidance the metadata database therefore
+     * has to be a different database than the one being read, otherwise the
+     * database-level grant it needs overrides the role's restrictions.
+     */
+    static SpannerConfig buildSpannerConfig(PayloadLinkOptions options) {
+        SpannerConfig spannerConfig = SpannerConfig.create()
+            .withProjectId(options.getSpannerProjectId())
+            .withInstanceId(options.getSpannerInstanceId())
+            .withDatabaseId(options.getSpannerDatabase())
+            .withRpcPriority(options.getRpcPriority());
+
+        String databaseRole = options.getSpannerDatabaseRole();
+        if (!databaseRole.isEmpty()) {
+            spannerConfig =
+                spannerConfig.withDatabaseRole(StaticValueProvider.of(databaseRole));
+        }
+
+        return spannerConfig;
     }
 
     /**

--- a/tools/payload-link-dataflow/src/main/java/com/mozilla/sync/payloadlink/PayloadLinkOptions.java
+++ b/tools/payload-link-dataflow/src/main/java/com/mozilla/sync/payloadlink/PayloadLinkOptions.java
@@ -22,6 +22,16 @@ public interface PayloadLinkOptions extends DataflowPipelineOptions {
     String getSpannerDatabase();
     void setSpannerDatabase(String value);
 
+    @Description(
+        "Spanner database role to assume when reading the change stream, for "
+        + "fine-grained access control. The role needs SELECT on the change "
+        + "stream and EXECUTE on its read function. Applies to the change "
+        + "stream read only -- the connector's metadata database always "
+        + "authenticates via IAM. Empty -> assume no role.")
+    @Default.String("")
+    String getSpannerDatabaseRole();
+    void setSpannerDatabaseRole(String value);
+
     @Required
     @Description("Spanner instance where the change stream's metadata table lives.")
     String getSpannerMetadataInstanceId();

--- a/tools/payload-link-dataflow/src/test/java/com/mozilla/sync/payloadlink/PayloadLinkChangesToPubSubTest.java
+++ b/tools/payload-link-dataflow/src/test/java/com/mozilla/sync/payloadlink/PayloadLinkChangesToPubSubTest.java
@@ -3,22 +3,28 @@ package com.mozilla.sync.payloadlink;
 import com.google.cloud.Timestamp;
 import java.util.Arrays;
 import java.util.Collections;
+import org.apache.beam.sdk.io.gcp.spanner.SpannerConfig;
 import org.apache.beam.sdk.io.gcp.spanner.changestreams.model.DataChangeRecord;
 import org.apache.beam.sdk.io.gcp.spanner.changestreams.model.Mod;
 import org.apache.beam.sdk.io.gcp.spanner.changestreams.model.ModType;
 import org.apache.beam.sdk.io.gcp.spanner.changestreams.model.ValueCaptureType;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 /**
- * Unit tests for {@link PayloadLinkChangesToPubSub#isPayloadLinkActionable}.
+ * Unit tests for {@link PayloadLinkChangesToPubSub#isPayloadLinkActionable}
+ * and {@link PayloadLinkChangesToPubSub#buildSpannerConfig}.
  *
- * <p>The filter is the sole customization this template adds over the
- * upstream Spanner-CS-to-Pub/Sub template; its semantics are load-bearing
- * for the downstream reconciler and Pub/Sub volume budget. Test cases
- * mirror the column-scoped change-stream shapes for {@code payload_link}.
+ * <p>The filter is the sole transform-level customization this template adds
+ * over the upstream Spanner-CS-to-Pub/Sub template; its semantics are
+ * load-bearing for the downstream reconciler and Pub/Sub volume budget. Test
+ * cases mirror the column-scoped change-stream shapes for
+ * {@code payload_link}.
  *
  * <p>Note: {@link DataChangeRecord} constructor signatures have shifted
  * across Beam releases. If a Beam version bump breaks compilation here,
@@ -110,6 +116,48 @@ public class PayloadLinkChangesToPubSubTest {
     public void emptyJsonStrings_treatedAsNull_dropped() {
         DataChangeRecord r = recordWithMods(new Mod("{}", "", ""));
         assertFalse(PayloadLinkChangesToPubSub.isPayloadLinkActionable(r));
+    }
+
+    @Test
+    public void databaseRoleUnset_isNotAppliedToConfig() {
+        SpannerConfig config = PayloadLinkChangesToPubSub.buildSpannerConfig(options());
+        assertNull(
+            "an unset role must leave the config on plain IAM auth",
+            config.getDatabaseRole());
+    }
+
+    @Test
+    public void databaseRoleSet_isAppliedToConfig() {
+        PayloadLinkOptions options = options();
+        options.setSpannerDatabaseRole("payload_link_reader");
+
+        SpannerConfig config = PayloadLinkChangesToPubSub.buildSpannerConfig(options);
+        assertEquals("payload_link_reader", config.getDatabaseRole().get());
+    }
+
+    @Test
+    public void databaseRoleDoesNotDisturbOtherConfig() {
+        PayloadLinkOptions options = options();
+        options.setSpannerDatabaseRole("payload_link_reader");
+
+        SpannerConfig config = PayloadLinkChangesToPubSub.buildSpannerConfig(options);
+        assertEquals("test-project", config.getProjectId().get());
+        assertEquals("test-instance", config.getInstanceId().get());
+        assertEquals("test-database", config.getDatabaseId().get());
+    }
+
+    /**
+     * Minimal options for {@code buildSpannerConfig}. Built without
+     * {@code withValidation()} so the {@code @Required} options this method
+     * does not read can stay unset.
+     */
+    private static PayloadLinkOptions options() {
+        PayloadLinkOptions options =
+            PipelineOptionsFactory.create().as(PayloadLinkOptions.class);
+        options.setSpannerProjectId("test-project");
+        options.setSpannerInstanceId("test-instance");
+        options.setSpannerDatabase("test-database");
+        return options;
     }
 
     private static DataChangeRecord recordWithMods(Mod... mods) {


### PR DESCRIPTION
## Description

This is for use by the access defined in webservices-infra: https://github.com/mozilla-services/cloudops-infra/pull/6952

The `payload_link_reader` role added in #2507 had no consumer. The dataflow job still reads the change stream through a database-wide IAM grant, so the role sat unused. This ports spannerDatabaseRole over from the upstream flex template, which already supports it, so the job can assume the role instead.

What's here:

- `spannerDatabaseRole` option, optional, empty by default
- `buildSpannerConfig` pulled out of run() so the wiring is unit testable
- the matching flex template parameter in `metadata.json`
- README section on the preconditions, and spannerDatabaseRole removed from
  the "no support for these upstream options" list

The role only scopes the change stream read, I think. Beam deliberately does not copy `databaseRole` onto the change stream connector's metadata database config, so that connection keeps using the job service account's own IAM grants. 

Also ran .`/generate-full-delta.sh `against the pinned upstream SHA (as Phil suggested) to compare the port against upstream's own implementation. Same `withDatabaseRole` call and the same `StaticValueProvider` wrapping. The only difference is that we default to empty and guard on empty where upstream leaves it null and guards on null, which matches how `startTimestamp` and `endTimes`tamp already work here. That's noted in the README.


## Issue(s)
Issue STOR-661