### PR TITLE
fix: SpannerIO requires the v2 runner

### DIFF
--- a/tools/payload-link-dataflow/Dockerfile
+++ b/tools/payload-link-dataflow/Dockerfile
@@ -27,7 +27,11 @@ RUN mvn -B -e dependency:go-offline
 COPY src /build/src
 RUN mvn -B -e package
 
-FROM gcr.io/dataflow-templates-base/java17-template-launcher-base:latest
+# Pinned to a specific dated release, not ":latest", so the launcher's Beam
+# version can't drift out from under the pipeline's pinned beam.version in
+# pom.xml. Bump both together when upgrading Beam. Find newer tags at:
+#   https://gcr.io/v2/dataflow-templates-base/java17-template-launcher-base/tags/list
+FROM gcr.io/dataflow-templates-base/java17-template-launcher-base:20260803-rc00
 
 ENV FLEX_TEMPLATE_JAVA_MAIN_CLASS=com.mozilla.sync.payloadlink.PayloadLinkChangesToPubSub
 ENV FLEX_TEMPLATE_JAVA_CLASSPATH=/template/payload-link-dataflow.jar

--- a/tools/payload-link-dataflow/README.md
+++ b/tools/payload-link-dataflow/README.md
@@ -137,8 +137,6 @@ differences are:
   `numberOfPartitionsInTransaction`, `partitionToken`,
   `recordSequence`, `isLastRecordInTransactionInPartition`,
   `valueCaptureType`.
-- **No Runner V2 experiment auto-injection.** Upstream mutates
-  `options.experiments` to append `use_runner_v2`; we don't.
 - **No `UncaughtExceptionLogger.register()`.** Uncaught exceptions
   flow to the runner's default handler.
 - **No `@Template` / `TemplateCategory` annotations.** Upstream uses
@@ -159,13 +157,23 @@ differences are:
 - **No ValueProvider indirection on options.** Upstream wraps
   several config fields in `ValueProvider` for template
   parameterisation; we take plain strings.
-- **No `enableStreamingEngine=true` / `streaming=true` mutation.**
-  Beam infers streaming from the source; we don't force it.
+- **No explicit `streaming=true` mutation.** Beam infers streaming
+  from the source (`SpannerIO.readChangeStream` is
+  `@UnboundedPerElement`) and `DataflowRunner` flips the flag at
+  translation time.
 
 These deltas were deliberate scope choices, not oversights. The
 filter-only patch is kept as the primary review artifact because
 it's small enough to eyeball, applies cleanly against the pinned
 SHA, and is insensitive to upstream churn on features we don't use.
+
+`main()` matches upstream on two pipeline-shape invariants that are
+not deployment choices for this source: it appends `use_runner_v2`
+to `options.experiments` and calls `setEnableStreamingEngine(true)`.
+`BundleFinalizer` (used by `SpannerIO.readChangeStream`) requires the
+Dataflow Portable Runner ("Runner V2"), and V2 streaming jobs
+require Streaming Engine -- so both settings are pinned in code
+rather than left to launch-time flags.
 
 ## Output wire format
 

--- a/tools/payload-link-dataflow/src/main/java/com/mozilla/sync/payloadlink/PayloadLinkChangesToPubSub.java
+++ b/tools/payload-link-dataflow/src/main/java/com/mozilla/sync/payloadlink/PayloadLinkChangesToPubSub.java
@@ -5,6 +5,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.cloud.Timestamp;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubIO;
@@ -48,6 +51,21 @@ public final class PayloadLinkChangesToPubSub {
             .fromArgs(args)
             .withValidation()
             .as(PayloadLinkOptions.class);
+
+        // BundleFinalizer (used by SpannerIO.readChangeStream) requires the
+        // Dataflow Portable Runner ("Runner V2"), and V2 for streaming jobs
+        // requires Streaming Engine. Both are pipeline-shape invariants of
+        // this source, not deployment choices -- pinning them here means
+        // every launch path (flex-template, java -jar, tests) gets it right
+        // without having to remember to pass the flags.
+        List<String> experiments = new ArrayList<>(
+            Optional.ofNullable(options.getExperiments()).orElse(List.of()));
+        if (!experiments.contains("use_runner_v2")) {
+            experiments.add("use_runner_v2");
+        }
+        options.setExperiments(experiments);
+        options.setEnableStreamingEngine(true);
+
         run(options);
     }
 


### PR DESCRIPTION
## Description

and the v2 runner requires streaming engine

also pin the base Docker for reproducable builds

## Issue(s)

Closes STOR-669
