### PR TITLE
feat: add metrics for gcs payload cleanup on failed db transactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4743,6 +4743,7 @@ dependencies = [
  "base64 0.23.0",
  "cadence",
  "chrono",
+ "crossbeam-channel",
  "deadpool",
  "docopt",
  "futures 0.3.32",

--- a/syncserver/Cargo.toml
+++ b/syncserver/Cargo.toml
@@ -64,6 +64,8 @@ validator_derive = "0.20"
 woothee = "0.13"
 
 [dev-dependencies]
+# Receiver half of cadence's SpyMetricSink, used to assert on emitted metrics.
+crossbeam-channel = "0.5"
 google-cloud-gax = "1.11"
 httptest = "0.16"
 temp-env.workspace = true

--- a/syncserver/src/web/handlers.rs
+++ b/syncserver/src/web/handlers.rs
@@ -29,7 +29,8 @@ use crate::{
             HeartbeatRequest, MetaRequest, ReplyFormat, TestErrorRequest,
         },
         payload_offload::{
-            delete_payload, download_payload, offload_bucket, reattach_by_index, upload_payload,
+            CLEANUP_METRIC, cleanup_tags, delete_payload, download_payload, offload_bucket,
+            reattach_by_index, upload_payload,
         },
         transaction::DbTransactionPool,
     },
@@ -526,12 +527,20 @@ pub async fn post_collection(
         })
         .await;
 
-    if resp.is_err()
-        && !offload_urls.is_empty()
-        && let Ok(client) = state.gcs_control_client()
-    {
-        for url in offload_urls {
-            let _ = delete_payload(client, &url, &metrics, "post_collection").await;
+    if resp.is_err() && !offload_urls.is_empty() {
+        match state.gcs_control_client() {
+            Ok(client) => {
+                for url in offload_urls {
+                    let _ = delete_payload(client, &url, &metrics, "post_collection").await;
+                }
+            }
+            // No client to clean up with: the objects are left to the
+            // reconciler, so count them rather than dropping the signal.
+            Err(_) => metrics.count_with_tags(
+                CLEANUP_METRIC,
+                offload_urls.len() as i64,
+                cleanup_tags("post_collection", "skipped"),
+            ),
         }
     }
 
@@ -864,9 +873,17 @@ pub async fn put_bso(
 
     if resp.is_err()
         && let Some(gcs_url) = &payload_link
-        && let Ok(client) = state.gcs_control_client()
     {
-        let _ = delete_payload(client, gcs_url, &metrics, "put_bso").await;
+        match state.gcs_control_client() {
+            Ok(client) => {
+                let _ = delete_payload(client, gcs_url, &metrics, "put_bso").await;
+            }
+            // No client to clean up with: the object is left to the
+            // reconciler, so count it rather than dropping the signal.
+            Err(_) => {
+                metrics.incr_with_tags(CLEANUP_METRIC, cleanup_tags("put_bso", "skipped"));
+            }
+        }
     }
     resp
 }

--- a/syncserver/src/web/handlers.rs
+++ b/syncserver/src/web/handlers.rs
@@ -29,8 +29,8 @@ use crate::{
             HeartbeatRequest, MetaRequest, ReplyFormat, TestErrorRequest,
         },
         payload_offload::{
-            CLEANUP_METRIC, CleanupHandler, CleanupResult, cleanup_tags, delete_payload,
-            download_payload, offload_bucket, reattach_by_index, upload_payload,
+            CleanupHandler, delete_payload, download_payload, offload_bucket, reattach_by_index,
+            upload_payload,
         },
         transaction::DbTransactionPool,
     },
@@ -527,21 +527,15 @@ pub async fn post_collection(
         })
         .await;
 
-    if resp.is_err() && !offload_urls.is_empty() {
-        match state.gcs_control_client() {
-            Ok(client) => {
-                for url in offload_urls {
-                    let _ = delete_payload(client, &url, &metrics, CleanupHandler::PostCollection)
-                        .await;
-                }
-            }
-            // No client to clean up with: the objects are left to the
-            // reconciler, so count them rather than dropping the signal.
-            Err(_) => metrics.count_with_tags(
-                CLEANUP_METRIC,
-                offload_urls.len() as i64,
-                cleanup_tags(CleanupHandler::PostCollection, CleanupResult::Skipped),
-            ),
+    // The control client is always present here: both GCS clients are built
+    // together at startup when a payload bucket is configured, and the upload
+    // above already required the other one.
+    if resp.is_err()
+        && !offload_urls.is_empty()
+        && let Ok(client) = state.gcs_control_client()
+    {
+        for url in offload_urls {
+            let _ = delete_payload(client, &url, &metrics, CleanupHandler::PostCollection).await;
         }
     }
 
@@ -872,22 +866,12 @@ pub async fn put_bso(
         })
         .await;
 
+    // The control client is always present here, see post_collection above.
     if resp.is_err()
         && let Some(gcs_url) = &payload_link
+        && let Ok(client) = state.gcs_control_client()
     {
-        match state.gcs_control_client() {
-            Ok(client) => {
-                let _ = delete_payload(client, gcs_url, &metrics, CleanupHandler::PutBso).await;
-            }
-            // No client to clean up with: the object is left to the
-            // reconciler, so count it rather than dropping the signal.
-            Err(_) => {
-                metrics.incr_with_tags(
-                    CLEANUP_METRIC,
-                    cleanup_tags(CleanupHandler::PutBso, CleanupResult::Skipped),
-                );
-            }
-        }
+        let _ = delete_payload(client, gcs_url, &metrics, CleanupHandler::PutBso).await;
     }
     resp
 }

--- a/syncserver/src/web/handlers.rs
+++ b/syncserver/src/web/handlers.rs
@@ -29,8 +29,8 @@ use crate::{
             HeartbeatRequest, MetaRequest, ReplyFormat, TestErrorRequest,
         },
         payload_offload::{
-            CLEANUP_METRIC, cleanup_tags, delete_payload, download_payload, offload_bucket,
-            reattach_by_index, upload_payload,
+            CLEANUP_METRIC, CleanupHandler, CleanupResult, cleanup_tags, delete_payload,
+            download_payload, offload_bucket, reattach_by_index, upload_payload,
         },
         transaction::DbTransactionPool,
     },
@@ -531,7 +531,8 @@ pub async fn post_collection(
         match state.gcs_control_client() {
             Ok(client) => {
                 for url in offload_urls {
-                    let _ = delete_payload(client, &url, &metrics, "post_collection").await;
+                    let _ = delete_payload(client, &url, &metrics, CleanupHandler::PostCollection)
+                        .await;
                 }
             }
             // No client to clean up with: the objects are left to the
@@ -539,7 +540,7 @@ pub async fn post_collection(
             Err(_) => metrics.count_with_tags(
                 CLEANUP_METRIC,
                 offload_urls.len() as i64,
-                cleanup_tags("post_collection", "skipped"),
+                cleanup_tags(CleanupHandler::PostCollection, CleanupResult::Skipped),
             ),
         }
     }
@@ -876,12 +877,15 @@ pub async fn put_bso(
     {
         match state.gcs_control_client() {
             Ok(client) => {
-                let _ = delete_payload(client, gcs_url, &metrics, "put_bso").await;
+                let _ = delete_payload(client, gcs_url, &metrics, CleanupHandler::PutBso).await;
             }
             // No client to clean up with: the object is left to the
             // reconciler, so count it rather than dropping the signal.
             Err(_) => {
-                metrics.incr_with_tags(CLEANUP_METRIC, cleanup_tags("put_bso", "skipped"));
+                metrics.incr_with_tags(
+                    CLEANUP_METRIC,
+                    cleanup_tags(CleanupHandler::PutBso, CleanupResult::Skipped),
+                );
             }
         }
     }

--- a/syncserver/src/web/handlers.rs
+++ b/syncserver/src/web/handlers.rs
@@ -440,6 +440,10 @@ pub async fn post_collection(
     // This also covers the batched path: post_collection_batch reads from
     // `coll.bsos.valid` once the transaction is open, by which point each
     // entry's payload/payload_link have already been swapped.
+
+    // Cloned up front: `coll` is moved into the transaction closure below, but
+    // the GCS cleanup after it needs to emit metrics.
+    let metrics = coll.metrics.clone();
     let mut offload_urls: Vec<String> = Vec::new();
     if let Some(bucket) = offload_bucket(&state, &coll.collection) {
         let client = state.gcs_client()?;
@@ -527,7 +531,7 @@ pub async fn post_collection(
         && let Ok(client) = state.gcs_control_client()
     {
         for url in offload_urls {
-            let _ = delete_payload(client, &url).await;
+            let _ = delete_payload(client, &url, &metrics, "post_collection").await;
         }
     }
 
@@ -817,6 +821,9 @@ pub async fn put_bso(
     state: Data<ServerState>,
     request: HttpRequest,
 ) -> Result<HttpResponse, ApiError> {
+    // Cloned up front: `bso_req` is moved into the transaction closure below,
+    // but the GCS cleanup after it needs to emit metrics.
+    let metrics = bso_req.metrics.clone();
     let mut payload_link = None;
     if let Some(bucket) = offload_bucket(&state, &bso_req.collection)
         && let Some(payload) = bso_req.body.payload.take()
@@ -859,7 +866,7 @@ pub async fn put_bso(
         && let Some(gcs_url) = &payload_link
         && let Ok(client) = state.gcs_control_client()
     {
-        let _ = delete_payload(client, gcs_url).await;
+        let _ = delete_payload(client, gcs_url, &metrics, "put_bso").await;
     }
     resp
 }

--- a/syncserver/src/web/payload_offload.rs
+++ b/syncserver/src/web/payload_offload.rs
@@ -348,6 +348,30 @@ mod tests {
         );
     }
 
+    #[actix_rt::test]
+    async fn delete_payload_counts_a_gcs_failure() {
+        let client = StorageControl::from_stub(FailingStub);
+        let (metrics, recorded) = recording_metrics();
+
+        delete_payload(
+            &client,
+            "gs://test-bucket/uid/bookmarks/bid/uuid",
+            &metrics,
+            "post_collection",
+        )
+        .await
+        .expect_err("a failed GCS delete should surface as an error");
+
+        let emitted = recorded.lock().unwrap().join("\n");
+        assert!(
+            emitted.contains(CLEANUP_METRIC)
+                && emitted.contains("result:failure")
+                && emitted.contains("reason:gcs_error")
+                && emitted.contains("handler:post_collection"),
+            "unexpected cleanup metric: {emitted}"
+        );
+    }
+
     #[test]
     fn reattach_results_to_correct_slots() {
         let mut items: Vec<Option<String>> = vec![None, None, None, None];

--- a/syncserver/src/web/payload_offload.rs
+++ b/syncserver/src/web/payload_offload.rs
@@ -153,30 +153,22 @@ pub async fn delete_payload(
     metrics: &Metrics,
     handler: &str,
 ) -> Result<(), ApiError> {
-    let (bucket, object) = match parse_gs_url(gs_url) {
-        Ok(parsed) => parsed,
-        Err(e) => {
-            metrics.incr_with_tags(CLEANUP_METRIC, cleanup_failure_tags(handler, "invalid_url"));
-            return Err(e);
-        }
-    };
+    let (bucket, object) = parse_gs_url(gs_url).inspect_err(|_| {
+        metrics.incr_with_tags(CLEANUP_METRIC, cleanup_failure_tags(handler, "invalid_url"))
+    })?;
 
-    let result = client
+    client
         .delete_object()
         .set_bucket(bucket_path(bucket))
         .set_object(object)
         .send()
-        .await;
-
-    match &result {
-        Ok(_) => metrics.incr_with_tags(CLEANUP_METRIC, cleanup_tags(handler, "success")),
-        Err(e) => {
+        .await
+        .inspect(|_| metrics.incr_with_tags(CLEANUP_METRIC, cleanup_tags(handler, "success")))
+        .inspect_err(|e| {
             warn!("gcs payload cleanup failed for {gs_url}: {e}");
             metrics.incr_with_tags(CLEANUP_METRIC, cleanup_failure_tags(handler, "gcs_error"));
-        }
-    }
-
-    result.map_err(|e| ApiErrorKind::Internal(format!("cannot delete GCS object: {e}")).into())
+        })
+        .map_err(|e| ApiErrorKind::Internal(format!("cannot delete GCS object: {e}")).into())
 }
 
 fn bucket_path(bucket: &str) -> String {

--- a/syncserver/src/web/payload_offload.rs
+++ b/syncserver/src/web/payload_offload.rs
@@ -31,9 +31,8 @@ const COMMITTED_METADATA_KEY: &str = "committed";
 
 /// Counter for the best-effort GCS cleanup that runs when the database
 /// transaction of an offloading write fails. Tagged with the `handler` that
-/// issued it, a `result` of `success`, `failure` or `skipped`, and on failure
-/// a `reason`.
-pub const CLEANUP_METRIC: &str = "storage.gcs.payload.cleanup";
+/// issued it, a `result` of `success` or `failure`, and on failure a `reason`.
+const CLEANUP_METRIC: &str = "storage.gcs.payload.cleanup";
 
 /// Return the GCS bucket name if `collection` is opted into payload off-load
 /// and a bucket is configured. `None` disables off-load for this request.
@@ -151,10 +150,8 @@ impl CleanupHandler {
 
 /// The outcome of a cleanup attempt, as the `result` and `reason` tags.
 #[derive(Clone, Copy, Debug)]
-pub enum CleanupResult {
+enum CleanupResult {
     Success,
-    /// No GCS control client was available, so no delete was attempted.
-    Skipped,
     /// The `gs://` URL did not parse, so no delete was issued.
     InvalidUrl,
     /// GCS rejected the delete.
@@ -165,7 +162,6 @@ impl CleanupResult {
     fn as_str(self) -> &'static str {
         match self {
             Self::Success => "success",
-            Self::Skipped => "skipped",
             Self::InvalidUrl | Self::GcsError => "failure",
         }
     }
@@ -173,7 +169,7 @@ impl CleanupResult {
     /// The `reason` tag, set for the failure variants only.
     fn reason(self) -> Option<&'static str> {
         match self {
-            Self::Success | Self::Skipped => None,
+            Self::Success => None,
             Self::InvalidUrl => Some("invalid_url"),
             Self::GcsError => Some("gcs_error"),
         }
@@ -181,7 +177,7 @@ impl CleanupResult {
 }
 
 /// Tags for a [`CLEANUP_METRIC`] emission from `handler` with `result`.
-pub fn cleanup_tags(handler: CleanupHandler, result: CleanupResult) -> HashMap<String, String> {
+fn cleanup_tags(handler: CleanupHandler, result: CleanupResult) -> HashMap<String, String> {
     let mut tags = HashMap::from([
         ("handler".to_owned(), handler.as_str().to_owned()),
         ("result".to_owned(), result.as_str().to_owned()),
@@ -255,7 +251,8 @@ mod tests {
         sync::{Arc, Mutex},
     };
 
-    use cadence::{MetricSink, StatsdClient};
+    use cadence::{SpyMetricSink, StatsdClient};
+    use crossbeam_channel::Receiver;
     use google_cloud_gax::{
         error::{
             Error,
@@ -268,24 +265,11 @@ mod tests {
 
     use super::*;
 
-    /// Sink that keeps every statsd line so tests can assert on emissions.
-    #[derive(Debug)]
-    struct RecordingSink(Arc<Mutex<Vec<String>>>);
-
-    impl MetricSink for RecordingSink {
-        fn emit(&self, metric: &str) -> std::io::Result<usize> {
-            self.0
-                .lock()
-                .expect("metrics lock poisoned")
-                .push(metric.to_owned());
-            Ok(metric.len())
-        }
-    }
-
-    /// A [`Metrics`] backed by a [`RecordingSink`], alongside its recording.
-    fn recording_metrics() -> (Metrics, Arc<Mutex<Vec<String>>>) {
-        let recorded = Arc::new(Mutex::new(Vec::new()));
-        let client = StatsdClient::builder("", RecordingSink(recorded.clone())).build();
+    /// A [`Metrics`] that records every statsd line, alongside the receiver
+    /// those lines arrive on.
+    fn recording_metrics() -> (Metrics, Receiver<Vec<u8>>) {
+        let (recorded, sink) = SpyMetricSink::new();
+        let client = StatsdClient::builder("", sink).build();
         (
             Metrics {
                 client: Some(Arc::new(client)),
@@ -294,6 +278,15 @@ mod tests {
             },
             recorded,
         )
+    }
+
+    /// Every statsd line emitted so far, joined for substring assertions.
+    fn emitted(recorded: &Receiver<Vec<u8>>) -> String {
+        recorded
+            .try_iter()
+            .map(|line| String::from_utf8(line).expect("statsd line was not utf-8"))
+            .collect::<Vec<_>>()
+            .join("\n")
     }
 
     /// Stub to record delete_object
@@ -369,7 +362,7 @@ mod tests {
         .await
         .expect("delete_payload should succeed");
 
-        let emitted = recorded.lock().unwrap().join("\n");
+        let emitted = emitted(&recorded);
         assert!(
             emitted.contains(CLEANUP_METRIC)
                 && emitted.contains("result:success")
@@ -410,7 +403,7 @@ mod tests {
         .await
         .expect_err("a failed GCS delete should surface as an error");
 
-        let emitted = recorded.lock().unwrap().join("\n");
+        let emitted = emitted(&recorded);
         assert!(
             emitted.contains(CLEANUP_METRIC)
                 && emitted.contains("result:failure")
@@ -436,7 +429,7 @@ mod tests {
             deletes.lock().unwrap().is_empty(),
             "no delete should be issued for an unparseable URL"
         );
-        let emitted = recorded.lock().unwrap().join("\n");
+        let emitted = emitted(&recorded);
         assert!(
             emitted.contains(CLEANUP_METRIC)
                 && emitted.contains("result:failure")

--- a/syncserver/src/web/payload_offload.rs
+++ b/syncserver/src/web/payload_offload.rs
@@ -372,6 +372,31 @@ mod tests {
         );
     }
 
+    #[actix_rt::test]
+    async fn delete_payload_counts_an_unparseable_url() {
+        let deletes = Arc::new(Mutex::new(Vec::new()));
+        let client = StorageControl::from_stub(RecordingStub {
+            deletes: deletes.clone(),
+        });
+        let (metrics, recorded) = recording_metrics();
+
+        delete_payload(&client, "not-a-gs-url", &metrics, "put_bso")
+            .await
+            .expect_err("an unparseable URL should surface as an error");
+
+        assert!(
+            deletes.lock().unwrap().is_empty(),
+            "no delete should be issued for an unparseable URL"
+        );
+        let emitted = recorded.lock().unwrap().join("\n");
+        assert!(
+            emitted.contains(CLEANUP_METRIC)
+                && emitted.contains("result:failure")
+                && emitted.contains("reason:invalid_url"),
+            "unexpected cleanup metric: {emitted}"
+        );
+    }
+
     #[test]
     fn reattach_results_to_correct_slots() {
         let mut items: Vec<Option<String>> = vec![None, None, None, None];

--- a/syncserver/src/web/payload_offload.rs
+++ b/syncserver/src/web/payload_offload.rs
@@ -207,6 +207,7 @@ mod tests {
         sync::{Arc, Mutex},
     };
 
+    use cadence::{MetricSink, StatsdClient};
     use google_cloud_gax::{
         error::{
             Error,
@@ -218,6 +219,34 @@ mod tests {
     use google_cloud_storage::{Result as GcsResult, client::StorageControl, model};
 
     use super::*;
+
+    /// Sink that keeps every statsd line so tests can assert on emissions.
+    #[derive(Debug)]
+    struct RecordingSink(Arc<Mutex<Vec<String>>>);
+
+    impl MetricSink for RecordingSink {
+        fn emit(&self, metric: &str) -> std::io::Result<usize> {
+            self.0
+                .lock()
+                .expect("metrics lock poisoned")
+                .push(metric.to_owned());
+            Ok(metric.len())
+        }
+    }
+
+    /// A [`Metrics`] backed by a [`RecordingSink`], alongside its recording.
+    fn recording_metrics() -> (Metrics, Arc<Mutex<Vec<String>>>) {
+        let recorded = Arc::new(Mutex::new(Vec::new()));
+        let client = StatsdClient::builder("", RecordingSink(recorded.clone())).build();
+        (
+            Metrics {
+                client: Some(Arc::new(client)),
+                tags: HashMap::default(),
+                timer: None,
+            },
+            recorded,
+        )
+    }
 
     /// Stub to record delete_object
     #[derive(Debug, Default)]
@@ -275,6 +304,29 @@ mod tests {
                 "projects/_/buckets/test-bucket".to_owned(),
                 "uid/bookmarks/bid/uuid".to_owned(),
             )],
+        );
+    }
+
+    #[actix_rt::test]
+    async fn delete_payload_counts_a_success() {
+        let client = StorageControl::from_stub(RecordingStub::default());
+        let (metrics, recorded) = recording_metrics();
+
+        delete_payload(
+            &client,
+            "gs://test-bucket/uid/bookmarks/bid/uuid",
+            &metrics,
+            "put_bso",
+        )
+        .await
+        .expect("delete_payload should succeed");
+
+        let emitted = recorded.lock().unwrap().join("\n");
+        assert!(
+            emitted.contains(CLEANUP_METRIC)
+                && emitted.contains("result:success")
+                && emitted.contains("handler:put_bso"),
+            "unexpected cleanup metric: {emitted}"
         );
     }
 

--- a/syncserver/src/web/payload_offload.rs
+++ b/syncserver/src/web/payload_offload.rs
@@ -133,17 +133,62 @@ pub async fn build_control_client(endpoint: Option<&str>) -> Result<StorageContr
         .map_err(|e| ApiErrorKind::Internal(format!("GCS builder error: {e}")).into())
 }
 
-/// Tags for a [`CLEANUP_METRIC`] emission from `handler` with `result`.
-pub fn cleanup_tags(handler: &str, result: &str) -> HashMap<String, String> {
-    HashMap::from([
-        ("handler".to_owned(), handler.to_owned()),
-        ("result".to_owned(), result.to_owned()),
-    ])
+/// The write handler a [`CLEANUP_METRIC`] emission came from.
+#[derive(Clone, Copy, Debug)]
+pub enum CleanupHandler {
+    PutBso,
+    PostCollection,
 }
 
-fn cleanup_failure_tags(handler: &str, reason: &str) -> HashMap<String, String> {
-    let mut tags = cleanup_tags(handler, "failure");
-    tags.insert("reason".to_owned(), reason.to_owned());
+impl CleanupHandler {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::PutBso => "put_bso",
+            Self::PostCollection => "post_collection",
+        }
+    }
+}
+
+/// The outcome of a cleanup attempt, as the `result` and `reason` tags.
+#[derive(Clone, Copy, Debug)]
+pub enum CleanupResult {
+    Success,
+    /// No GCS control client was available, so no delete was attempted.
+    Skipped,
+    /// The `gs://` URL did not parse, so no delete was issued.
+    InvalidUrl,
+    /// GCS rejected the delete.
+    GcsError,
+}
+
+impl CleanupResult {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Success => "success",
+            Self::Skipped => "skipped",
+            Self::InvalidUrl | Self::GcsError => "failure",
+        }
+    }
+
+    /// The `reason` tag, set for the failure variants only.
+    fn reason(self) -> Option<&'static str> {
+        match self {
+            Self::Success | Self::Skipped => None,
+            Self::InvalidUrl => Some("invalid_url"),
+            Self::GcsError => Some("gcs_error"),
+        }
+    }
+}
+
+/// Tags for a [`CLEANUP_METRIC`] emission from `handler` with `result`.
+pub fn cleanup_tags(handler: CleanupHandler, result: CleanupResult) -> HashMap<String, String> {
+    let mut tags = HashMap::from([
+        ("handler".to_owned(), handler.as_str().to_owned()),
+        ("result".to_owned(), result.as_str().to_owned()),
+    ]);
+    if let Some(reason) = result.reason() {
+        tags.insert("reason".to_owned(), reason.to_owned());
+    }
     tags
 }
 
@@ -151,10 +196,13 @@ pub async fn delete_payload(
     client: &StorageControl,
     gs_url: &str,
     metrics: &Metrics,
-    handler: &str,
+    handler: CleanupHandler,
 ) -> Result<(), ApiError> {
     let (bucket, object) = parse_gs_url(gs_url).inspect_err(|_| {
-        metrics.incr_with_tags(CLEANUP_METRIC, cleanup_failure_tags(handler, "invalid_url"))
+        metrics.incr_with_tags(
+            CLEANUP_METRIC,
+            cleanup_tags(handler, CleanupResult::InvalidUrl),
+        )
     })?;
 
     client
@@ -163,10 +211,18 @@ pub async fn delete_payload(
         .set_object(object)
         .send()
         .await
-        .inspect(|_| metrics.incr_with_tags(CLEANUP_METRIC, cleanup_tags(handler, "success")))
+        .inspect(|_| {
+            metrics.incr_with_tags(
+                CLEANUP_METRIC,
+                cleanup_tags(handler, CleanupResult::Success),
+            )
+        })
         .inspect_err(|e| {
             warn!("gcs payload cleanup failed for {gs_url}: {e}");
-            metrics.incr_with_tags(CLEANUP_METRIC, cleanup_failure_tags(handler, "gcs_error"));
+            metrics.incr_with_tags(
+                CLEANUP_METRIC,
+                cleanup_tags(handler, CleanupResult::GcsError),
+            );
         })
         .map_err(|e| ApiErrorKind::Internal(format!("cannot delete GCS object: {e}")).into())
 }
@@ -284,7 +340,7 @@ mod tests {
             &client,
             "gs://test-bucket/uid/bookmarks/bid/uuid",
             &Metrics::noop(),
-            "put_bso",
+            CleanupHandler::PutBso,
         )
         .await
         .expect("delete_payload should succeed");
@@ -308,7 +364,7 @@ mod tests {
             &client,
             "gs://test-bucket/uid/bookmarks/bid/uuid",
             &metrics,
-            "put_bso",
+            CleanupHandler::PutBso,
         )
         .await
         .expect("delete_payload should succeed");
@@ -330,7 +386,7 @@ mod tests {
             &client,
             "gs://test-bucket/uid/bookmarks/bid/uuid",
             &Metrics::noop(),
-            "put_bso",
+            CleanupHandler::PutBso,
         )
         .await;
 
@@ -349,7 +405,7 @@ mod tests {
             &client,
             "gs://test-bucket/uid/bookmarks/bid/uuid",
             &metrics,
-            "post_collection",
+            CleanupHandler::PostCollection,
         )
         .await
         .expect_err("a failed GCS delete should surface as an error");
@@ -372,7 +428,7 @@ mod tests {
         });
         let (metrics, recorded) = recording_metrics();
 
-        delete_payload(&client, "not-a-gs-url", &metrics, "put_bso")
+        delete_payload(&client, "not-a-gs-url", &metrics, CleanupHandler::PutBso)
             .await
             .expect_err("an unparseable URL should surface as an error");
 

--- a/syncserver/src/web/payload_offload.rs
+++ b/syncserver/src/web/payload_offload.rs
@@ -14,10 +14,11 @@
 //! `customTime` set to upload time; a later step flips `committed` to `true`
 //! once the database row is durably visible.
 
-use std::time::SystemTime;
+use std::{collections::HashMap, time::SystemTime};
 
 use google_cloud_auth::credentials::anonymous;
 use google_cloud_storage::client::{Storage, StorageControl};
+use syncserver_common::Metrics;
 use syncstorage_db::UserIdentifier;
 use uuid::Uuid;
 
@@ -27,6 +28,12 @@ use crate::{
 };
 
 const COMMITTED_METADATA_KEY: &str = "committed";
+
+/// Counter for the best-effort GCS cleanup that runs when the database
+/// transaction of an offloading write fails. Tagged with the `handler` that
+/// issued it, a `result` of `success`, `failure` or `skipped`, and on failure
+/// a `reason`.
+pub const CLEANUP_METRIC: &str = "storage.gcs.payload.cleanup";
 
 /// Return the GCS bucket name if `collection` is opted into payload off-load
 /// and a bucket is configured. `None` disables off-load for this request.
@@ -126,16 +133,50 @@ pub async fn build_control_client(endpoint: Option<&str>) -> Result<StorageContr
         .map_err(|e| ApiErrorKind::Internal(format!("GCS builder error: {e}")).into())
 }
 
-pub async fn delete_payload(client: &StorageControl, gs_url: &str) -> Result<(), ApiError> {
-    let (bucket, object) = parse_gs_url(gs_url)?;
-    client
+/// Tags for a [`CLEANUP_METRIC`] emission from `handler` with `result`.
+pub fn cleanup_tags(handler: &str, result: &str) -> HashMap<String, String> {
+    HashMap::from([
+        ("handler".to_owned(), handler.to_owned()),
+        ("result".to_owned(), result.to_owned()),
+    ])
+}
+
+fn cleanup_failure_tags(handler: &str, reason: &str) -> HashMap<String, String> {
+    let mut tags = cleanup_tags(handler, "failure");
+    tags.insert("reason".to_owned(), reason.to_owned());
+    tags
+}
+
+pub async fn delete_payload(
+    client: &StorageControl,
+    gs_url: &str,
+    metrics: &Metrics,
+    handler: &str,
+) -> Result<(), ApiError> {
+    let (bucket, object) = match parse_gs_url(gs_url) {
+        Ok(parsed) => parsed,
+        Err(e) => {
+            metrics.incr_with_tags(CLEANUP_METRIC, cleanup_failure_tags(handler, "invalid_url"));
+            return Err(e);
+        }
+    };
+
+    let result = client
         .delete_object()
         .set_bucket(bucket_path(bucket))
         .set_object(object)
         .send()
-        .await
-        .inspect_err(|e| warn!("gcs payload cleanup failed for {gs_url}: {e}"))
-        .map_err(|e| ApiErrorKind::Internal(format!("cannot delete GCS object: {e}")).into())
+        .await;
+
+    match &result {
+        Ok(_) => metrics.incr_with_tags(CLEANUP_METRIC, cleanup_tags(handler, "success")),
+        Err(e) => {
+            warn!("gcs payload cleanup failed for {gs_url}: {e}");
+            metrics.incr_with_tags(CLEANUP_METRIC, cleanup_failure_tags(handler, "gcs_error"));
+        }
+    }
+
+    result.map_err(|e| ApiErrorKind::Internal(format!("cannot delete GCS object: {e}")).into())
 }
 
 fn bucket_path(bucket: &str) -> String {
@@ -218,9 +259,14 @@ mod tests {
             deletes: deletes.clone(),
         });
 
-        delete_payload(&client, "gs://test-bucket/uid/bookmarks/bid/uuid")
-            .await
-            .expect("delete_payload should succeed");
+        delete_payload(
+            &client,
+            "gs://test-bucket/uid/bookmarks/bid/uuid",
+            &Metrics::noop(),
+            "put_bso",
+        )
+        .await
+        .expect("delete_payload should succeed");
 
         let recorded = deletes.lock().unwrap();
         assert_eq!(
@@ -236,7 +282,13 @@ mod tests {
     async fn delete_payload_surfaces_delete_error() {
         let client = StorageControl::from_stub(FailingStub);
 
-        let result = delete_payload(&client, "gs://test-bucket/uid/bookmarks/bid/uuid").await;
+        let result = delete_payload(
+            &client,
+            "gs://test-bucket/uid/bookmarks/bid/uuid",
+            &Metrics::noop(),
+            "put_bso",
+        )
+        .await;
 
         assert!(
             result.is_err(),


### PR DESCRIPTION
## Description

STOR-623 added a best-effort GCS delete for payloads that were offloaded before a
write's database transaction failed, but it was fire and forget, so there's no way
to tell from prod whether those deletes actually land. This adds a counter around
them.

The metric is `storage.gcs.payload.cleanup`, tagged with:

- `handler`: `put_bso` or `post_collection`
- `result`: `success` or `failure`
- `reason` on failures: `gcs_error` if GCS rejected the delete, `invalid_url` if the
  `gs://` URL didn't parse (a code bug rather than an infra problem)

Both are emitted inside `delete_payload`, so any future call site gets them for free.

Tests use cadence's `SpyMetricSink` over the existing `StorageControl` stubs, one per
branch. Commits are split so each addition is reviewable on its own.

Note on local verification: `cargo fmt --check` is clean, clippy is clean for
`syncserver`, and the `web::payload_offload` unit tests pass. The full
`make clippy_mysql` can't run on arm64 here because `grpcio-sys` fails to build, and
it also trips two pre-existing `needless_as_bytes` errors in `tokenserver-auth` that
are already on master, so CI is the real check for those.

## Review round

Rebased onto master, so the merge commit is gone and the history is linear.

- Dropped the `skipped` result entirely. Both GCS clients are built together at
  startup when a payload bucket is configured, so there is no state where the control
  client is missing but the upload succeeded. The counter could only ever read zero.
  Back to `if let Ok(client)` with a comment recording why it holds.
- Swapped the hand-rolled recording sink for cadence's `SpyMetricSink`, which needed
  `crossbeam-channel` as a dev-dependency to name the receiver. It was already in the
  lock via cadence.
- Dropped the `.config/nextest.toml` retry commit as out of scope. Worth noting for
  whenever it gets picked up separately: nextest profiles inherit from
  `[profile.default]`, so `test-threads = 1` does apply to `profile.ci`, which means
  parallel tests contending on shared rows can't be the cause of that abort.

I did not take the `gcs_control_client()?` variant. At the cleanup site the `?` would
return the GCS client error in place of the database error that actually caused the
rollback, so the real cause would be lost from both the response and Sentry.

## Testing

No behaviour change beyond the metric. `cargo test -p syncserver --lib web::payload_offload`
covers success, GCS failure, and unparseable URL.

## Issue(s)

Closes [STOR-653](https://mozilla-hub.atlassian.net/browse/STOR-653).


[STOR-653]: https://mozilla-hub.atlassian.net/browse/STOR-653?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ