### PR TITLE
chore: update h2@0.4.x per RUSTSEC-2026-0258

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,7 +1,5 @@
 [advisories]
 ignore = [
-       "RUSTSEC-2024-0365", # Bound by diesel 1.4 (4GB limit n/a to tokenserver)
-       "RUSTSEC-2024-0421", # Bound by diesel 1.4, `idna`  < 0.1.5, Upgrade to >=1.0.0
        "RUSTSEC-2024-0437", # Bound by grpcio 0.13,
-       "RUSTSEC-2026-0002", # Bound by mysql_async, via diesel-async
+       "RUSTSEC-2026-0258", # Bound by actix-web, actix-http
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1654,7 +1654,7 @@ dependencies = [
  "google-cloud-gax",
  "google-cloud-rpc",
  "google-cloud-wkt",
- "h2 0.4.15",
+ "h2 0.4.16",
  "http 1.4.2",
  "http-body",
  "http-body-util",
@@ -1878,9 +1878,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2131,7 +2131,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.15",
+ "h2 0.4.16",
  "http 1.4.2",
  "http-body",
  "httparse",
@@ -2205,7 +2205,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -3631,7 +3631,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.19",
  "tokio",
  "tracing",
@@ -3669,7 +3669,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.52.0",
 ]


### PR DESCRIPTION
## Description

also ignore the h2@0.3.x pinned by actix and disable a couple RUSTSECs that no longer apply

## Issue(s)

Closes STOR-677
