### PR TITLE
fix: don't overflow GCS custom-time

### DIFF
--- a/docs/src/payload-offload/overview.md
+++ b/docs/src/payload-offload/overview.md
@@ -168,7 +168,7 @@ stateDiagram-v2
 
     note right of Committed
         committed=true
-        customTime = 9999-12-31T23:59:59Z
+        customTime = 2200-12-31T23:59:59Z
         the lifecycle policy cannot reach it
     end note
 ```
@@ -197,7 +197,7 @@ is in preserving one of them.
    nothing has promised to keep it.
 
 3. **Finalizing is what makes an object permanent.** The reconciler flips
-   `committed=true` and pins `customTime` to `9999-12-31T23:59:59Z`. That
+   `committed=true` and pins `customTime` to `2200-12-31T23:59:59Z`. That
    pushes `daysSinceCustomTime` permanently negative, so the bucket's
    lifecycle policy can never reach the object again, no matter how old it
    gets.

--- a/docs/src/tools/payload_link_reconciler.md
+++ b/docs/src/tools/payload_link_reconciler.md
@@ -9,7 +9,7 @@ BSO row's `payload_link` column points at it. A separate pipeline must:
 
 - **Finalize** newly-committed objects — flip metadata to
   `committed=true` and pin `customTime` to its maximum value
-  (`9999-12-31T23:59:59Z`) so the bucket's lifecycle policy (see
+  (`2200-12-31T23:59:59Z`) so the bucket's lifecycle policy (see
   below) cannot reclaim them.
 - **Garbage-collect orphans** — delete GCS objects whose row's
   `payload_link` was replaced (UPDATE) or removed (DELETE, including
@@ -216,7 +216,7 @@ Sync-pull drain loop with two deployment modes selected by whether
 For each mod in the change record:
 
 - New `payload_link` present: `blob.patch()` sets
-  `metadata.committed = "true"` and `customTime = "9999-12-31T23:59:59Z"`.
+  `metadata.committed = "true"` and `customTime = "2200-12-31T23:59:59Z"`.
 - Old `payload_link` present and not equal to the new value: `blob.delete()`,
   with one interim exception. Any `batch_bsos` row removal is skipped
   (`payload_reconciler.batch_bsos_skips`). On a batch commit syncstorage deletes

--- a/tools/integration_tests/test_payload_link_reconciliation.py
+++ b/tools/integration_tests/test_payload_link_reconciliation.py
@@ -96,7 +96,7 @@ def test_upload_finalizes_object(st_ctx: dict[str, Any], gcs: storage.Client) ->
     assert blob is not None
     # customTime should be pinned to the far-future sentinel.
     assert blob.custom_time is not None
-    assert blob.custom_time.year == 9999
+    assert blob.custom_time.year == 2200
 
 
 def test_update_deletes_old_object(st_ctx: dict[str, Any], gcs: storage.Client) -> None:

--- a/tools/payload-reconciler/reconcile_payload_links.py
+++ b/tools/payload-reconciler/reconcile_payload_links.py
@@ -55,7 +55,7 @@ from utils import parse_gs_url  # noqa: E402
 # daysSinceCustomTime > N can never touch a committed payload
 # regardless of object age.
 MAX_CUSTOM_TIME = datetime.datetime(
-    9999, 12, 31, 23, 59, 59, tzinfo=datetime.timezone.utc
+    2200, 12, 31, 23, 59, 59, tzinfo=datetime.timezone.utc
 )
 
 # Custom metadata key the syncserver writer sets to "false" on upload;


### PR DESCRIPTION
## Description

it apparently tops off at go's max UnixNano (around year 2262), we'll use 2200 because it's maybe more easily identifiable

## Issue(s)

Closes STOR-682
