### PR TITLE
feat: hard limit payload reads in extractors

### DIFF
--- a/syncserver/src/server/mod.rs
+++ b/syncserver/src/server/mod.rs
@@ -169,7 +169,7 @@ pub struct Server;
 
 #[macro_export]
 macro_rules! build_app {
-    ($syncstorage_state: expr, $tokenserver_state: expr, $secrets: expr, $limits: expr, $cors: expr, $metrics: expr) => {
+    ($syncstorage_state: expr, $tokenserver_state: expr, $secrets: expr, $cors: expr, $metrics: expr) => {
         App::new()
             .configure(|cfg| {
                 cfg.app_data(Data::new($syncstorage_state));
@@ -213,35 +213,18 @@ macro_rules! build_app {
                 web::resource(&cfg_path("/storage")).route(web::delete().to(handlers::delete_all)),
             )
             .service(
+                // No `PayloadConfig`/`JsonConfig` here: the body extractors
+                // read the payload themselves and hold it to the collection's
+                // own `max_request_bytes`. Anything added later that reads the
+                // body via `String`/`Bytes`/`Json` would fall back to actix's
+                // 256kB default, so give it a limit of its own.
                 web::resource(&cfg_path("/storage/{collection}"))
-                    .app_data(
-                        // The resource-level payload limit is the ceiling
-                        // across the default and any per-collection overrides;
-                        // extractors enforce the actual per-collection
-                        // `max_request_bytes` once the collection is known.
-                        web::PayloadConfig::new($limits.effective_max_request_bytes() as usize),
-                    )
-                    .app_data(
-                        // Declare the payload limits for "JSON" payloads
-                        // (Specify "text/plain" for legacy client reasons)
-                        web::JsonConfig::default()
-                            .limit($limits.effective_max_request_bytes() as usize)
-                            .content_type(|ct| ct == mime::TEXT_PLAIN),
-                    )
                     .route(web::delete().to(handlers::delete_collection))
                     .route(web::get().to(handlers::get_collection))
                     .route(web::post().to(handlers::post_collection)),
             )
             .service(
                 web::resource(&cfg_path("/storage/{collection}/{bso}"))
-                    .app_data(web::PayloadConfig::new(
-                        $limits.effective_max_request_bytes() as usize,
-                    ))
-                    .app_data(
-                        web::JsonConfig::default()
-                            .limit($limits.effective_max_request_bytes() as usize)
-                            .content_type(|ct| ct == mime::TEXT_PLAIN),
-                    )
                     .route(web::delete().to(handlers::delete_bso))
                     .route(web::get().to(handlers::get_bso))
                     .route(web::put().to(handlers::put_bso)),
@@ -500,7 +483,6 @@ impl Server {
                 syncstorage_state,
                 tokenserver_state.clone(),
                 Arc::clone(&secrets),
-                limits,
                 build_cors(&settings_copy),
                 metrics.clone()
             )

--- a/syncserver/src/server/test.rs
+++ b/syncserver/src/server/test.rs
@@ -157,14 +157,12 @@ macro_rules! init_app {
     ($settings:expr) => {
         async {
             crate::logging::init_logging(false).unwrap();
-            let limits = Arc::new($settings.syncstorage.limits.clone());
             let state = get_test_state(&$settings).await;
             let metrics = state.metrics.clone();
             test::init_service(build_app!(
                 state,
                 None::<tokenserver::ServerState>,
                 Arc::clone(&SECRETS),
-                limits,
                 build_cors(&$settings),
                 metrics
             ))
@@ -278,14 +276,12 @@ where
     T: DeserializeOwned,
 {
     let settings = get_test_settings();
-    let limits = Arc::new(settings.syncstorage.limits.clone());
     let state = get_test_state(&settings).await;
     let metrics = state.metrics.clone();
     let app = test::init_service(build_app!(
         state,
         None::<tokenserver::ServerState>,
         Arc::clone(&SECRETS),
-        limits,
         build_cors(&settings),
         metrics
     ))
@@ -322,14 +318,12 @@ async fn test_endpoint_with_body(
     body: serde_json::Value,
 ) -> Bytes {
     let settings = get_test_settings();
-    let limits = Arc::new(settings.syncstorage.limits.clone());
     let state = get_test_state(&settings).await;
     let metrics = state.metrics.clone();
     let app = test::init_service(build_app!(
         state,
         None::<tokenserver::ServerState>,
         Arc::clone(&SECRETS),
-        limits,
         build_cors(&settings),
         metrics
     ))

--- a/syncserver/src/web/extractors/bso_bodies.rs
+++ b/syncserver/src/web/extractors/bso_bodies.rs
@@ -90,8 +90,15 @@ impl FromRequest for BsoBodies {
                 }
                 Err(_) => return Err(size_limit_exceeded().into()),
             };
-            let Ok(body) = std::str::from_utf8(&body) else {
-                warn!("⚠️ Payload read error: body is not utf-8");
+            // Decode with the request's charset instead of assuming utf-8,
+            // as `String`'s extractor did for us before
+            let encoding = req.encoding().map_err(|e| {
+                warn!("⚠️ Payload read error: {:?}", e);
+                unreadable_body()
+            })?;
+            let Some(body) = encoding.decode_without_bom_handling_and_without_replacement(&body)
+            else {
+                warn!("⚠️ Payload read error: could not decode the body");
                 return Err(unreadable_body());
             };
 
@@ -108,7 +115,7 @@ impl FromRequest for BsoBodies {
                     }
                 }
                 bsos
-            } else if let Ok(json_vals) = serde_json::from_str::<Vec<Value>>(body) {
+            } else if let Ok(json_vals) = serde_json::from_str::<Vec<Value>>(&body) {
                 json_vals
             } else {
                 // Per Python version, BSO's must json deserialize

--- a/syncserver/src/web/extractors/bso_bodies.rs
+++ b/syncserver/src/web/extractors/bso_bodies.rs
@@ -2,6 +2,7 @@ use std::collections::{HashMap, HashSet};
 
 use actix_web::{
     Error, FromRequest, HttpMessage, HttpRequest,
+    body::{BodyStream, to_bytes_limited},
     dev::Payload,
     http::header::{ContentType, Header},
     web::Data,
@@ -12,7 +13,7 @@ use serde_json::Value;
 
 use super::{
     ACCEPTED_CONTENT_TYPES, BatchBsoBody, CollectionParam, RequestErrorLocation,
-    utils::check_content_length,
+    utils::{check_content_length, size_limit_exceeded},
 };
 use crate::{error::ApiError, server::ServerState, web::error::ValidationErrorKind};
 
@@ -37,7 +38,7 @@ impl FromRequest for BsoBodies {
     /// No collection id is used, so payload checks are not done here.
     fn from_request(req: &HttpRequest, payload: &mut Payload) -> Self::Future {
         let req = req.clone();
-        let mut payload = payload.take();
+        let payload = payload.take();
 
         Box::pin(async move {
             // Only try and parse the body if its a valid content-type
@@ -74,18 +75,25 @@ impl FromRequest for BsoBodies {
             let coll_limits = state.limits.limits_for(collection.as_deref());
 
             check_content_length(&req, coll_limits.max_request_bytes as usize)?;
-            // Load the entire request into a String
-            let body = <String>::from_request(&req, &mut payload)
-                .await
-                .map_err(|e| {
+            // Load the entire request, holding it to the same limit as it's
+            // read: a chunked request has no Content-Length to check
+            let body = match to_bytes_limited(
+                BodyStream::new(payload),
+                coll_limits.max_request_bytes as usize,
+            )
+            .await
+            {
+                Ok(Ok(body)) => body,
+                Ok(Err(e)) => {
                     warn!("⚠️ Payload read error: {:?}", e);
-                    ValidationErrorKind::FromDetails(
-                        "Mimetype/encoding/content-length error".to_owned(),
-                        RequestErrorLocation::Header,
-                        None,
-                        None,
-                    )
-                })?;
+                    return Err(unreadable_body());
+                }
+                Err(_) => return Err(size_limit_exceeded().into()),
+            };
+            let Ok(body) = std::str::from_utf8(&body) else {
+                warn!("⚠️ Payload read error: body is not utf-8");
+                return Err(unreadable_body());
+            };
 
             // Get all the raw / values
             let bsos: Vec<Value> = if content_type == "application/newlines" {
@@ -100,7 +108,7 @@ impl FromRequest for BsoBodies {
                     }
                 }
                 bsos
-            } else if let Ok(json_vals) = serde_json::from_str::<Vec<Value>>(&body) {
+            } else if let Ok(json_vals) = serde_json::from_str::<Vec<Value>>(body) {
                 json_vals
             } else {
                 // Per Python version, BSO's must json deserialize
@@ -173,6 +181,17 @@ impl FromRequest for BsoBodies {
             Ok(BsoBodies { valid, invalid })
         })
     }
+}
+
+/// Return an error for a request body we couldn't read
+fn unreadable_body() -> Error {
+    ValidationErrorKind::FromDetails(
+        "Mimetype/encoding/content-length error".to_owned(),
+        RequestErrorLocation::Header,
+        None,
+        None,
+    )
+    .into()
 }
 
 /// Return an Invalid JSON error

--- a/syncserver/src/web/extractors/bso_body.rs
+++ b/syncserver/src/web/extractors/bso_body.rs
@@ -1,5 +1,6 @@
 use actix_web::{
     Error, FromRequest, HttpMessage, HttpRequest,
+    body::{BodyStream, to_bytes_limited},
     dev::Payload,
     http::header::{ContentType, Header},
     web::Data,
@@ -9,7 +10,8 @@ use serde::{Deserialize, Serialize, de::IgnoredAny};
 use validator::Validate;
 
 use super::{
-    ACCEPTED_CONTENT_TYPES, CollectionParam, RequestErrorLocation, utils::check_content_length,
+    ACCEPTED_CONTENT_TYPES, CollectionParam, RequestErrorLocation,
+    utils::{check_content_length, size_limit_exceeded},
     validate_body_bso_id, validate_body_bso_sortindex, validate_body_bso_ttl,
 };
 use crate::{server::ServerState, web::error::ValidationErrorKind};
@@ -41,7 +43,7 @@ impl FromRequest for BsoBody {
         // with an empty payload so we strictly read the request body payload once
         // and dispense with it
         let req = req.clone();
-        let mut payload = payload.take();
+        let payload = payload.take();
 
         Box::pin(async move {
             // Only try and parse the body if its a valid content-type
@@ -68,6 +70,12 @@ impl FromRequest for BsoBody {
                 )
                 .into());
             }
+            // A single BSO is never a series of newline delimited records.
+            // `Json` used to turn this away for us before we parsed the body
+            // ourselves, so keep returning what it did.
+            if content_type == "application/newlines" {
+                return Err(bad_bso_body("Content type error."));
+            }
             let state = match req.app_data::<Data<ServerState>>() {
                 Some(s) => s,
                 None => {
@@ -91,18 +99,25 @@ impl FromRequest for BsoBody {
             let coll_limits = state.limits.limits_for(collection.as_deref());
 
             check_content_length(&req, coll_limits.max_request_bytes as usize)?;
-            let bso = <actix_web::web::Json<BsoBody>>::from_request(&req, &mut payload)
-                .await
-                .map_err(|e| {
-                    warn!("⚠️ Could not parse BSO Body: {:?}", e);
-
-                    ValidationErrorKind::FromDetails(
-                        e.to_string(),
-                        RequestErrorLocation::Body,
-                        Some("bso".to_owned()),
-                        Some("request.validate.bad_bso_body"),
-                    )
-                })?;
+            // Load the body, holding it to the same limit as it's read: a
+            // chunked request has no Content-Length to check
+            let body = match to_bytes_limited(
+                BodyStream::new(payload),
+                coll_limits.max_request_bytes as usize,
+            )
+            .await
+            {
+                Ok(Ok(body)) => body,
+                Ok(Err(e)) => {
+                    warn!("⚠️ Could not read BSO Body: {:?}", e);
+                    return Err(bad_bso_body(&e.to_string()));
+                }
+                Err(_) => return Err(size_limit_exceeded().into()),
+            };
+            let bso: BsoBody = serde_json::from_slice(&body).map_err(|e| {
+                warn!("⚠️ Could not parse BSO Body: {:?}", e);
+                bad_bso_body(&e.to_string())
+            })?;
 
             // Check the max payload size manually with our desired limit
             if bso
@@ -128,7 +143,18 @@ impl FromRequest for BsoBody {
                 )
                 .into());
             }
-            Ok(bso.into_inner())
+            Ok(bso)
         })
     }
+}
+
+/// Return an error for a BSO body we couldn't read or parse
+fn bad_bso_body(description: &str) -> Error {
+    ValidationErrorKind::FromDetails(
+        description.to_owned(),
+        RequestErrorLocation::Body,
+        Some("bso".to_owned()),
+        Some("request.validate.bad_bso_body"),
+    )
+    .into()
 }

--- a/syncserver/src/web/extractors/bso_put_request.rs
+++ b/syncserver/src/web/extractors/bso_put_request.rs
@@ -89,7 +89,8 @@ mod tests {
         auth::HawkPayload,
         extractors::test_utils::{
             SECRETS, TEST_HOST, TEST_PORT, USER_ID, USER_ID_STR, create_valid_hawk_header,
-            extract_body_as_str, make_db, make_state,
+            extract_body_as_str, limits_with_max_request_bytes, make_db, make_state,
+            make_state_with_limits,
         },
     };
 
@@ -126,6 +127,40 @@ mod tests {
         assert_eq!(&result.collection, "tabs");
         assert_eq!(&result.bso, "asdf");
         assert_eq!(result.body.payload, Some("x".to_string()));
+    }
+
+    #[test]
+    fn test_bso_put_body_over_max_request_bytes() {
+        let payload = HawkPayload::test_default(*USER_ID);
+        let state = make_state_with_limits(limits_with_max_request_bytes("tabs", 128));
+        let secrets = Arc::clone(&SECRETS);
+        let uri = format!("/1.5/{}/storage/tabs/asdf", *USER_ID);
+        let header =
+            create_valid_hawk_header(&payload, &secrets, "PUT", &uri, TEST_HOST, TEST_PORT);
+        let bso_body = json!({
+            "id": "128", "payload": "x".repeat(1024)
+        });
+        // No Content-Length is set, so the limit can only be caught while
+        // reading the body.
+        let req = TestRequest::with_uri(&uri)
+            .data(state)
+            .data(secrets)
+            .insert_header(("authorization", header))
+            .insert_header(("content-type", "application/json"))
+            .method(Method::PUT)
+            .param("uid", USER_ID_STR.as_str())
+            .param("collection", "tabs")
+            .param("bso", "asdf")
+            .to_http_request();
+        req.extensions_mut().insert(make_db());
+        let (_sender, mut payload) = h1::Payload::create(true);
+        payload.unread_data(Bytes::from(bso_body.to_string()));
+        let result = block_on(BsoPutRequest::from_request(&req, &mut payload.into()));
+        let response: HttpResponse = result
+            .err()
+            .expect("Expected an error in test_bso_put_body_over_max_request_bytes")
+            .into();
+        assert_eq!(response.status(), 413);
     }
 
     #[test]

--- a/syncserver/src/web/extractors/collection_post_request.rs
+++ b/syncserver/src/web/extractors/collection_post_request.rs
@@ -117,7 +117,8 @@ mod tests {
     use serde_json::json;
 
     use crate::web::extractors::test_utils::{
-        USER_ID, extract_body_as_str, make_state, post_collection,
+        USER_ID, extract_body_as_str, limits_with_max_request_bytes, make_state,
+        make_state_with_limits, post_collection, post_collection_with_state,
     };
 
     #[actix_rt::test]
@@ -188,6 +189,20 @@ mod tests {
             .expect("Could not get batch3 in test_valid_collection_batch_post_request");
         assert!(batch3.id.is_some());
         assert!(batch3.commit);
+    }
+
+    #[actix_rt::test]
+    async fn test_collection_post_request_over_max_request_bytes() {
+        // The request carries no Content-Length, so the limit can only be
+        // caught while reading the body.
+        let bso_body = json!([{"id": "123", "payload": "x".repeat(1024)}]);
+        let state = make_state_with_limits(limits_with_max_request_bytes("tabs", 128));
+        let result = post_collection_with_state("", &bso_body, state).await;
+        let response: HttpResponse = result
+            .err()
+            .expect("Expected an error in test_collection_post_request_over_max_request_bytes")
+            .into();
+        assert_eq!(response.status(), 413);
     }
 
     #[actix_rt::test]

--- a/syncserver/src/web/extractors/test_utils.rs
+++ b/syncserver/src/web/extractors/test_utils.rs
@@ -20,7 +20,9 @@ use tokio::sync::RwLock;
 use syncserver_common;
 use syncserver_settings::{Secrets, Settings as GlobalSettings};
 use syncstorage_db::mock::{MockDb, MockDbPool};
-use syncstorage_settings::{Deadman, ServerLimits, Settings as SyncstorageSettings};
+use syncstorage_settings::{
+    CollectionLimitOverride, Deadman, ServerLimits, Settings as SyncstorageSettings,
+};
 
 use super::CollectionPostRequest;
 use crate::{server::ServerState, web::auth::HawkPayload};
@@ -44,6 +46,11 @@ pub fn make_db() -> MockDb {
 }
 
 pub fn make_state() -> ServerState {
+    make_state_with_limits(Arc::clone(&SERVER_LIMITS))
+}
+
+/// A [ServerState] with the given limits, e.g. per collection overrides.
+pub fn make_state_with_limits(limits: Arc<ServerLimits>) -> ServerState {
     let syncserver_settings = GlobalSettings::default();
     let syncstorage_settings = SyncstorageSettings::default();
     let glean_logger = Arc::new(GleanEventsLogger {
@@ -55,8 +62,8 @@ pub fn make_state() -> ServerState {
     });
     ServerState {
         db_pool: Box::new(MockDbPool::new()),
-        limits: Arc::clone(&SERVER_LIMITS),
-        limits_json: serde_json::to_string(&**SERVER_LIMITS).unwrap(),
+        limits_json: serde_json::to_string(&*limits).unwrap(),
+        limits,
         port: 8000,
         metrics: syncserver_common::metrics_from_opts(
             &syncstorage_settings.statsd_label,
@@ -74,6 +81,22 @@ pub fn make_state() -> ServerState {
         gcs_payload_max_concurrency: syncstorage_settings.gcs_payload_max_concurrency,
         gcs_payload_offload_collections: Arc::new(Vec::new()),
     }
+}
+
+/// [ServerLimits] overriding `max_request_bytes` for a single collection.
+pub fn limits_with_max_request_bytes(
+    collection: &str,
+    max_request_bytes: u32,
+) -> Arc<ServerLimits> {
+    let mut limits = ServerLimits::default();
+    limits.collections.insert(
+        collection.to_owned(),
+        CollectionLimitOverride {
+            max_request_bytes: Some(max_request_bytes),
+            ..Default::default()
+        },
+    );
+    Arc::new(limits)
 }
 
 pub fn extract_body_as_str(sresponse: ServiceResponse) -> String {
@@ -117,8 +140,15 @@ pub async fn post_collection(
     qs: &str,
     body: &serde_json::Value,
 ) -> Result<CollectionPostRequest, Error> {
+    post_collection_with_state(qs, body, make_state()).await
+}
+
+pub async fn post_collection_with_state(
+    qs: &str,
+    body: &serde_json::Value,
+    state: ServerState,
+) -> Result<CollectionPostRequest, Error> {
     let payload = HawkPayload::test_default(*USER_ID);
-    let state = make_state();
     let secrets = Arc::clone(&SECRETS);
     let path = format!(
         "/1.5/{}/storage/tabs{}{}",

--- a/syncserver/src/web/extractors/utils.rs
+++ b/syncserver/src/web/extractors/utils.rs
@@ -87,15 +87,20 @@ pub fn check_content_length(
         .and_then(|v| v.parse::<usize>().ok())
         && len > max_request_bytes
     {
-        return Err(ValidationErrorKind::FromDetails(
-            "size-limit-exceeded".to_owned(),
-            RequestErrorLocation::Header,
-            Some("Content-Length".to_owned()),
-            Some("request.validate.request_bytes_exceeded"),
-        )
-        .into());
+        return Err(size_limit_exceeded());
     }
     Ok(())
+}
+
+/// The 413 for a request larger than its collection's `max_request_bytes`.
+pub fn size_limit_exceeded() -> ValidationError {
+    ValidationErrorKind::FromDetails(
+        "size-limit-exceeded".to_owned(),
+        RequestErrorLocation::Header,
+        Some("Content-Length".to_owned()),
+        Some("request.validate.request_bytes_exceeded"),
+    )
+    .into()
 }
 
 #[cfg(test)]

--- a/syncstorage-settings/src/lib.rs
+++ b/syncstorage-settings/src/lib.rs
@@ -258,17 +258,6 @@ impl ServerLimits {
             .map(|override_| PerCollectionLimits::from(override_, self))
             .unwrap_or_else(|| PerCollectionLimits::from(&Default::default(), self))
     }
-
-    /// The maximum `max_request_bytes` across the default and any
-    /// per-collection overrides. Used to size actix's `PayloadConfig` /
-    /// `JsonConfig` so overridden collections aren't rejected at the
-    /// resource level before per-collection enforcement runs.
-    pub fn effective_max_request_bytes(&self) -> u32 {
-        self.collections
-            .values()
-            .filter_map(|o| o.max_request_bytes)
-            .fold(self.max_request_bytes, u32::max)
-    }
 }
 
 impl Default for ServerLimits {
@@ -396,38 +385,5 @@ mod tests {
         let tabs_limits = limits.limits_for(Some("tabs"));
         assert_eq!(tabs_limits.max_post_bytes, DEFAULT_MAX_POST_BYTES);
         assert_eq!(tabs_limits.max_request_bytes, DEFAULT_MAX_REQUEST_BYTES);
-    }
-
-    #[test]
-    fn effective_max_request_bytes_picks_the_ceiling() {
-        let mut limits = ServerLimits::default();
-        // No overrides: the effective ceiling equals the default.
-        assert_eq!(
-            limits.effective_max_request_bytes(),
-            DEFAULT_MAX_REQUEST_BYTES
-        );
-
-        // An override *below* the default doesn't lower the ceiling.
-        limits.collections.insert(
-            "small".to_owned(),
-            CollectionLimitOverride {
-                max_request_bytes: Some(1024),
-                ..Default::default()
-            },
-        );
-        assert_eq!(
-            limits.effective_max_request_bytes(),
-            DEFAULT_MAX_REQUEST_BYTES
-        );
-
-        // An override *above* the default raises the ceiling to match.
-        limits.collections.insert(
-            "newtab-images".to_owned(),
-            CollectionLimitOverride {
-                max_request_bytes: Some(26_218_496),
-                ..Default::default()
-            },
-        );
-        assert_eq!(limits.effective_max_request_bytes(), 26_218_496);
     }
 }


### PR DESCRIPTION
## Description

STOR-642 added per collection `max_request_bytes`, but we only ever compared it against the `Content-Length` header. Actix's `PayloadConfig`/`JsonConfig` limits are set at startup, before we know the collection, so they have to be sized to the largest limit across every collection. 

Both BSO body extractors now read the body with `to_bytes_limited` at the collection's own limit, so an oversized body is cut off as it arrives whilst streaming rather than after it has all been buffered. Made sure it follows same 413 and weave error code the header check already returned.

The PUT path used to use actix's `Json` extractor and now parses the bytes itself. I think this is ok. Status, response body and metric labels are unchanged, the only difference is the text that lands in logs. `Json` was also turning away `application/newlines` for us, so there's a check for that to keep the same response.

One caveat worth raising (mentioned in the ticket...): this may be overkill and ended up being a bit more complex than I would have liked. The ticket calls it minor, the load balancer caps request size ahead of us, and the server still has a hard overall limit, so the exposure was somewhat handled already. Fine by me if we'd rather not carry the extra code.

Docs for the actix pieces:

- `Payload::to_bytes_limited`: https://docs.rs/actix-web/4.13.0/actix_web/web/struct.Payload.html#method.to_bytes_limited
- `body::to_bytes_limited`, the one used here: https://docs.rs/actix-web/4.13.0/actix_web/body/fn.to_bytes_limited.html
- `BodyLimitExceeded`, the error meaning the cap was hit: https://docs.rs/actix-web/4.13.0/actix_web/body/struct.BodyLimitExceeded.html

Closes [STOR-672](https://mozilla-hub.atlassian.net/browse/STOR-672)


[STOR-672]: https://mozilla-hub.atlassian.net/browse/STOR-672?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ