### PR TITLE
test: docker rig for offloaded payload load tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -384,10 +384,97 @@ loadtest-jwt: syncstorage-loadtest  ##  Run load tests with self-signed JWT mode
 	OAUTH_PRIVATE_KEY_FILE=$(OAUTH_PRIVATE_KEY_FILE) \
 	$(POETRY) run molotov $(or $(MOLOTOV_ARGS),--workers 100 --duration 300 -v) loadtest.py
 
-.PHONY: loadtest-docker
-loadtest-docker:  ##  Run load tests in Docker container.
-	@echo "Running syncstorage load tests in Docker..."
-	docker run -e TEST_REPO=https://github.com/mozilla-services/syncstorage-loadtest -e TEST_NAME=test tarekziade/molotov:latest
+## Offloaded Payload Load Tests
+#
+# Molotov against the full offload + change-stream pipeline on emulators.
+# No GCP project, no credentials. Documented in
+# docs/src/tools/load-testing.md. Covers STOR-628 and STOR-629.
+
+# The reconciliation stack reads the server image from SYNCSTORAGE_RS_IMAGE
+# while its setup/mock-fxa containers hardcode app:build, so both names have to
+# point at the same locally built spanner image. Set inline rather than
+# exported, so the existing docker_run_*_e2e_tests targets keep their own
+# defaults.
+LOADTEST_COMPOSE := SYNCSTORAGE_RS_IMAGE=$(or $(SYNCSTORAGE_RS_IMAGE),app:build) \
+	docker compose \
+	-f docker/docker-compose.spanner.yaml \
+	-f docker/docker-compose.e2e.spanner.yaml \
+	-f docker/docker-compose.e2e.reconciliation.yaml \
+	-f docker/docker-compose.e2e.jwk-cache.yaml \
+	-f docker/docker-compose.loadtest.yaml
+
+.PHONY: loadtest-offload-image
+loadtest-offload-image:  ##  Build the spanner server image the load-test rig needs.
+	docker build . --tag app:build --build-arg SYNCSTORAGE_DATABASE_BACKEND=spanner
+
+# Services the rig needs running before molotov starts. mock-fxa-server is not
+# a syncserver dependency in compose, but tokenserver is enabled in this stack,
+# so start it rather than leave a dangling FXA_OAUTH_SERVER_URL. The load test
+# itself uses direct-access mode and never calls tokenserver.
+LOADTEST_SERVICES := sync-db-setup syncserver mock-fxa-server \
+	payload-link-publisher payload-reconciler statsd
+
+# Per-collection raised limits. Only ever applied to offloaded collections:
+# Spanner caps a single STRING(MAX) value at 2.5 MiB, so an inline collection
+# above that fails in the database. See docker-compose.loadtest.yaml.
+LOADTEST_BIG := {"max_record_payload_bytes":10485760,"max_post_bytes":20971520,"max_request_bytes":22020096}
+LOADTEST_ALL_COLLS := bookmarks,forms,passwords,history,prefs
+
+# STOR-629: every batch write offloaded and expanded.
+LOADTEST_ENV_HANDLER := \
+	LOADTEST_OFFLOAD_COLLECTIONS=$(LOADTEST_ALL_COLLS) \
+	LOADTEST_COLLECTION_LIMITS='{"bookmarks":$(LOADTEST_BIG),"forms":$(LOADTEST_BIG),"passwords":$(LOADTEST_BIG),"history":$(LOADTEST_BIG),"prefs":$(LOADTEST_BIG)}' \
+	OFFLOAD_COLLECTIONS=$(LOADTEST_ALL_COLLS) \
+	LARGE_PAYLOAD_PROB=1.0
+
+# STOR-628: bookmarks+history offloaded and expanded; forms/passwords/prefs
+# inline, capped at the 2.5 MiB Spanner limit. OFFLOAD_COLLECTIONS is
+# deliberately left unset so writes spread across all five.
+LOADTEST_ENV_CHANGESTREAM := \
+	LOADTEST_OFFLOAD_COLLECTIONS=bookmarks,history \
+	LOADTEST_COLLECTION_LIMITS='{"bookmarks":$(LOADTEST_BIG),"history":$(LOADTEST_BIG)}' \
+	LARGE_PAYLOAD_PROB=0.5
+
+# LOADTEST_OFFLOAD_COLLECTIONS and LOADTEST_COLLECTION_LIMITS configure
+# *syncserver*, so they have to be in the environment when its container is
+# created, not just when molotov runs. `compose run` will not recreate an
+# already-running container whose env has since changed, so each scenario does
+# its own `up --wait` with its own env first -- compose then recreates
+# syncserver because its config hash moved. Do not factor this back into a
+# shared prerequisite target: that reintroduces a silent bug where the scenario
+# runs against the previous scenario's server config.
+.PHONY: loadtest-offload-up
+loadtest-offload-up:  ##  Start the load-test rig with the default (STOR-628) server config.
+	$(LOADTEST_ENV_CHANGESTREAM) $(LOADTEST_COMPOSE) up -d --wait --build $(LOADTEST_SERVICES)
+
+.PHONY: loadtest-offload-handler
+loadtest-offload-handler:  ##  STOR-629: 100% offloaded payloads, handler GCS read/write path.
+	@echo "STOR-629: every batch write offloaded and expanded."
+	$(LOADTEST_ENV_HANDLER) $(LOADTEST_COMPOSE) up -d --wait --build $(LOADTEST_SERVICES)
+	$(LOADTEST_ENV_HANDLER) \
+	MOLOTOV_ARGS="$(or $(MOLOTOV_ARGS),--processes 1 --workers 5 --duration 60 -v)" \
+	$(LOADTEST_COMPOSE) run --rm loadtest
+
+.PHONY: loadtest-offload-changestream
+loadtest-offload-changestream:  ##  STOR-628: mixed offloaded/inline payloads, change stream to reconciler.
+	@echo "STOR-628: bookmarks+history offloaded and expanded;"
+	@echo "          forms/passwords/prefs inline, capped at the 2.5 MiB Spanner limit."
+	$(LOADTEST_ENV_CHANGESTREAM) $(LOADTEST_COMPOSE) up -d --wait --build $(LOADTEST_SERVICES)
+	$(LOADTEST_ENV_CHANGESTREAM) \
+	MOLOTOV_ARGS="$(or $(MOLOTOV_ARGS),--processes 1 --workers 5 --duration 120 -v)" \
+	$(LOADTEST_COMPOSE) run --rm loadtest
+
+.PHONY: loadtest-offload-report
+loadtest-offload-report:  ##  Wait for the pipeline to drain, then report reconciler + GCS state.
+	docker/loadtest-report.sh
+
+.PHONY: loadtest-offload-logs
+loadtest-offload-logs:  ##  Tail the pipeline containers.
+	$(LOADTEST_COMPOSE) logs -f syncserver payload-link-publisher payload-reconciler
+
+.PHONY: loadtest-offload-down
+loadtest-offload-down:  ##  Tear the load-test rig down, including the fake-gcs volume.
+	$(LOADTEST_COMPOSE) down -v --remove-orphans
 
 ## Python Utilities
 .PHONY: ruff-lint

--- a/docker/batch-commit-probe.py
+++ b/docker/batch-commit-probe.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#
+# Diagnostic for the batch-commit payload handoff (STOR-657 / STOR-668).
+#
+# The load test showed a large payload_reconciler.gcs_404{op=finalize} count
+# and zero batch_commit_skips, which is the signature of the reconciler
+# deleting a GCS object that a committed bsos row still points at. This isolates
+# that path from the rest of the load: one transactional batch, one commit, then
+# read the BSO back.
+#
+# Run inside the rig's network, from the loadtest image (it already has
+# tokenlib and requests):
+#
+#   docker compose ... run --rm --entrypoint python3 \
+#     -v "$PWD/docker/batch-commit-probe.py:/probe.py:ro" loadtest /probe.py
+#
+# Exits 0 if the payload survives the commit, 1 if it does not.
+
+import hashlib
+import hmac
+import json
+import os
+import random
+import sys
+import time
+from base64 import b64encode
+from urllib.parse import urlparse
+
+import requests
+from tokenlib import get_derived_secret as derive
+from tokenlib import make_token
+
+SERVER_URL = os.environ.get("SERVER_URL", "http://syncserver:8000#secret0")
+# Must be in the server's gcs_payload_offload_collections.
+COLLECTION = os.environ.get("PROBE_COLLECTION", "bookmarks")
+# Comfortably over any inline threshold, well under the 2.5 MiB Spanner cap so
+# the probe also works against a stock server.
+PAYLOAD_SIZE = int(os.environ.get("PROBE_PAYLOAD_SIZE", "300000"))
+SETTLE_SECONDS = int(os.environ.get("PROBE_SETTLE_SECONDS", "25"))
+
+
+def b64(data: bytes) -> str:
+    # Padding is kept: storage/utils.py does not strip it, and the MAC has to
+    # match what the server recomputes from the header verbatim.
+    return b64encode(data).decode("ascii")
+
+
+class Client:
+    """Minimal direct-access Hawk client, mirroring storage/client.py."""
+
+    def __init__(self, server_url: str):
+        url = urlparse(server_url)
+        if not url.fragment:
+            raise SystemExit("SERVER_URL must carry a #<master-secret> fragment")
+        self.uid = random.randint(1, 1000000)
+        secret = url.fragment
+        endpoint = url._replace(
+            path=url.path.rstrip("/") + "/1.5/" + str(self.uid), fragment=""
+        )
+        self.endpoint_url = endpoint.geturl()
+        data = {
+            "uid": self.uid,
+            "fxa_uid": hashlib.sha256(
+                f"{self.uid}:fxa_uid".encode("ascii")
+            ).hexdigest(),
+            "fxa_kid": hashlib.sha256(
+                f"{self.uid}:fxa_kid".encode("ascii")
+            ).hexdigest()[:32],
+            "hashed_fxa_uid": hashlib.sha256(
+                f"{self.uid}:hashed_fxa_uid".encode("ascii")
+            ).hexdigest(),
+            "node": url._replace(path="", fragment="").geturl(),
+            "expires": time.time() + 3600,
+        }
+        token = make_token(data, secret=secret)
+        self.auth_token = token
+        self.auth_secret = derive(token, secret=secret).encode("ascii")
+        parsed = urlparse(self.endpoint_url)
+        self.host = parsed.hostname
+        self.port = str(parsed.port or (80 if parsed.scheme == "http" else 443))
+        self.host_header = parsed.netloc
+        self.timeskew = 0
+
+    def _auth_header(self, method: str, url: str) -> str:
+        parsed = urlparse(url)
+        path_qs = parsed.path + ("?" + parsed.query if parsed.query else "")
+        params = {
+            "id": self.auth_token,
+            "ts": str(int(time.time()) + self.timeskew),
+            "nonce": b64(os.urandom(5)),
+        }
+        sigstr = "\n".join(
+            [
+                "hawk.1.header",
+                params["ts"],
+                params["nonce"],
+                method,
+                path_qs,
+                self.host.lower(),
+                self.port,
+                "",
+                "",
+                "",
+            ]
+        )
+        params["mac"] = b64(
+            hmac.new(self.auth_secret, sigstr.encode("ascii"), hashlib.sha256).digest()
+        )
+        return "Hawk " + ", ".join(f'{k}="{v}"' for k, v in params.items())
+
+    def request(self, method: str, path: str, body=None):
+        url = self.endpoint_url + path
+
+        def send():
+            headers = {
+                "Authorization": self._auth_header(method, url),
+                "Host": self.host_header,
+                "Content-Type": "application/json",
+            }
+            return requests.request(
+                method, url, headers=headers, data=body, timeout=120
+            )
+
+        resp = send()
+        # Same correction the real client makes: a 401 carries the server's
+        # clock in X-Weave-Timestamp, so re-sign once against it.
+        if resp.status_code == 401 and "X-Weave-Timestamp" in resp.headers:
+            server_time = int(float(resp.headers["X-Weave-Timestamp"]))
+            self.timeskew = server_time - int(time.time())
+            resp = send()
+        return resp
+
+
+GCS_HOST = os.environ.get("PROBE_GCS_HOST", "http://fake-gcs:4443")
+GCS_BUCKET = os.environ.get("PROBE_GCS_BUCKET", "test-payloads")
+
+
+def gcs_objects(fxa_uid: str) -> list:
+    """List this user's payload objects, so the probe can say at which stage an
+    object appears and disappears rather than only that it is gone at the end.
+    """
+    try:
+        resp = requests.get(
+            f"{GCS_HOST}/storage/v1/b/{GCS_BUCKET}/o",
+            params={"prefix": f"{fxa_uid}/", "maxResults": "100"},
+            timeout=30,
+        )
+        return resp.json().get("items", []) or []
+    except Exception as e:  # noqa: BLE001
+        print(f"probe:   (gcs list failed: {e})")
+        return []
+
+
+def show_gcs(stage: str, fxa_uid: str) -> None:
+    items = gcs_objects(fxa_uid)
+    print(f"probe: [{stage}] gcs objects: {len(items)}")
+    for it in items:
+        committed = (it.get("metadata") or {}).get("committed", "<unset>")
+        print(
+            f"probe:   {it.get('name')} size={it.get('size')} "
+            f"committed={committed} customTime={it.get('customTime', '<unset>')}"
+        )
+
+
+def main() -> int:
+    c = Client(SERVER_URL)
+    payload = "p" * PAYLOAD_SIZE
+    bso_id = "probe-batch-commit"
+    fxa_uid = hashlib.sha256(f"{c.uid}:fxa_uid".encode("ascii")).hexdigest()
+
+    print(f"probe: uid={c.uid} fxa_uid={fxa_uid[:16]}...")
+    print(f"probe: collection={COLLECTION} payload={PAYLOAD_SIZE}B")
+
+    # Two-request transactional batch, so the commit is a real handoff from
+    # batch_bsos to bsos rather than the single-request optimisation.
+    resp = c.request(
+        "POST",
+        f"/storage/{COLLECTION}?batch=true",
+        json.dumps([{"id": bso_id, "payload": payload}]),
+    )
+    print(f"probe: batch create -> {resp.status_code}")
+    if resp.status_code != 202:
+        print(f"probe: unexpected batch-create response: {resp.text[:400]}")
+        return 1
+    batch_id = resp.json()["batch"]
+    show_gcs("after batch create", fxa_uid)
+
+    resp = c.request(
+        "POST",
+        f"/storage/{COLLECTION}?commit=true&batch={batch_id}",
+        json.dumps([{"id": bso_id + "-2", "payload": payload}]),
+    )
+    print(f"probe: batch commit -> {resp.status_code}")
+    if resp.status_code != 200:
+        print(f"probe: unexpected commit response: {resp.text[:400]}")
+        return 1
+    show_gcs("immediately after commit", fxa_uid)
+
+    print(f"probe: waiting {SETTLE_SECONDS}s for the reconciler to act...")
+    time.sleep(SETTLE_SECONDS)
+    show_gcs("after settle", fxa_uid)
+
+    failed = []
+    for bid in (bso_id, bso_id + "-2"):
+        resp = c.request("GET", f"/storage/{COLLECTION}/{bid}")
+        ok = resp.status_code == 200
+        size = len(resp.json().get("payload", "")) if ok else 0
+        print(f"probe: GET {bid} -> {resp.status_code} payload={size}B")
+        if not ok or size != PAYLOAD_SIZE:
+            failed.append(bid)
+            if not ok:
+                print(f"probe:   body: {resp.text[:300]}")
+
+    if failed:
+        print(
+            "probe: FAIL -- committed batch payload(s) unreadable after "
+            f"reconciliation: {failed}"
+        )
+        print(
+            "probe: the reconciler deleted a GCS object that a committed bsos "
+            "row still points at (STOR-657 shape)."
+        )
+        return 1
+    print("probe: PASS -- committed batch payloads survived reconciliation.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docker/docker-compose.loadtest.yaml
+++ b/docker/docker-compose.loadtest.yaml
@@ -1,0 +1,178 @@
+# docker-compose overlay: molotov load tests against the offload +
+# change-stream pipeline.
+#
+# Layers on top of:
+#   docker-compose.spanner.yaml
+#   docker-compose.e2e.spanner.yaml
+#   docker-compose.e2e.reconciliation.yaml
+#   docker-compose.e2e.jwk-cache.yaml
+#
+# It turns the reconciliation e2e stack into a load-test rig by adding four
+# things that stack deliberately does not need for pytest:
+#
+#   1. A molotov container (`loadtest`) driving syncserver in direct-access
+#      mode, so no tokenserver rows, FxA accounts or JWKs are involved.
+#   2. Raised syncstorage limits, so payloads can actually exceed the 2.5 MiB
+#      default and reach the offload path at size.
+#   3. fake-gcs on its filesystem backend. The default in-memory backend is
+#      fine for a handful of pytest objects and will exhaust the container's
+#      memory once a load test starts writing multi-MiB payloads in bulk.
+#   4. A statsd sink, so the reconciler counters that prove the pipeline
+#      drained are readable instead of being fired into a closed UDP port.
+#
+# Invocation lives in the Makefile (`loadtest-offload-*`) and is documented in
+# docs/src/tools/load-testing.md. Covers STOR-628 and STOR-629.
+
+services:
+  # Collects dogstatsd from syncserver and the reconciler and re-exposes it as
+  # Prometheus text on :9102. Nothing scrapes it -- docker/loadtest-report.sh
+  # curls it directly, which keeps the rig to one extra container instead of a
+  # Prometheus + Grafana pair.
+  statsd:
+    image: prom/statsd-exporter:v0.28.0
+    command:
+      - --statsd.listen-udp=:8125
+      - --web.listen-address=:9102
+    ports:
+      - "9102:9102"
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:9102/metrics"]
+      interval: 2s
+      retries: 15
+      start_period: 3s
+      timeout: 3s
+
+  # Replaces the in-memory backend with a disk-backed one. `command` is a list,
+  # so this overrides the base definition outright rather than appending.
+  fake-gcs:
+    command:
+      - -scheme=http
+      - -host=0.0.0.0
+      - -port=4443
+      - -public-host=fake-gcs:4443
+      - -backend=filesystem
+      - -filesystem-root=/data
+      - -log-level=${FAKE_GCS_LOG_LEVEL:-warn}
+    volumes:
+      - fake_gcs_data:/data
+
+  payload-reconciler:
+    environment:
+      SYNC_STATSD_HOST: statsd
+      SYNC_STATSD_PORT: "8125"
+
+  # The publisher uses pystatsd via `statsd.defaults.env`, which reads the
+  # bare STATSD_HOST/STATSD_PORT rather than the SYNC_-prefixed pair the
+  # reconciler and syncserver use. Its payload_link_publisher.filtered counter
+  # is the direct evidence that inert records (payload_link NULL on both
+  # sides) are being dropped before Pub/Sub, which is the STOR-628 claim.
+  payload-link-publisher:
+    environment:
+      STATSD_HOST: statsd
+      STATSD_PORT: "8125"
+
+  syncserver:
+    depends_on:
+      sync-db-setup:
+        condition: service_started
+      tokenserver-db:
+        condition: service_healthy
+      reconciliation-setup:
+        condition: service_healthy
+      statsd:
+        condition: service_healthy
+    environment:
+      SYNC_STATSD_HOST: statsd
+      SYNC_STATSD_PORT: "8125"
+
+      # Which collections syncserver offloads. This is the setting that
+      # decides mixed vs fully-offloaded traffic, and it is deliberately
+      # separate from the load test's own OFFLOAD_COLLECTIONS (which only
+      # decides which collections get *written to*).
+      #
+      # Default is the molotov batch-write set minus forms/passwords/prefs, so
+      # a default run produces both offloaded and inline writes -- the STOR-628
+      # shape. The Makefile's handler target overrides it with all five.
+      SYNC_SYNCSTORAGE__GCS_PAYLOAD_OFFLOAD_COLLECTIONS: ${LOADTEST_OFFLOAD_COLLECTIONS:-bookmarks,history}
+
+      # Raised limits, PER COLLECTION, and only for collections that are in
+      # the offload list above.
+      #
+      # Do not raise the global max_record_payload_bytes instead. Spanner's
+      # STRING(MAX) columns cap a single value at 2621440 bytes (2.5 MiB) --
+      # that hard cap is the reason this whole offload project exists. An
+      # inline write above it fails in the database, not at the API:
+      #
+      #   FAILED_PRECONDITION New value exceeds the maximum size limit for
+      #   this column: bsos.payload, size: 10485760, limit: 2621440
+      #
+      # An offloaded collection is exempt because its payload goes to GCS and
+      # the row stores only a gs:// URL in payload_link, leaving payload NULL.
+      # So a limit above 2.5 MiB is only ever correct for a collection that is
+      # offloaded, which is exactly what the per-collection override is for
+      # and how production raises it. Keys here must be a subset of
+      # LOADTEST_OFFLOAD_COLLECTIONS.
+      #
+      # Globals are deliberately left at their defaults, so any collection not
+      # listed here keeps stock 2.5 MiB behaviour and writes inline safely.
+      # actix's payload config is sized from the max max_request_bytes across
+      # these overrides (ServerLimits::effective_max_request_bytes), so large
+      # bodies are not rejected before per-collection enforcement runs.
+      SYNC_SYNCSTORAGE__LIMITS__COLLECTIONS: ${LOADTEST_COLLECTION_LIMITS:-{"bookmarks":{"max_record_payload_bytes":10485760,"max_post_bytes":20971520,"max_request_bytes":22020096},"history":{"max_record_payload_bytes":10485760,"max_post_bytes":20971520,"max_request_bytes":22020096}}}
+
+      # Concurrent GCS uploads/downloads within a single batch request. Worth
+      # sweeping: it is the main server-side knob on offload throughput.
+      SYNC_SYNCSTORAGE__GCS_PAYLOAD_MAX_CONCURRENCY: ${LOADTEST_GCS_MAX_CONCURRENCY:-4}
+
+      # The default pool of 10 is the first thing to saturate once molotov
+      # runs more than a handful of workers.
+      SYNC_SYNCSTORAGE__DATABASE_POOL_MAX_SIZE: ${LOADTEST_DB_POOL_MAX_SIZE:-40}
+
+  loadtest:
+    build:
+      context: ../tools/syncstorage-loadtest
+    # No container_name: this service is driven with `docker compose run`,
+    # which generates its own container name.
+    depends_on:
+      syncserver:
+        condition: service_healthy
+      payload-link-publisher:
+        condition: service_started
+      payload-reconciler:
+        condition: service_started
+      statsd:
+        condition: service_healthy
+    environment:
+      # Direct-access mode: the fragment is the master secret, so the client
+      # mints its own Hawk token and talks straight to syncstorage. Skips
+      # tokenserver, FxA and JWK setup entirely. Matches SYNC_MASTER_SECRET
+      # in docker-compose.spanner.yaml.
+      SERVER_URL: http://syncserver:8000#secret0
+
+      # Fraction of BSOs given an expanded payload.
+      LARGE_PAYLOAD_PROB: ${LARGE_PAYLOAD_PROB:-0.5}
+      # Target size for those payloads. Unset means "use the server's
+      # max_record_payload_bytes".
+      LARGE_PAYLOAD_SIZE: ${LARGE_PAYLOAD_SIZE:-}
+      # Restricts batch writes to these collections. Leave unset for mixed
+      # runs so writes spread across the default five and the ones missing
+      # from the server's offload list stay inline.
+      OFFLOAD_COLLECTIONS: ${OFFLOAD_COLLECTIONS:-}
+      # Deletes drive the reconciler's orphan_deletes branch, so they are on
+      # by default here.
+      DISABLE_DELETES: ${DISABLE_DELETES:-false}
+
+      MOLOTOV_ARGS: ${MOLOTOV_ARGS:---processes 1 --workers 5 --duration 60 -v}
+    # $$ escapes to a literal $, so MOLOTOV_ARGS is word-split by the
+    # container's shell rather than by compose.
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        echo "loadtest: SERVER_URL=$${SERVER_URL%%#*}#<redacted>"
+        echo "loadtest: LARGE_PAYLOAD_PROB=$$LARGE_PAYLOAD_PROB LARGE_PAYLOAD_SIZE=$${LARGE_PAYLOAD_SIZE:-<server max>}"
+        echo "loadtest: OFFLOAD_COLLECTIONS=$${OFFLOAD_COLLECTIONS:-<default five>} DISABLE_DELETES=$$DISABLE_DELETES"
+        echo "loadtest: molotov $$MOLOTOV_ARGS loadtest.py"
+        exec molotov $$MOLOTOV_ARGS loadtest.py
+
+volumes:
+  fake_gcs_data:

--- a/docker/loadtest-report.sh
+++ b/docker/loadtest-report.sh
@@ -1,0 +1,340 @@
+#!/bin/bash
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#
+# Post-run report for the offload load-test rig (docker-compose.loadtest.yaml).
+#
+# Molotov tells you what the client saw. This tells you what the pipeline did
+# with it: whether the change stream -> publisher -> Pub/Sub -> reconciler arm
+# drained, and whether every offloaded object ended up finalized.
+#
+# Run it with the stack still up, after the loadtest container has exited:
+#
+#   make loadtest-offload-report
+#   docker/loadtest-report.sh --no-wait      # skip the drain wait
+#
+# Requires curl and jq on the host. Reads the emulators through their
+# published ports, so it needs no docker exec.
+
+set -uo pipefail
+
+STATSD_URL="${STATSD_URL:-http://localhost:9102/metrics}"
+GCS_HOST="${GCS_HOST:-http://localhost:4443}"
+GCS_PAYLOAD_BUCKET="${GCS_PAYLOAD_BUCKET:-test-payloads}"
+
+# Drain wait: poll until the reconciler's handled-record total stops moving for
+# STABLE_POLLS consecutive polls, or DRAIN_TIMEOUT seconds elapse.
+POLL_INTERVAL="${POLL_INTERVAL:-5}"
+STABLE_POLLS="${STABLE_POLLS:-3}"
+DRAIN_TIMEOUT="${DRAIN_TIMEOUT:-300}"
+
+WAIT_FOR_DRAIN=1
+[ "${1:-}" = "--no-wait" ] && WAIT_FOR_DRAIN=0
+
+# Set to 1 by any failed health assertion; becomes the exit code.
+problems=0
+
+for tool in curl jq; do
+    if ! command -v "$tool" >/dev/null 2>&1; then
+        echo "error: $tool is required but not installed" >&2
+        exit 2
+    fi
+done
+
+hr() { printf '%s\n' "----------------------------------------------------------------"; }
+
+# Scrape the exporter once.
+scrape() { curl -sf --max-time 10 "$STATSD_URL"; }
+
+# Sum every sample of a metric family, across all label combinations.
+# statsd counters arrive as `name{labels} value`; a bare counter has no braces.
+# Prints 0 when the family has not been emitted yet.
+metric_sum() {
+    local body="$1" name="$2"
+    printf '%s\n' "$body" \
+        | awk -v n="$name" '
+            $0 ~ "^"n"($|[{ ])" {
+                v = $NF
+                if (v + 0 == v) s += v
+            }
+            END { printf "%d\n", s + 0 }
+        '
+}
+
+# Print every sample line for a metric prefix, minus the HELP/TYPE comments.
+metric_lines() {
+    local body="$1" prefix="$2"
+    printf '%s\n' "$body" | grep -E "^${prefix}" | grep -v '^#' | sort
+}
+
+if ! body="$(scrape)"; then
+    echo "error: cannot reach the statsd exporter at $STATSD_URL" >&2
+    echo "       is the stack up? (make loadtest-offload-up)" >&2
+    exit 2
+fi
+
+# ---------------------------------------------------------------- drain wait
+
+# Total records the reconciler has finished with, by any route. While this is
+# still climbing there is backlog in Pub/Sub or the publisher.
+handled_total() {
+    local b="$1" sum=0 m
+    for m in payload_reconciler_finalizes \
+             payload_reconciler_orphan_deletes \
+             payload_reconciler_noop_skips \
+             payload_reconciler_batch_commit_skips \
+             payload_reconciler_gcs_404; do
+        sum=$(( sum + $(metric_sum "$b" "$m") ))
+    done
+    printf '%d\n' "$sum"
+}
+
+if [ "$WAIT_FOR_DRAIN" -eq 1 ]; then
+    echo "waiting for the reconciler to drain (timeout ${DRAIN_TIMEOUT}s)..."
+    last=-1
+    stable=0
+    elapsed=0
+    while [ "$elapsed" -lt "$DRAIN_TIMEOUT" ]; do
+        current="$(handled_total "$body")"
+        if [ "$current" -eq "$last" ]; then
+            stable=$(( stable + 1 ))
+        else
+            stable=0
+        fi
+        printf '  handled=%s stable=%s/%s\n' "$current" "$stable" "$STABLE_POLLS"
+        if [ "$stable" -ge "$STABLE_POLLS" ]; then
+            if [ "$current" -gt 0 ]; then
+                echo "  drained."
+            else
+                # Flat at zero is not a drained pipeline, it is a pipeline that
+                # never started. Bail out now instead of burning the full
+                # timeout waiting for a number that will not move.
+                echo "  no progress at all -- nothing reached the reconciler."
+                problems=1
+            fi
+            break
+        fi
+        last="$current"
+        sleep "$POLL_INTERVAL"
+        elapsed=$(( elapsed + POLL_INTERVAL ))
+        body="$(scrape)" || { echo "  scrape failed, retrying" >&2; continue; }
+    done
+    if [ "$elapsed" -ge "$DRAIN_TIMEOUT" ]; then
+        echo "  warning: still moving at timeout -- the numbers below are a" \
+             "snapshot of an undrained pipeline."
+        problems=1
+    fi
+fi
+
+# ------------------------------------------------------------------- metrics
+
+hr
+echo "RECONCILER (payload_reconciler.*)"
+hr
+lines="$(metric_lines "$body" 'payload_reconciler_')"
+if [ -z "$lines" ]; then
+    echo "  no metrics emitted -- the reconciler never handled a record."
+    echo "  check: docker compose logs payload-link-publisher payload-reconciler"
+    problems=1
+else
+    printf '%s\n' "$lines" | sed 's/^/  /'
+fi
+
+finalizes="$(metric_sum "$body" payload_reconciler_finalizes)"
+orphan_deletes="$(metric_sum "$body" payload_reconciler_orphan_deletes)"
+handler_errors="$(metric_sum "$body" payload_reconciler_errors)"
+noop_skips="$(metric_sum "$body" payload_reconciler_noop_skips)"
+batch_skips="$(metric_sum "$body" payload_reconciler_batch_commit_skips)"
+
+hr
+echo "PUBLISHER (payload_link_publisher.*)"
+hr
+lines="$(metric_lines "$body" 'payload_link_publisher_')"
+if [ -z "$lines" ]; then
+    echo "  no metrics emitted -- the publisher never read a change record."
+    echo "  check: docker compose logs payload-link-publisher"
+    problems=1
+else
+    printf '%s\n' "$lines" | sed 's/^/  /'
+fi
+
+published="$(metric_sum "$body" payload_link_publisher_published)"
+filtered="$(metric_sum "$body" payload_link_publisher_filtered)"
+pub_errors="$(metric_sum "$body" payload_link_publisher_errors)"
+
+hr
+echo "SYNCSERVER (syncstorage.*)"
+hr
+lines="$(metric_lines "$body" 'syncstorage_')"
+if [ -z "$lines" ]; then
+    echo "  no metrics emitted."
+    problems=1
+else
+    printf '%s\n' "$lines" | sed 's/^/  /'
+fi
+
+# --------------------------------------------------------------- GCS objects
+
+hr
+echo "GCS OBJECTS (${GCS_PAYLOAD_BUCKET})"
+hr
+
+# Page through the bucket. fake-gcs honours maxResults/pageToken like the real
+# JSON API, and a load test can easily leave tens of thousands of objects.
+tmp="$(mktemp)"
+trap 'rm -f "$tmp"' EXIT
+token=""
+pages=0
+while :; do
+    url="${GCS_HOST}/storage/v1/b/${GCS_PAYLOAD_BUCKET}/o?maxResults=1000"
+    [ -n "$token" ] && url="${url}&pageToken=${token}"
+    if ! page="$(curl -sf --max-time 30 "$url")"; then
+        echo "  error: cannot list ${GCS_PAYLOAD_BUCKET} at ${GCS_HOST}" >&2
+        problems=1
+        break
+    fi
+    printf '%s' "$page" | jq -c '.items // [] | .[]' >>"$tmp"
+    token="$(printf '%s' "$page" | jq -r '.nextPageToken // empty')"
+    pages=$(( pages + 1 ))
+    [ -z "$token" ] && break
+done
+
+total="$(wc -l <"$tmp" | tr -d ' ')"
+if [ "$total" = "0" ]; then
+    echo "  bucket is empty -- no payload was offloaded."
+    echo "  check that the collections molotov writes to overlap"
+    echo "  SYNC_SYNCSTORAGE__GCS_PAYLOAD_OFFLOAD_COLLECTIONS."
+    problems=1
+else
+    committed="$(jq -rs '[.[] | select(.metadata.committed == "true")] | length' <"$tmp")"
+    uncommitted=$(( total - committed ))
+    # Finalize also pins customTime to the far-future sentinel; that is what
+    # actually protects the object from the 30-day lifecycle rule, so it is
+    # worth counting separately from the metadata flag.
+    pinned="$(jq -rs '[.[] | select((.customTime // "") | startswith("2200-12-31"))] | length' <"$tmp")"
+    bytes="$(jq -rs '[.[] | (.size // "0" | tonumber)] | add // 0' <"$tmp")"
+
+    printf '  objects           %s (across %s list page(s))\n' "$total" "$pages"
+    printf '  committed=true    %s\n' "$committed"
+    printf '  committed!=true   %s\n' "$uncommitted"
+    printf '  customTime pinned %s\n' "$pinned"
+    printf '  total bytes       %s (%s MiB)\n' "$bytes" "$(( bytes / 1048576 ))"
+
+    # A large tail of unfinalized objects is expected, not a fault, and the
+    # expected size is derivable from the load test's own distributions.
+    #
+    # loadtest.py picks num_requests from post_count_distribution
+    # ([67,18,9,4,2] -> P(0)=.67, P(1)=.18, P(>=2)=.15) and flips a coin for
+    # `transact`. A transactional run with exactly one request opens the batch
+    # with ?batch=true and the loop ends before it ever commits, so those
+    # uploads correctly stay committed=false until the lifecycle rule reaps
+    # them. Of the scenarios that write at all (P=.33), the never-committed
+    # share is .5 * .18/.33, about 28%. Measured runs land right on that.
+    #
+    # So the threshold has to sit comfortably above ~28%, not below it. Only a
+    # share far past that means the reconciler is genuinely not keeping up.
+    if [ "$uncommitted" -gt 0 ]; then
+        share=$(( uncommitted * 100 / total ))
+        printf '  unfinalized share %s%% (about 28%% is expected, see comment)\n' "$share"
+        if [ "$share" -ge "${UNFINALIZED_FAIL_PCT:-50}" ]; then
+            echo "  FAIL: $uncommitted of $total objects never finalized"
+            echo "        (>= ${UNFINALIZED_FAIL_PCT:-50}%). Either the reconciler is not"
+            echo "        keeping up with the write rate, or finalize is broken."
+            problems=1
+        else
+            echo "  NOTE: $uncommitted object(s) unfinalized. At this share it is the"
+            echo "        expected tail: molotov opens batches it never commits, and"
+            echo "        those uploads stay committed=false by design."
+        fi
+    fi
+    if [ "$committed" != "$pinned" ]; then
+        echo "  warning: committed count and pinned-customTime count disagree."
+        echo "  Finalize sets both in one patch, so they should match."
+        problems=1
+    fi
+fi
+
+# -------------------------------------------------------------------- verdict
+
+hr
+echo "VERDICT"
+hr
+printf '  published            %s\n' "$published"
+printf '  filtered (inert)     %s\n' "$filtered"
+printf '  publisher errors     %s\n' "$pub_errors"
+printf '  finalizes            %s\n' "$finalizes"
+printf '  orphan_deletes       %s\n' "$orphan_deletes"
+printf '  batch_commit_skips   %s\n' "$batch_skips"
+printf '  noop_skips           %s\n' "$noop_skips"
+printf '  handler errors       %s\n' "$handler_errors"
+
+if [ "$pub_errors" -gt 0 ]; then
+    echo "  FAIL: publisher errors are non-zero. Change records were either"
+    echo "        not read or not published; the reconciler numbers below are"
+    echo "        an undercount."
+    echo "        See: docker compose logs payload-link-publisher"
+    problems=1
+fi
+# The positive form of the STOR-628 claim. noop_skips == 0 only says the
+# reconciler saw nothing inert; a non-zero filtered count says the publisher
+# actively dropped inert records, which is what the filter is for. On a mixed
+# run there must be some: every inline write and every meta/clients write
+# produces a change record with payload_link NULL on both sides.
+if [ "$filtered" -eq 0 ]; then
+    echo "  WARN: nothing was filtered. On a mixed run this means either the"
+    echo "        filter is passing inert records through, or every write was"
+    echo "        offloaded and the NULL-filtering path went untested."
+    problems=1
+fi
+if [ "$handler_errors" -gt 0 ]; then
+    echo "  FAIL: handler errors are non-zero. Messages were left unacked;"
+    echo "        five failures on one message routes it to the DLQ in prod."
+    echo "        See: docker compose logs payload-reconciler"
+    problems=1
+fi
+if [ "$noop_skips" -gt 0 ]; then
+    echo "  FAIL: noop_skips is non-zero. The publisher's filter let records"
+    echo "        through that had payload_link NULL on both sides -- the"
+    echo "        exact regression STOR-628 is meant to catch."
+    problems=1
+fi
+if [ "$finalizes" -eq 0 ] && [ "$total" != "0" ]; then
+    echo "  FAIL: objects exist but nothing was finalized. The change stream,"
+    echo "        publisher or Pub/Sub leg is broken."
+    problems=1
+fi
+
+# The Spanner emulator emits transaction_tag on change records but never
+# populates it, so the reconciler cannot recognise a batch-commit handoff and
+# deletes the object the just-committed bsos row points at. That produces
+# batch_commit_skips == 0 alongside a high gcs_404{op=finalize}. It is a known
+# emulator gap rather than a regression, so it is reported and not counted
+# against the verdict by default. On GCP dev, where Spanner does record the
+# tag, this must be treated as a hard failure: run with STRICT_BATCH_COMMIT=1.
+finalize_404="$(printf '%s\n' "$body" \
+    | awk '/^payload_reconciler_gcs_404\{[^}]*op="finalize"/ { s += $NF } END { printf "%d\n", s + 0 }')"
+if [ "$batch_skips" -eq 0 ] && [ "$finalize_404" -gt 0 ]; then
+    if [ "${STRICT_BATCH_COMMIT:-0}" = "1" ]; then
+        echo "  FAIL: batch_commit_skips is 0 with $finalize_404 finalize 404s."
+        echo "        The batch_commit transaction tag is not reaching the"
+        echo "        reconciler, so batch-commit handoff objects are being"
+        echo "        deleted (STOR-657/668). Strict mode: treated as failure."
+        problems=1
+    else
+        echo "  NOTE: batch_commit_skips is 0 with $finalize_404 finalize 404s."
+        echo "        Expected on the local emulator, which never populates"
+        echo "        transaction_tag, so every batch-commit handoff looks like"
+        echo "        a genuine removal. See the emulator section in"
+        echo "        docs/src/tools/load-testing.md, and reproduce in isolation"
+        echo "        with docker/batch-commit-probe.py."
+        echo "        On GCP dev this is a real failure: re-run with"
+        echo "        STRICT_BATCH_COMMIT=1."
+    fi
+fi
+
+if [ "$problems" -eq 0 ]; then
+    echo "  OK: pipeline drained clean."
+fi
+exit "$problems"

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -9,6 +9,7 @@
 - [Application Architecture](architecture.md)
 - [Application Configuration](config.md)
 - [Testing](testing.md)
+    - [Load Testing](tools/load-testing.md)
 - [Release Process](release-process.md)
 - [Frequently Asked Questions](faq.md)
 - [Data Types](data-types.md)

--- a/docs/src/tools/load-testing.md
+++ b/docs/src/tools/load-testing.md
@@ -1,0 +1,738 @@
+# Load Testing
+
+## Quickstart: load test the change stream system (STOR-628)
+
+Four commands. Needs Docker, plus `curl` and `jq`. No GCP account, no
+credentials, no VM.
+
+```console
+make loadtest-offload-image          # once: builds the server image
+make loadtest-offload-changestream   # run the load test
+make loadtest-offload-report         # did the pipeline keep up?
+make loadtest-offload-down           # tear it all down
+```
+
+The report is the answer. Three numbers matter:
+
+| Look for | Meaning |
+| --- | --- |
+| `filtered` non-zero | The pipeline correctly dropped change records that have no payload file attached. This is the thing STOR-628 is asking about. |
+| `handler errors` zero | Nothing failed while finalizing or deleting objects. |
+| `noop_skips` zero | Nothing inert slipped past the filter. |
+
+It prints `OK: pipeline drained clean` at the end, or a list of `FAIL` lines
+explaining what went wrong, and exits non-zero on a real problem so it can gate
+a script.
+
+One thing to expect: a `NOTE` saying `batch_commit_skips` is 0. That is a known
+emulator limitation rather than your run going wrong. See
+[The emulator drops transaction tags](#the-emulator-drops-transaction-tags).
+
+For a real run rather than a smoke test, pass molotov your own arguments:
+
+```console
+make loadtest-offload-changestream \
+  MOLOTOV_ARGS="--processes 2 --workers 20 --duration 3600 -v"
+```
+
+To load test the handler read/write path instead (STOR-629), swap in
+`make loadtest-offload-handler`. Same report, same teardown.
+
+Everything below is detail you only need when a run looks wrong, or when you
+need real latency numbers and have to go to GCP.
+
+---
+
+## Summary
+
+This is the runbook for load testing syncstorage, with the offloaded-payload
+pipeline as the main case. It replaces the Confluence page "Syncstorage &
+Tokenserver Runbooks", whose molotov and locust instructions had become
+interleaved and unreadable.
+
+There are two load tests in the repo and they are unrelated:
+
+| | Target | Tool | Location |
+| --- | --- | --- | --- |
+| Syncstorage | storage read/write API | molotov | `tools/syncstorage-loadtest/` |
+| Tokenserver | `/1.0/sync/1.5` token issuance | locust | `tools/tokenserver/loadtests/` |
+
+Everything below is about the syncstorage/molotov one unless it says otherwise.
+For tokenserver, see [Tokenserver load tests](#tokenserver-load-tests-locust).
+
+Two tickets drive the offload work, and they want different traffic shapes:
+
+| Ticket | Goal | Traffic shape |
+| --- | --- | --- |
+| STOR-629 | Performance of the handler's GCS read/write path | 100% offloaded, every payload expanded |
+| STOR-628 | The change stream to reconciler pipeline, including the filtering of NULL `payload_link` records | Mixed offloaded and inline |
+
+The distinction matters. STOR-628 is only a real test if some writes are
+*not* offloaded, because the record it is checking for is the one the
+publisher's filter is supposed to drop.
+
+---
+
+## Which rig to use
+
+```mermaid
+flowchart TB
+    q1{"What are you<br/>measuring?"}
+    q1 -->|"pipeline correctness:<br/>does every object get<br/>finalized, is the filter<br/>dropping NULL records"| local["Local docker rig<br/>(emulators)"]
+    q1 -->|"real latency and<br/>throughput numbers<br/>for a capacity decision"| gcp["GCP dev environment"]
+    local --> both["Run local first either way:<br/>it catches wiring bugs in<br/>minutes with no GCP spend"]
+```
+
+The local rig runs the whole pipeline on emulators. It is the right default:
+it needs no GCP project, no credentials and no VM, and it answers every
+correctness question. What it cannot give you is a trustworthy latency
+number, because fake-gcs-server on a loopback interface is nothing like GCS
+over the network, and the Spanner emulator is single-node and in-process.
+
+Use GCP dev when the question is "how fast" rather than "does it work".
+
+---
+
+## Local docker rig
+
+### What it stands up
+
+The rig is the existing reconciliation e2e stack plus a molotov container and
+a metrics sink. Compose overlay: `docker/docker-compose.loadtest.yaml`.
+
+```mermaid
+flowchart LR
+    lt["loadtest<br/>molotov"]
+
+    subgraph fg["Foreground: the request path (STOR-629)"]
+        ss["syncserver<br/>offload enabled"]
+    end
+
+    gcs[("fake-gcs<br/>test-payloads<br/>filesystem backend")]
+    db[("Spanner emulator<br/>bsos, batch_bsos<br/>payload_link_changes")]
+
+    subgraph bg["Background: the cleanup arm (STOR-628)"]
+        pub["payload-link-publisher<br/>stands in for Dataflow"]
+        ps["Pub/Sub emulator"]
+        rec["payload-reconciler<br/>long-running mode"]
+    end
+
+    drop(["dropped: inert records<br/>payload_link NULL both sides"])
+    sd["statsd-exporter<br/>:9102"]
+    rep["loadtest-report.sh<br/>the verdict"]
+
+    lt -->|"Hawk, direct access<br/>no tokenserver or FxA"| ss
+    ss -->|"upload payload"| gcs
+    ss -->|"store gs:// in payload_link"| db
+    gcs -->|"download on read"| ss
+    db -->|"change stream"| pub
+    pub -.->|filtered| drop
+    pub -->|published| ps
+    ps --> rec
+    rec -->|"finalize: committed=true<br/>delete: orphans"| gcs
+
+    ss -.->|dogstatsd| sd
+    pub -.->|dogstatsd| sd
+    rec -.->|dogstatsd| sd
+    sd -->|"scrape counters"| rep
+    gcs -->|"list objects,<br/>check committed + customTime"| rep
+```
+
+The two halves map onto the two tickets. Everything left of the change stream
+is STOR-629's territory, and it costs the user latency. Everything right of it
+is STOR-628's, and no user waits on it, but a wrong decision there deletes a
+file a live row still needs.
+
+Note where the report gets its evidence: counters from the statsd sink, and
+object state read straight out of the bucket. It never trusts molotov's exit
+status, because the cleanup arm runs after the response is sent and can fail
+long after the client saw a 200.
+
+| Service | Role |
+| --- | --- |
+| `sync-db` | Spanner emulator, carrying the `payload_link_changes` change stream from `schema.ddl` |
+| `pubsub-emulator` | Pub/Sub |
+| `fake-gcs` | GCS, on its **filesystem** backend for this rig |
+| `reconciliation-setup` | One-shot: creates the topic, subscription and bucket |
+| `payload-link-publisher` | Python change-stream reader, stands in for the Dataflow job |
+| `payload-reconciler` | Drains Pub/Sub, finalizes and deletes GCS objects |
+| `syncserver` | Offload enabled, limits raised |
+| `statsd` | `prom/statsd-exporter`, so the publisher and reconciler counters are readable |
+| `loadtest` | molotov |
+
+The publisher is the Python one, not the Java Dataflow template. It publishes
+the identical JSON wire format, so everything downstream of it is
+production code. If you need to reproduce something Java-specific, layer
+`docker-compose.e2e.reconciliation.java.yaml` on top; see
+[Reconciliation Pipeline](payload_link_reconciler.md).
+
+On the NULL-filtering half of STOR-628, be precise about what the local rig
+proves. The filter exists twice: `isPayloadLinkActionable` in the Java flex
+template, and `is_payload_link_actionable` in
+`payload-link-publisher-py/utils.py`, which is written to mirror it. A local
+run exercises the **Python** one. That is a real test of the filter's logic
+and of everything downstream, but it is not a test of the Java code that runs
+in production. To exercise the shipping filter, either use the Java overlay
+locally or run against GCP dev, where the Dataflow job is the publisher.
+
+### Prerequisites
+
+- Docker running, with roughly 8 GB available to the VM. Expanded payloads
+  are held in memory in several places at once.
+- `curl` and `jq` on the host, for the report script.
+- Nothing else. No GCP credentials, no `service-account.json`.
+
+### The stale publisher image trap
+
+Read this before trusting any local result.
+
+`payload-link-publisher` is the only service in the stack built from a compose
+`build:` context rather than pulled or shared with `app:build`. Plain
+`docker compose up` reuses whatever `docker-payload-link-publisher` image is
+already in your local cache and **will not rebuild it when its source
+changes**. So a publisher image built before a change to
+`payload-link-publisher-py/` keeps running against new server code, silently.
+
+This is not hypothetical. It is how the rig behaved on first use here: a
+four-week-old publisher image had no `transaction_tag` support at all, so no
+record ever carried the `batch_commit` tag, so the reconciler treated every
+batch-commit handoff as a genuine `batch_bsos` removal and deleted GCS objects
+that committed `bsos` rows still pointed at. The symptom was HTTP 500s on
+reads, `payload_reconciler.batch_commit_skips` flat at zero, and
+`gcs_404{op=finalize}` running nearly 1:1 with `finalizes`. It looked exactly
+like the STOR-657 production bug, and it was entirely a stale image.
+
+The `loadtest-offload-*` targets therefore pass `--build` on every `up`. The
+first build is slow from a cold cache; afterwards it is cached and cheap.
+
+Two things follow. If you drive compose by hand instead of through the
+Makefile, pass `--build` yourself. And note that
+`make docker_run_reconciliation_e2e_tests` does **not** pass it, so a local run
+of the reconciliation e2e suite can exercise a stale publisher. CI is unaffected
+because its cache starts empty.
+
+The tell, if you suspect it:
+
+```console
+docker compose ... exec payload-link-publisher grep -c transaction_tag /app/publisher.py
+```
+
+Zero means the image predates transaction-tag support.
+
+### Run it
+
+```console
+make loadtest-offload-image           # build app:build (spanner backend), once
+
+make loadtest-offload-handler         # STOR-629
+make loadtest-offload-report
+
+make loadtest-offload-changestream    # STOR-628
+make loadtest-offload-report
+
+make loadtest-offload-down            # tear down, including the fake-gcs volume
+```
+
+`loadtest-offload-report` waits for the reconciler to stop making progress
+before reporting, so run it straight after the load test rather than trying
+to guess a sleep. It exits non-zero if it finds a problem, which makes it
+usable as a gate.
+
+Both scenario targets take `MOLOTOV_ARGS`:
+
+```console
+make loadtest-offload-handler MOLOTOV_ARGS="--processes 2 --workers 20 --duration 600 -v"
+```
+
+Start small. Every worker can be holding a multi-MiB payload, on both the
+client and the server, so worker count multiplies memory rather than just CPU.
+Five workers writing 10 MiB records is already a meaningful amount of traffic
+through this stack.
+
+### Reading the report
+
+```text
+RECONCILER (payload_reconciler.*)
+  payload_reconciler_finalizes 1843
+  payload_reconciler_orphan_deletes 291
+  payload_reconciler_batch_commit_skips 412
+...
+GCS OBJECTS (test-payloads)
+  objects           1552
+  committed=true    1552
+  committed!=true   0
+  customTime pinned 1552
+...
+VERDICT
+  OK: pipeline drained clean.
+```
+
+What each number should look like:
+
+| Metric | Healthy | If it is wrong |
+| --- | --- | --- |
+| `published` | Tracks actionable change records | Zero means the publisher is not reading the change stream at all |
+| `filtered` | **Non-zero on a mixed run.** This is the positive evidence for STOR-628: the publisher dropped records with `payload_link` NULL on both sides | Zero on a mixed run means either the filter is passing inert records through, or every write happened to be offloaded and the path went untested |
+| `finalizes` | Tracks offloaded write volume | Zero with objects in the bucket means the change stream, publisher or Pub/Sub leg is broken |
+| `orphan_deletes` | Non-zero, tracks overwrites and deletes | Zero means the load test never deleted anything; check `DISABLE_DELETES` |
+| `batch_commit_skips` | **Zero on the local rig** -- see the emulator limitation below. Non-zero is what you require on GCP dev | Zero on *GCP dev* means the transaction tag is not reaching the change stream, which is the STOR-657/668 bug class |
+| `noop_skips` | **Zero** | Non-zero is the STOR-628 regression: the filter let through a record with `payload_link` NULL on both sides |
+| `errors kind:handler` | **Zero** | Non-zero means messages went unacked. In prod five failures on one message routes it to the DLQ |
+| `committed!=true` | Zero once drained | A small tail is normal if you cut the run off mid-flight. A large or growing count means the pipeline is not keeping up with the write rate |
+
+`committed=true` count and `customTime pinned` count must agree. Finalize sets
+both in a single `blob.patch()`, so a divergence means something other than
+the reconciler is writing object metadata.
+
+One thing that surprises people: even the "100% offloaded" STOR-629 run
+produces a non-zero `filtered` count. `OFFLOAD_COLLECTIONS` only governs the
+batch-write arm, while the load test also PUTs `meta/global` and POSTs
+`clients` on every scenario pass. Those two are never in the offload list, so
+they generate exactly the inert NULL-on-both-sides records the filter is
+there to drop. So STOR-629 covers the filter incidentally, and STOR-628 is
+still the run that covers it deliberately, at volume, alongside offloaded
+traffic in the same stream.
+
+### Reading the 404 counters, and why they are the whole signal
+
+The reconciler treats `404 NotFound` as success on both of its operations.
+From `reconcile_payload_links.py`, a finalize whose target is gone logs at
+`debug`, bumps `gcs_404{op=finalize}`, and **acks the message**. Same shape for
+delete. [Reconciliation Pipeline](payload_link_reconciler.md) states the
+rationale plainly: "Both reconciler actions are idempotent, so a redelivered
+record is harmless."
+
+That is correct and deliberate, and it has a consequence worth internalising
+before you read a load test result. Because a missing object is success, a run
+that is silently destroying data produces:
+
+- `errors` `kind:handler` at **zero**
+- nothing in the DLQ
+- no `WARN` or `ERROR` in the reconciler log, only `debug`
+- an elevated `gcs_404` counter, and nothing else
+
+So on the offload path `gcs_404{op=finalize}` is not a nice-to-have gauge. It
+is the *only* signal that separates a healthy pipeline from one that is
+deleting live payloads. Everything else looks green.
+
+That existing doc's failure-modes table gives two causes for a sustained
+`gcs_404{op=finalize}`:
+
+| Documented cause | Applies to a local run? |
+| --- | --- |
+| The lifecycle rule reclaimed the object before it was finalized | **No.** The 30 day `daysSinceCustomTime` rule is a bucket policy in `bucket.tf`. fake-gcs has no lifecycle policy at all, so nothing can reap an object locally. |
+| The same message was redelivered after a successful prior run (the at-least-once tax) | **No**, not at volume. Redelivery is a background trickle, not a rate approaching `finalizes`. |
+
+Measured on these runs, neither explains what was observed:
+
+| Run | `finalizes` | `gcs_404{op=finalize}` | Ratio |
+| --- | --- | --- | --- |
+| STOR-629 handler | 930 | 716 | 77% |
+| STOR-628 changestream | 1853 | 1589 | 86% |
+
+A ratio near 1:1 is a third cause that the table does not list: **the
+reconciler deleted the object itself**, as an orphan, and the finalize for that
+same object then 404s. Locally that is the emulator dropping the
+`batch_commit` transaction tag (see below), so every batch-commit handoff is
+misread as a genuine `batch_bsos` removal.
+
+The signature to recognise, wherever you see it:
+
+```text
+batch_commit_skips     0          <- tag never arrived
+gcs_404{op=finalize}   ~= finalizes   <- finalizing objects already deleted
+orphan_deletes         high       <- the deletes that did the damage
+errors kind:handler    0          <- and nothing reports a problem
+```
+
+`gcs_404{op=delete}` is the benign one, and the existing doc's read of it holds
+without qualification: the object was already gone, the operation is idempotent
+by design, and a redelivery or a concurrent cleanup produces it. It carries no
+data-loss implication on its own.
+
+Two things follow for the alerting the reconciler doc already recommends. Its
+suggestion to watch "`gcs_404` `op:finalize` rising as a share of `finalizes`"
+is the right alert, and this gives it a concrete threshold to reason about: a
+low single-digit share is the redelivery tax, while anything approaching
+`finalizes` means objects are being deleted out from under committed rows. And
+pairing it with `batch_commit_skips == 0` distinguishes the batch-commit cause
+from a lifecycle-window problem.
+
+### Knobs
+
+Server side, set on the `syncserver` container:
+
+| Variable | Default in the rig | Meaning |
+| --- | --- | --- |
+| `LOADTEST_OFFLOAD_COLLECTIONS` | `bookmarks,history` | Which collections syncserver offloads. **This is what decides mixed vs fully offloaded.** |
+| `LOADTEST_COLLECTION_LIMITS` | 10 MiB record / 20 MiB post / 21 MiB request, for `bookmarks` and `history` only | Per-collection raised limits, as a JSON map. Keys must be a subset of the offload list -- see below |
+| `LOADTEST_GCS_MAX_CONCURRENCY` | 4 | Concurrent GCS ops within one batch request. The main server-side throughput knob, worth sweeping |
+| `LOADTEST_DB_POOL_MAX_SIZE` | 40 | The stock 10 saturates first once workers climb |
+
+### Raise limits per collection, never globally
+
+This is the one thing that will bite you, so it is worth stating plainly.
+
+Spanner caps a single `STRING(MAX)` value at **2621440 bytes (2.5 MiB)**. That
+hard cap is the reason this whole project exists. Raising the *global*
+`max_record_payload_bytes` above it does not fail at the API, it fails in the
+database, on every collection that is not offloaded:
+
+```text
+FAILED_PRECONDITION New value exceeds the maximum size limit for
+this column: bsos.payload, size: 10485760, limit: 2621440
+```
+
+An offloaded collection is exempt, because its payload goes to GCS and the row
+stores only a `gs://` URL in `payload_link`, leaving `payload` NULL. So a limit
+above 2.5 MiB is only ever correct for a collection that is in
+`gcs_payload_offload_collections`. That is exactly what the per-collection
+override exists for, and how production raises it:
+
+```console
+SYNC_SYNCSTORAGE__LIMITS__COLLECTIONS='{"bookmarks":{"max_record_payload_bytes":10485760,"max_post_bytes":20971520,"max_request_bytes":22020096}}'
+```
+
+Leave the globals alone. Any collection not named in the map keeps stock
+2.5 MiB behaviour and writes inline safely. `max_post_bytes` and
+`max_request_bytes` are overridable per collection too; actix's payload config
+is sized from the largest `max_request_bytes` across all overrides
+(`ServerLimits::effective_max_request_bytes`), so a big body is not rejected at
+the resource level before per-collection enforcement runs.
+
+There is no per-collection `max_total_bytes`. The global default (clamped to
+`MAX_SPANNER_LOAD_SIZE`, 100 MB, by `Settings::normalize` on spanner) is
+already generous, so the rig leaves it untouched.
+
+On a mixed run this arrangement gives you exactly the right traffic for free:
+offloaded collections take expanded payloads, and inline collections get
+`LARGE_PAYLOAD_PROB` applied but capped at 2.5 MiB by
+`payload_target_length`, which is realistic "large but not offloaded" traffic.
+
+Client side, set on the `loadtest` container:
+
+| Variable | Meaning |
+| --- | --- |
+| `LARGE_PAYLOAD_PROB` | Fraction of BSOs given an expanded payload. `1.0` for STOR-629 |
+| `LARGE_PAYLOAD_SIZE` | Explicit target size in bytes. Unset means "use the server's `max_record_payload_bytes`" |
+| `OFFLOAD_COLLECTIONS` | Restricts batch writes to these collections. **Leave unset for mixed runs** |
+| `DISABLE_DELETES` | Set truthy to suppress the DELETE arm. Leave off, or the reconciler's `orphan_deletes` branch is never exercised |
+
+The two collection lists are easy to confuse:
+
+- `LOADTEST_OFFLOAD_COLLECTIONS` (server) decides which collections get
+  offloaded.
+- `OFFLOAD_COLLECTIONS` (client) decides which collections get *written to*.
+
+Setting the client one to a single collection sends every batch write there,
+which is what you want for STOR-629 and exactly what you must not do for
+STOR-628. For a mixed run, leave the client variable unset so writes spread
+across molotov's default five (`bookmarks`, `forms`, `passwords`, `history`,
+`prefs`) and set the server list to a subset of those.
+
+### Per-collection limit overrides
+
+Production raises limits for one collection rather than globally, via a JSON
+map. The load test resolves limits per target collection out of
+`/info/configuration`, preferring a collection's override, so this path is
+covered too:
+
+```console
+SYNC_SYNCSTORAGE__LIMITS__COLLECTIONS='{"bookmarks":{"max_record_payload_bytes":20971520,"max_post_bytes":26214400,"max_request_bytes":26218496}}'
+```
+
+### Known limits of the local rig
+
+- **The emulator does not carry transaction tags, so the batch-commit skip
+  cannot be validated locally.** This one is load bearing; details below.
+- **No DLQ.** `docker/reconciliation-setup.sh` creates the topic and
+  subscription but no dead-letter topic, so dead-letter routing after five
+  failed deliveries cannot be exercised locally. Verify that on GCP dev.
+- **No Dataflow.** The Python publisher replaces the Java job. Autoscaling,
+  partition-split handling under real load and the connector's Spanner
+  metadata writes are all Dataflow behaviours that only appear on GCP.
+- **Latency is not meaningful.** fake-gcs over loopback and a single-node
+  Spanner emulator. Use it for correctness and relative comparisons only.
+- **No lifecycle policy.** The 30 day `daysSinceCustomTime` rule that reaps
+  unfinalized objects is a bucket policy, so the local rig can only check
+  that `customTime` was pinned, not that the reaping behaves.
+
+### The emulator drops transaction tags
+
+The Spanner emulator emits the `transaction_tag` field on change stream
+DataChangeRecords but never populates it. Measured on emulator v1.5.52: the
+DataChangeRecord struct has arity 13, so index 11 (`transaction_tag`) exists
+and the publisher reads it correctly, but every record carries the empty
+string, including the `batch_bsos` DELETE that *is* the batch-commit handoff.
+
+That single gap has a large consequence. The reconciler decides whether to keep
+or delete a `batch_bsos` removal's object by checking
+`transactionTag == "batch_commit"` (see
+[Reconciliation Pipeline](payload_link_reconciler.md)). With the tag always
+empty, every batch-commit handoff looks like a genuine removal, so the
+reconciler deletes the GCS object that the just-committed `bsos` row now points
+at. The BSO becomes unreadable and syncserver returns a 500 backed by a GCS 404.
+
+So on the local rig, expect all of this, and do not read it as a regression:
+
+- `payload_reconciler.batch_commit_skips` flat at zero.
+- `gcs_404{op=finalize}` running close to 1:1 with `finalizes`.
+- Objects missing for BSOs written in a batch create/append request.
+- A residual molotov failure rate, because roughly 50% of its POST scenarios
+  are transactional batches. Reads of those BSOs 500.
+
+`docker/batch-commit-probe.py` reproduces it in isolation: one two-request
+transactional batch, then a read of both BSOs, printing the bucket contents at
+each stage.
+
+```console
+make loadtest-offload-up
+SYNCSTORAGE_RS_IMAGE=app:build docker compose \
+  -f docker/docker-compose.spanner.yaml \
+  -f docker/docker-compose.e2e.spanner.yaml \
+  -f docker/docker-compose.e2e.reconciliation.yaml \
+  -f docker/docker-compose.e2e.jwk-cache.yaml \
+  -f docker/docker-compose.loadtest.yaml \
+  run --rm --entrypoint python3 \
+  -v "$PWD/docker/batch-commit-probe.py:/probe.py:ro" loadtest /probe.py
+```
+
+Adding `--no-deps` to that command keeps the reconciler stopped, and the probe
+then passes with both payloads intact. That is the control which proves the
+reconciler is the thing deleting the object, rather than the batch commit
+losing the `payload_link`.
+
+What this does **not** tell you is whether production is affected. The app side
+is correct: `handlers.rs` calls
+`with_transaction_tag(BATCH_COMMIT_TRANSACTION_TAG)` on the commit path, and
+real Spanner does record transaction tags on change streams. The evidence
+points at an emulator gap rather than a code defect, but the local rig cannot
+close that question. **Confirm the batch-commit skip on GCP dev**, where the
+Dataflow job reads a real change stream: run the probe there and require
+`payload_reconciler.batch_commit_skips` to be non-zero.
+
+Two follow-ups worth filing rather than leaving implicit:
+
+1. There is no e2e test for the batch-commit handoff.
+   `tools/integration_tests/test_payload_link_reconciliation.py` covers upload,
+   update and delete, but not a transactional batch. That is presumably because
+   it cannot pass against the emulator, which is exactly the point: the gap is
+   invisible in CI.
+2. If the Java overlay behaves the same way, the emulator is confirmed as the
+   cause. That is a cheap check and worth doing before spending GCP time.
+
+---
+
+## GCP dev environment
+
+Use this for real numbers. The dev pipeline is fully provisioned; see
+[GCP Infrastructure](payload-offload-infrastructure.md) for what lives where
+and which repo owns it. That page is the authority on the resources
+themselves. The diagram below is only the load-testing view: where the
+generator sits, what it traverses, and where you go to observe each leg.
+
+```mermaid
+flowchart TB
+    subgraph gen["Load generator (you create this)"]
+        vm["C4D VM, Ubuntu<br/>molotov + load_test.pem<br/>in moz-fx-sync-nonprod"]
+    end
+
+    subgraph high["moz-fx-webservices-high-nonpro (shared GKE)"]
+        ts["tokenserver<br/>trusts your public JWK"]
+        ss["syncserver<br/>needs GCS_PAYLOAD_BUCKET +<br/>OFFLOAD_COLLECTIONS + raised limits"]
+        rec["payload-reconciler<br/>cronjob, ~5 min cadence"]
+    end
+
+    subgraph v1["moz-fx-sync-nonprod-904c (GCPv1, cloudops-infra)"]
+        sp[("Spanner syncdb-dev<br/>change stream:<br/>payload_link_changes")]
+    end
+
+    subgraph tenant["moz-fx-sync-nonprod (tenant, webservices-infra)"]
+        df["Dataflow flex template<br/>the REAL Java filter"]
+        ps["Pub/Sub<br/>payload-link-changes"]
+        dlq["Pub/Sub DLQ<br/>after 5 failed deliveries"]
+        b[("GCS<br/>sync-nonprod-dev-<br/>syncstorage-payloads<br/>30d lifecycle rule")]
+    end
+
+    vm -->|"1. self-signed JWT"| ts
+    ts -->|"2. Hawk token"| vm
+    vm -->|"3. storage reads + writes"| ss
+    ss -->|"upload / download"| b
+    ss -->|"payload_link"| sp
+    sp -->|"change stream read"| df
+    df -->|publish| ps
+    ps -->|"pull subscription"| rec
+    ps -.-> dlq
+    rec -->|"finalize / delete"| b
+```
+
+Three things this buys you that the local rig cannot:
+
+| Leg | Why it only exists here |
+| --- | --- |
+| Dataflow | The local rig substitutes a Python publisher. This is the actual Java `isPayloadLinkActionable` filter that ships, plus autoscaling and partition-split behaviour under real load. |
+| Real Spanner | Populates `transaction_tag`, so the batch-commit skip can finally be verified. Also the only place to measure what the change stream costs in Spanner storage, which has never been quantified. |
+| DLQ and lifecycle rule | Neither exists locally. `reconciliation-setup.sh` creates no dead-letter topic, and fake-gcs has no lifecycle policy. |
+
+### Load generator VM
+
+Generate load from inside GCP, not from a laptop. A laptop's uplink is the
+bottleneck long before the server is, and multi-MiB payloads make that worse.
+
+1. Console -> project `moz-fx-sync-nonprod` -> Compute Engine -> VM instances
+   -> Create instance.
+2. Machine type: `C4D` series. OS: Ubuntu, not the Debian default.
+3. The project already has IAP TCP forwarding and the firewall rules. If SSH
+   is refused, check the project inherited them; see the SRE space's IAP page.
+
+Set the VM up:
+
+```console
+sudo apt update && sudo apt install -y git python3 python3-venv
+git clone https://github.com/mozilla-services/syncstorage-rs.git
+cd syncstorage-rs/tools/syncstorage-loadtest
+curl -sSL https://install.python-poetry.org | python3 -
+poetry install
+```
+
+Docker is an alternative to poetry on the VM, and avoids the Python version
+dance:
+
+```console
+docker build . --tag syncstorage-loadtest:local
+docker run --rm -e SERVER_URL -e OAUTH_PRIVATE_KEY_FILE \
+  -e LARGE_PAYLOAD_PROB -e OFFLOAD_COLLECTIONS \
+  -v /path/to/load_test.pem:/keys/load_test.pem:ro \
+  syncstorage-loadtest:local \
+  -c "molotov --processes 4 --workers 100 --duration 3600 -v loadtest.py"
+```
+
+### Authentication
+
+Three modes, in `storage/auth.py`. For a dev run use self-signed JWTs: no FxA
+accounts to create or clean up, and the token lifetime is yours to set.
+
+```console
+poetry run ./generate-keys.sh
+```
+
+That writes `load_test.pem` (private, stays on the VM) and `jwk.json`
+(public). The dev tokenserver has to trust that public key, which means
+landing the JWK in the tokenserver FxA JWK configuration in
+`webservices-infra` under `sync/k8s/`. That is a PR plus an ArgoCD sync, so do
+it before you book time for the run.
+
+Then:
+
+```console
+SERVER_URL="https://<dev tokenserver host>" \
+  OAUTH_PRIVATE_KEY_FILE=./load_test.pem \
+  LARGE_PAYLOAD_PROB=1.0 \
+  OFFLOAD_COLLECTIONS=bookmarks \
+  poetry run molotov --processes 4 --workers 100 --duration 3600 -v loadtest.py
+```
+
+Direct-access mode (`SERVER_URL` with a `#secret` fragment) bypasses
+tokenserver entirely and is what the local rig uses. It needs the deployed
+master secret, so do not use it against a shared environment.
+
+### Server side prerequisites on dev
+
+The pipeline being provisioned is not the same as offload being on. Offload
+does nothing until both of these are set on syncserver, and expanded payloads
+do nothing until the limits are raised:
+
+- `SYNC_SYNCSTORAGE__GCS_PAYLOAD_BUCKET`
+- `SYNC_SYNCSTORAGE__GCS_PAYLOAD_OFFLOAD_COLLECTIONS`
+- `SYNC_SYNCSTORAGE__LIMITS__MAX_RECORD_PAYLOAD_BYTES` and the
+  `MAX_POST_BYTES` / `MAX_REQUEST_BYTES` / `MAX_TOTAL_BYTES` that go with it
+
+All four are Helm values in `webservices-infra` under `sync/k8s/sync/`. Raise
+any front-end proxy body-size limit to match, or requests get a 413 before
+they reach the server.
+
+Confirm what actually took effect by reading it back from the server rather
+than from the values file:
+
+```console
+curl -s https://<host>/1.5/<uid>/info/configuration | jq .
+```
+
+The load test sizes its batches from exactly this response, so if the limits
+are not in there, the run is not testing expanded payloads no matter what the
+environment variables say.
+
+### Verifying a dev run
+
+Everything the local report script checks, plus the parts that only exist on
+GCP:
+
+| What | Where |
+| --- | --- |
+| Reconciler counters (`payload_reconciler.*`) | The metrics pipeline, same as any other service metric |
+| Oldest unacked message age on `payload-link-reconciler-sub` | Pub/Sub console. The most direct measure of finalize latency; should sit in minutes |
+| Anything at all in `payload-link-changes-dlq` | Pub/Sub console. A message only lands there after five failed deliveries, so it always needs a human |
+| Dataflow job lag, autoscaling, worker errors | Dataflow console |
+| Spanner CPU and change-stream storage cost | Spanner console on `moz-fx-sync-nonprod-904c` |
+| Object count and finalize state in the bucket | GCS console, or `gcloud storage ls -L` |
+
+Change-stream storage cost is worth capturing deliberately. It has not been
+quantified, and the plan for prod is to measure it before enabling offload
+traffic, so a dev run is the cheapest place to get a number.
+
+---
+
+## What to record
+
+Standard long run is 60 to 65 minutes. Log results to the shared documents
+rather than only in a ticket:
+
+- Syncstorage molotov runs: "Sync Load Test Run Document"
+- Tokenserver locust runs: the tokenserver load test results document
+
+Capture at minimum: the git SHA under test, molotov arguments, the effective
+`/info/configuration`, the server-side offload collection list, molotov's
+own summary (request counts, failures, RPS), and the reconciler counters plus
+GCS finalize state from the report.
+
+---
+
+## Tokenserver load tests (locust)
+
+Separate tool, separate target, unrelated to payload offload. Locust rather
+than molotov, and it has a web UI.
+
+```console
+cd tools/tokenserver/loadtests
+poetry install
+poetry run ./generate-keys.sh
+OAUTH_PRIVATE_KEY_FILE=./load_test.pem poetry run locust   # UI on :8089
+```
+
+Running on a VM, tunnel the UI out over IAP:
+
+```console
+gcloud compute ssh --zone "<zone>" "<instance>" --project "<project>" \
+  --tunnel-through-iap -- -L 8090:localhost:8089
+```
+
+Then open `localhost:8090`. See `tools/tokenserver/loadtests/README.md` for
+the rest.
+
+---
+
+## Gaps worth knowing about
+
+- **The offload read/write path is not timed.** `payload_offload.rs` emits
+  `storage.gcs.payload.cleanup`, tagged by handler and result, but that covers
+  only the cleanup/delete path. `upload_payload` and `download_payload` emit
+  nothing, so GCS transfer cost is folded into the enclosing
+  `request.post_collection` / `request.get_collection` timings and cannot be
+  separated from Spanner time. A STOR-629 run can say "the handler got
+  slower", but not "GCS accounted for N ms of it". If attributing that split
+  matters for a capacity decision, the upload and download paths need timers
+  before the run, not after.
+- **No per-collection metric dimension**, so a mixed run cannot separate
+  offloaded from inline request latency from the server side either. Working
+  around it means either running the two shapes separately and comparing, or
+  adding a collection tag.

--- a/tools/syncstorage-loadtest/Dockerfile
+++ b/tools/syncstorage-loadtest/Dockerfile
@@ -23,8 +23,11 @@ RUN \
     apt-get clean -y
 
 # app install
+# No --no-dev: it was removed in Poetry 2.x. The dev tools live in
+# [project.optional-dependencies], which Poetry treats as extras and so
+# leaves out unless asked for -- a plain install is already runtime-only.
 RUN poetry config virtualenvs.create false && \
-    poetry install --no-dev --no-interaction --no-ansi
+    poetry install --no-interaction --no-ansi --no-root
 
 # Using:
 # Start an interactive terminal using

--- a/tools/syncstorage-loadtest/README.md
+++ b/tools/syncstorage-loadtest/README.md
@@ -172,10 +172,32 @@ on the load-generating host — size the harness accordingly.
 
 ## Docker
 
-To run it inside docker:
+Build and run this directory's image:
 
 ```bash
-docker run -e TEST_REPO=https://github.com/mozilla-services/syncstorage-loadtest -e TEST_NAME=test tarekziade/molotov:latest
+docker build . --tag syncstorage-loadtest:local
+
+docker run --rm --net=host \
+  -e SERVER_URL="http://localhost:8000#secretValue" \
+  syncstorage-loadtest:local \
+  -c "molotov --processes 1 --workers 5 --duration 60 -v loadtest.py"
 ```
+
+## Full offload pipeline on docker
+
+For the offload and change-stream load tests (STOR-628, STOR-629) there is a
+compose rig that stands up syncserver with offload enabled, a Spanner emulator
+carrying the change stream, Pub/Sub, GCS, the publisher, the reconciler and
+this load test, then reports whether the pipeline drained clean:
+
+```bash
+make loadtest-offload-image
+make loadtest-offload-handler        # 100% offloaded
+make loadtest-offload-report
+make loadtest-offload-down
+```
+
+See `docs/src/tools/load-testing.md` for the runbook, the knobs, and the GCP
+dev path.
 
 Happy Breaking!


### PR DESCRIPTION
Docker rig for running the molotov load tests against the whole offload pipeline on emulators, plus a runbook to replace the Confluence page (its molotov and locust steps had gotten interleaved and unreadable).

```
make loadtest-offload-image
make loadtest-offload-handler       # STOR-629, 100% offloaded
make loadtest-offload-report
make loadtest-offload-changestream  # STOR-628, mixed
make loadtest-offload-report
```

No GCP project or credentials needed. Also fixes the loadtest Dockerfile, which hasn't built since poetry 2 dropped `--no-dev`, and drops the `loadtest-docker` target that pointed at a repo folded into this one years ago.

Three things turned up from actually running it:

- `max_record_payload_bytes` can only be raised per collection, for collections  in the offload list. Spanner caps a `STRING(MAX)` value at 2.5 MiB, so raising  it globally fails in the database on every non-offloaded collection.
- The Spanner emulator emits `transaction_tag` on change records but never fills it in, so the reconciler can't tell a batch-commit handoff from a real removal  and deletes the object the committed `bsos` row points at. Repro in `docker/batch-commit-probe.py`. Reads like an emulator gap rather than a code bug, but it means the STOR-668 skip can't be verified locally.
- compose never rebuilds `payload-link-publisher` when its source changes, so a stale image quietly runs against new server code. These targets pass
  `--build`; `docker_run_reconciliation_e2e_tests` doesn't.

STOR-629 is covered. STOR-628 is half covered: the NULL-filtering half checks
out (1340 published vs 1311 filtered on a mixed run), the batch-commit skip
needs a dev run with `STRICT_BATCH_COMMIT=1`.

Closes STOR-629
Refs STOR-628
