### PR TITLE
docs: refresh the payload offload docs

### DIFF
--- a/docs/src/payload-offload/overview.md
+++ b/docs/src/payload-offload/overview.md
@@ -207,17 +207,27 @@ is in preserving one of them.
    it. There is no scanner, no sweeper, and no age-based deletion of
    finalized objects.
 
-5. **Every reconciler operation is idempotent, and 404 counts as success.**
+5. **A batch commit is a handoff, not a delete.** Batched writes land in
+   `batch_bsos` first, and committing the batch moves the link into the
+   permanent `bsos` row and drops the staging row in one transaction. The
+   change stream reports that as a row that stopped pointing at the object,
+   which under invariant 4 alone would delete a live payload. Syncstorage
+   tags that transaction `batch_commit` and the reconciler skips the delete
+   when it sees the tag. Every other `batch_bsos` removal, TTL expiry and
+   `user_collections` cascade deletes among them, carries no tag and is
+   treated as a real delete.
+
+6. **Every reconciler operation is idempotent, and 404 counts as success.**
    Pub/Sub is at-least-once, so the same record is sometimes handled twice.
    Finalizing an already finalized object and deleting an already deleted one
    are both no-ops.
 
-6. **The subscription is the retry queue.** The reconciler acks only what it
+7. **The subscription is the retry queue.** The reconciler acks only what it
    handled. An unacked message comes back, and after five failed attempts it
    lands in a dead-letter topic rather than blocking the queue. There is no
    in-process retry loop and no in-window Kubernetes retry.
 
-7. **The bucket lifecycle policy is the backstop.** Anything uploaded and
+8. **The bucket lifecycle policy is the backstop.** Anything uploaded and
    never finalized, because the request died, the transaction rolled back, or
    the inline cleanup failed, is deleted 30 days after upload. That is the
    only thing standing between a crashed write and an object that leaks

--- a/docs/src/payload-offload/overview.md
+++ b/docs/src/payload-offload/overview.md
@@ -113,6 +113,9 @@ fail fast: the first upload error abandons the request, and any object already
 uploaded is left for the lifecycle policy rather than deleted inline. The
 compensating delete only runs when the database transaction fails, and its
 result is ignored, because the lifecycle policy is a sufficient second line.
+Ignored is not unobserved: the attempt is counted as
+`storage.gcs.payload.cleanup`, tagged with the handler and whether the delete
+landed, which is how you find out an object leaked.
 
 Between the upload and the finalize the object exists but is not protected.
 That window is normally seconds to a few minutes, set by the reconciler's

--- a/docs/src/payload-offload/overview.md
+++ b/docs/src/payload-offload/overview.md
@@ -265,3 +265,10 @@ This is a work in progress. As of this writing:
 - Only the dev environment is built out. Stage and prod need the same set of
   resources plus a dedicated Spanner metadata database.
 - Change stream storage cost in prod has not been measured.
+- The synchronous half is barely instrumented. The rollback cleanup emits
+  `storage.gcs.payload.cleanup`, but there are no counters or timers on
+  upload or download, so how much latency offload adds to a request is not
+  something metrics can currently answer.
+- Load testing of both halves is still in flight, so the numbers above for
+  the upload-to-finalize window are reasoned from the cronjob cadence
+  rather than observed under load.

--- a/docs/src/tools/payload-offload-infrastructure.md
+++ b/docs/src/tools/payload-offload-infrastructure.md
@@ -145,6 +145,7 @@ Names are derived from `${application}-${realm}-${environment}` in
 | Spanner project | `moz-fx-sync-nonprod-904c` |
 | Spanner instance and database | `sync` / `syncdb-dev` |
 | Dataflow metadata database | `sync` / `syncdb-pldf-meta-dev` |
+| Dataflow metadata table | `Metadata_payload_link`, pinned via `spannerMetadataTableName` |
 | Change stream | `payload_link_changes` |
 | Spanner database role | `payload_link_reader` |
 | Payload bucket | `sync-nonprod-dev-syncstorage-payloads`, us-west1 |
@@ -179,6 +180,13 @@ editing them.
    `syncdb-pldf-meta-stage`, so the connector holds no write access
    to the syncstorage database. This is a cloudops-infra change.
 
+   Pin the table inside it as well, with
+   `spannerMetadataTableName = "Metadata_payload_link"` on the job.
+   Dev uses that name; reusing it per environment is fine, since the
+   databases are already separate. The parameter is optional and the
+   consequence of skipping it is silent, so it is easy to miss: see
+   step 6.
+
 3. **DDL.** Apply the change stream and the `payload_link_reader` role to
    the target database. See [Out-of-band steps](#out-of-band-steps).
 
@@ -191,13 +199,22 @@ editing them.
    environment's `-tmpl-pub` service account exists first. The spec has
    to be in the bucket before the Terraform job resource is applied.
 
-6. **Job deletion behaviour.** Keep `on_delete = "cancel"`. This is not a
+6. **Job lifecycle.** Keep `on_delete = "cancel"`. This is not a
    dev-only shortcut: the SpannerIO change stream connector does not
    support draining at all, so `"drain"` is never the right setting for
    this pipeline. See
    [Draining a change streams pipeline](https://docs.cloud.google.com/spanner/docs/change-streams/use-dataflow#draining).
    The change stream's 7 day retention is what covers the gap while a
    replacement job comes up.
+
+   Cancel is only safe to rely on because the metadata table name is
+   pinned. The connector generates that name from a random UUID at
+   graph-construction time, so an unpinned job that is cancelled and
+   relaunched, or updated in place, comes up against an empty table and
+   resumes from `Timestamp.now()` instead of the previous watermarks.
+   Nothing errors; the records committed in between are simply never
+   published, and the reconciler never learns those objects need
+   finalizing or deleting. Set the name once and do not change it.
 
 7. **Reconciler cronjob.** Enable `payloadReconciler` in the
    environment's values file in `sync/k8s/sync/`. The chart requires

--- a/docs/src/tools/payload-offload-infrastructure.md
+++ b/docs/src/tools/payload-offload-infrastructure.md
@@ -144,6 +144,7 @@ Names are derived from `${application}-${realm}-${environment}` in
 | Tenant project | `moz-fx-sync-nonprod`, number `960020799362` |
 | Spanner project | `moz-fx-sync-nonprod-904c` |
 | Spanner instance and database | `sync` / `syncdb-dev` |
+| Dataflow metadata database | `sync` / `syncdb-pldf-meta-dev` |
 | Change stream | `payload_link_changes` |
 | Spanner database role | `payload_link_reader` |
 | Payload bucket | `sync-nonprod-dev-syncstorage-payloads`, us-west1 |

--- a/docs/src/tools/payload_link_reconciler.md
+++ b/docs/src/tools/payload_link_reconciler.md
@@ -374,10 +374,16 @@ real dev Spanner instance).
 
 ## Metrics
 
-The reconciler emits statsd counters under the `payload_reconciler`
-namespace. Everything the pipeline can tell you about itself is in this
-list, so it is worth knowing what each one looks like when things are
-working.
+Two processes report on this system, and they are instrumented to
+different depths. The reconciler covers the asynchronous arm end to end.
+The syncserver side has one counter, on the rollback cleanup, and
+nothing on upload or download.
+
+### Reconciler
+
+Statsd counters under the `payload_reconciler` namespace. Everything the
+asynchronous arm can tell you about itself is in this list, so it is
+worth knowing what each one looks like when things are working.
 
 | Metric | Meaning | Healthy shape |
 |---|---|---|
@@ -388,6 +394,30 @@ working.
 | `batch_commit_skips` | A `batch_bsos` removal carrying the `batch_commit` transaction tag was kept rather than deleted | Tracks batch commit volume on offloaded collections |
 | `noop_skips` | A record arrived with nothing to do | Near zero; the Dataflow filter should have dropped it |
 | `errors` `kind:handler` | Handler raised, message left unacked | Zero |
+
+### Syncserver offload path
+
+One counter, `storage.gcs.payload.cleanup`, emitted from
+`syncserver/src/web/payload_offload.rs` when the best-effort delete runs
+after an offloading write's database transaction fails. It is the only
+instrumentation on the synchronous half.
+
+| Tag | Values | Meaning |
+|---|---|---|
+| `handler` | `put_bso`, `post_collection` | Which write handler issued the cleanup |
+| `result` | `success`, `failure` | Whether the object was deleted |
+| `reason` | `invalid_url`, `gcs_error` | Failure only. `invalid_url` means the `gs://` URL did not parse and no delete was attempted; `gcs_error` means GCS rejected it |
+
+The counter firing at all means writes are failing after their payload
+reached GCS, so read it against the write error rate rather than on its
+own. `result:failure` is the more interesting cut: those objects are now
+leaked until the 30 day lifecycle policy reaps them. A steady
+`reason:invalid_url` is a code bug rather than an operational problem,
+since the URL is one syncserver just generated.
+
+Note the gap: there are no counters or timers on the upload and download
+paths, so offload's contribution to request latency is not visible in
+metrics today.
 
 Worth alerting on:
 
@@ -404,6 +434,8 @@ Worth alerting on:
   Pub/Sub metric rather than one of ours, and it is the most direct
   measure of finalize latency. It should sit in minutes. The 30 day
   lifecycle window is the deadline it must never approach.
+- `storage.gcs.payload.cleanup` with `result:failure`, which counts
+  objects that leaked because the compensating delete did not land.
 
 ---
 
@@ -416,6 +448,7 @@ Worth alerting on:
 | Sustained `payload_reconciler.gcs_404` with `op:delete` | Object was already deleted (redelivery or concurrent cleanup) | Acceptable; idempotent by design. |
 | Messages in `payload-link-changes-dlq` | Repeated handler exceptions on the same message after 5 retries (malformed JSON, cross-bucket link, GCS auth failure) | Inspect the DLQ payload; fix and re-publish or discard. The main subscription continues to drain. |
 | `payload_reconciler.errors` with `kind:handler` non-zero | Same as above before reaching DLQ. | Same. |
+| `storage.gcs.payload.cleanup` with `result:failure` | The compensating delete after a failed write transaction did not land | The object is stranded at `committed=false` and the 30 day lifecycle policy is the only thing left to reap it. Tolerable in ones; sustained means the write path is failing and cleanup is failing with it. |
 | Finalize latency jumps after a Dataflow deploy, with a gap in `finalizes` | The job relaunched against a fresh partition-metadata table and resumed from `Timestamp.now()` | Records committed during the gap are lost for good; the change stream's 7 day retention only helps if you notice in time. Check that `spannerMetadataTableName` is pinned and unchanged. |
 
 A `payload_link` pointing at a bucket other than `GCS_PAYLOAD_BUCKET`

--- a/docs/src/tools/payload_link_reconciler.md
+++ b/docs/src/tools/payload_link_reconciler.md
@@ -148,6 +148,17 @@ gcloud dataflow flex-template build \
   dedicated database, `syncdb-pldf-meta-dev`, so the connector holds no
   write access to the syncstorage database. Every environment should do
   the same.
+- `spannerMetadataTableName=Metadata_payload_link` names the
+  partition-state table itself. Optional in the template, but pin it on
+  any streaming launch. Left unset, the connector generates a random
+  table name inside `expand()` and bakes it into the pipeline graph, so a
+  `--update` or a cancel-then-relaunch comes up against a fresh empty
+  table, reads from `Timestamp.now()`, and silently drops every record
+  committed between the two jobs. The name only has to be a legal Spanner
+  identifier and stable for the life of the environment; the connector
+  creates the table on first use.
+  See "Job update and restart continuity" in
+  `tools/payload-link-dataflow/README.md`.
 - `changeStreamName=payload_link_changes`.
 - `spannerDatabaseRole=payload_link_reader` — the fine-grained access
   role the job reads the stream through, created by the DDL in
@@ -405,6 +416,7 @@ Worth alerting on:
 | Sustained `payload_reconciler.gcs_404` with `op:delete` | Object was already deleted (redelivery or concurrent cleanup) | Acceptable; idempotent by design. |
 | Messages in `payload-link-changes-dlq` | Repeated handler exceptions on the same message after 5 retries (malformed JSON, cross-bucket link, GCS auth failure) | Inspect the DLQ payload; fix and re-publish or discard. The main subscription continues to drain. |
 | `payload_reconciler.errors` with `kind:handler` non-zero | Same as above before reaching DLQ. | Same. |
+| Finalize latency jumps after a Dataflow deploy, with a gap in `finalizes` | The job relaunched against a fresh partition-metadata table and resumed from `Timestamp.now()` | Records committed during the gap are lost for good; the change stream's 7 day retention only helps if you notice in time. Check that `spannerMetadataTableName` is pinned and unchanged. |
 
 A `payload_link` pointing at a bucket other than `GCS_PAYLOAD_BUCKET`
 raises `ValueError` and the message is left unacked — it retries up to

--- a/docs/src/tools/payload_link_reconciler.md
+++ b/docs/src/tools/payload_link_reconciler.md
@@ -454,7 +454,7 @@ Worth alerting on:
 | Sustained `payload_reconciler.gcs_404` with `op:delete` | Object was already deleted (redelivery or concurrent cleanup) | Acceptable; idempotent by design. |
 | Messages in `payload-link-changes-dlq` | Repeated handler exceptions on the same message after 5 retries (malformed JSON, cross-bucket link, GCS auth failure) | Inspect the DLQ payload; fix and re-publish or discard. The main subscription continues to drain. |
 | `payload_reconciler.errors` with `kind:handler` non-zero | Same as above before reaching DLQ. | Same. |
-| `storage.gcs.payload.cleanup` with `result:failure` | The compensating delete after a failed write transaction did not land | The object is stranded at `committed=false` and the 30 day lifecycle policy is the only thing left to reap it. Tolerable in ones; sustained means the write path is failing and cleanup is failing with it. |
+| `storage.gcs.payload.cleanup` with `result:failure` | The compensating delete after a failed write transaction did not land | The object is stranded at `committed=false` and the 30 day lifecycle policy is the only thing left to reap it. Occasional failures are tolerable; sustained means the write path is failing and cleanup is failing with it. |
 | Finalize latency jumps after a Dataflow deploy, with a gap in `finalizes` | The job relaunched against a fresh partition-metadata table and resumed from `Timestamp.now()` | Records committed during the gap are lost for good; the change stream's 7 day retention only helps if you notice in time. Check that `spannerMetadataTableName` is pinned and unchanged. |
 
 A `payload_link` pointing at a bucket other than `GCS_PAYLOAD_BUCKET`

--- a/docs/src/tools/payload_link_reconciler.md
+++ b/docs/src/tools/payload_link_reconciler.md
@@ -385,7 +385,7 @@ working.
 | `orphan_deletes` | Objects deleted because a row stopped pointing at them | Tracks overwrite and delete volume |
 | `gcs_404` `op:finalize` | Finalize target was gone | Low and flat |
 | `gcs_404` `op:delete` | Delete target was already gone | Low and flat, redeliveries are normal |
-| `batch_bsos_skips` | A `batch_bsos` removal was skipped | Non-zero and expected while the blanket skip is in place |
+| `batch_commit_skips` | A `batch_bsos` removal carrying the `batch_commit` transaction tag was kept rather than deleted | Tracks batch commit volume on offloaded collections |
 | `noop_skips` | A record arrived with nothing to do | Near zero; the Dataflow filter should have dropped it |
 | `errors` `kind:handler` | Handler raised, message left unacked | Zero |
 

--- a/docs/src/tools/payload_link_reconciler.md
+++ b/docs/src/tools/payload_link_reconciler.md
@@ -424,7 +424,13 @@ Worth alerting on:
 - Anything at all in `payload-link-changes-dlq`. A message only lands
   there after five failed deliveries, so it means a record cannot be
   handled and needs a human. Inspect it through
-  `payload-link-changes-dlq-sub`.
+  `payload-link-changes-dlq-sub`. Note the DLQ is terminal: its
+  subscription carries no dead-letter policy of its own, so a message
+  sits there until the 7 day retention drops it and no further queue
+  catches it. That is the same 7 days as the change stream retention,
+  so once a dead-lettered record ages out the underlying change is
+  unrecoverable from both. Seven days is a response deadline, not a
+  margin.
 - `errors` `kind:handler` sustained above zero.
 - `noop_skips` climbing, which means the Dataflow filter regressed and
   the pipeline is paying Pub/Sub for records it discards.

--- a/docs/src/tools/payload_link_reconciler.md
+++ b/docs/src/tools/payload_link_reconciler.md
@@ -144,8 +144,10 @@ gcloud dataflow flex-template build \
 - `spannerProjectId`, `spannerInstanceId`, `spannerDatabase` — the
   syncstorage Spanner database.
 - `spannerMetadataInstanceId`, `spannerMetadataDatabase` — where the
-  change-stream connector keeps its partition-state table. Recommend
-  a dedicated database in prod for isolation.
+  change-stream connector keeps its partition-state table. Dev uses a
+  dedicated database, `syncdb-pldf-meta-dev`, so the connector holds no
+  write access to the syncstorage database. Every environment should do
+  the same.
 - `changeStreamName=payload_link_changes`.
 - `spannerDatabaseRole=payload_link_reader` — the fine-grained access
   role the job reads the stream through, created by the DDL in
@@ -155,12 +157,11 @@ gcloud dataflow flex-template build \
 
 **Service account requires:**
 
-- `roles/spanner.databaseUser` on the syncstorage database. This one
-  grant covers both reading the change stream and maintaining the
-  connector's partition metadata, and in dev the metadata table shares
-  `syncdb-dev`. Where the metadata database is separate, the grant is
-  needed on both. Note the IAM grant targets the `-904c` project, so it
-  is applied out of band; see
+- `roles/spanner.databaseUser` on the syncstorage database and on the
+  metadata database. The one role covers both reading the change stream
+  and maintaining the connector's partition metadata, but since the two
+  live in separate databases the grant is needed on each. Note the IAM
+  grant targets the `-904c` project, so it is applied out of band; see
   [GCP Infrastructure](payload-offload-infrastructure.md#out-of-band-steps).
 - Membership of the `payload_link_reader` database role, which is what
   actually narrows the job to the change stream. The IAM grant alone


### PR DESCRIPTION
## Description

Refreshes the three payload offload docs.

Two are done, but one will need a touch up later:

- STOR-668 (tag-based batch commit detection) landed in #2518 , the metrics table listing `batch_bsos_skips` was missed. The code emits `batch_commit_skips`, and the "while the blanket skip is in place" note was stale.
- Syncserver offload metrics had no ticket when STOR-681 was filed. They became STOR-653 and landed in #2528  That added one counter, we needed to consider`storage.gcs.payload.cleanup`, on the rollback cleanup. Upload and download are still uninstrumented (tbd), so the docs now say that plainly rather than implying (and so we don't forget).
- STOR-639 (change stream storage sizing) is still in progress, so I've made note on that ticket to update docs when we make the final choice.

Two things added (since more stuff has been merged since tkt was filed_:

- `spannerMetadataTableName` (STOR-683, #2543) was missing from the launch-parameter list. Worth reading if nothing else: unpinned, a `--update` or cancel-then-relaunch resumes from `Timestamp.now()` against a fresh metadata table and silently drops every record committed in between. 
- The doc claimed the dev metadata table shares `syncdb-dev`, but not so... It uses the dedicated `syncdb-pldf-meta-dev`, which also makes the service account grant wrong.

Added  "batch commit is a handoff, not a delete" invariant to the overview. 

## Testing

`mdbook test docs/` passes clean.

Values document were checked against the live dev resources rather than inferred (or left up to my memory or glancing around). The running Dataflow job pins `spannerMetadataTableName: Metadata_payload_link`, and the rest of the infra doc's dev-resources table matches the job's pipeline options. Both Pub/Sub subscriptions match the documented ack deadline, retention, and delivery attempts:

To check:
```
gcloud dataflow jobs describe <JOB_ID> --project=moz-fx-sync-nonprod --region=us-west1 --full --format=json
```

I had an initial hiccup... the `--full` flag matters here, since the default view omits pipeline options. 😕 

## Issue(s)

Closes [STOR-681](https://mozilla-hub.atlassian.net/browse/STOR-681).


[STOR-681]: https://mozilla-hub.atlassian.net/browse/STOR-681?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ