### PR TITLE
feat: update off-loaded gcs object name format

### DIFF
--- a/docs/src/config.md
+++ b/docs/src/config.md
@@ -91,14 +91,19 @@ The following configuration options are available.
 
 Off-loads large BSO payloads to a Google Cloud Storage bucket, storing the
 object URL in the `payload_link` column instead of the inline `payload`
-column. Supported on the Spanner backend only: setting either variable on a
-mysql or postgres backend fails startup, since those backends have no
-`payload_link` column and would silently drop the payload.
+column. Supported on the Spanner backend only: setting
+`SYNC_SYNCSTORAGE__GCS_PAYLOAD_BUCKET` or
+`SYNC_SYNCSTORAGE__GCS_PAYLOAD_OFFLOAD_COLLECTIONS` on a mysql or postgres
+backend fails startup, since those backends have no `payload_link` column and
+would silently drop the payload.
 
 | Env Var | Default Value | Description |
 | --- | --- | --- |
 | <span id="SYNC_SYNCSTORAGE__GCS_PAYLOAD_BUCKET"></span>SYNC_SYNCSTORAGE__GCS_PAYLOAD_BUCKET | unset | GCS bucket for off-loaded payloads. Unset disables off-load. |
 | <span id="SYNC_SYNCSTORAGE__GCS_PAYLOAD_OFFLOAD_COLLECTIONS"></span>SYNC_SYNCSTORAGE__GCS_PAYLOAD_OFFLOAD_COLLECTIONS | unset | Comma-separated collection names whose payloads are off-loaded. Empty disables off-load for all collections. |
+| <span id="SYNC_SYNCSTORAGE__GCS_PAYLOAD_PREFIX"></span>SYNC_SYNCSTORAGE__GCS_PAYLOAD_PREFIX | v1 | The prefix for off-loaded GCS object names. The server formats each object name as `{prefix}/{fxa_uid}/{uuid}`. |
+| <span id="SYNC_SYNCSTORAGE__GCS_PAYLOAD_MAX_CONCURRENCY"></span>SYNC_SYNCSTORAGE__GCS_PAYLOAD_MAX_CONCURRENCY | 4 | The maximum number of concurrent GCS payload uploads and downloads within one batch request. This value must be greater than zero. |
+| <span id="SYNC_SYNCSTORAGE__GCS_ENDPOINT"></span>SYNC_SYNCSTORAGE__GCS_ENDPOINT | unset | A test-only override for the GCS endpoint URL, for example a mock server or a fake-gcs-server instance. If set, the server uses anonymous credentials. Do not set this variable in production. |
 
 ### Tokenserver Database
 

--- a/syncserver-settings/src/lib.rs
+++ b/syncserver-settings/src/lib.rs
@@ -222,6 +222,13 @@ impl Settings {
             ));
         }
 
+        // The prefix for the offload gcs object name cannot be empty.
+        if self.syncstorage.enabled && self.syncstorage.gcs_payload_prefix.is_empty() {
+            return Err(ConfigError::Message(
+                "SYNC_SYNCSTORAGE__GCS_PAYLOAD_PREFIX must not be empty".to_owned(),
+            ));
+        }
+
         if let Some(init_node_url) = &self.tokenserver.init_node_url {
             let url = Url::parse(init_node_url).map_err(|e| {
                 ConfigError::Message(format!("Invalid SYNC_TOKENSERVER__INIT_NODE_URL: {e}"))
@@ -574,6 +581,46 @@ mod test {
                 let err = Settings::with_env_and_config_file(None)
                     .expect_err("off-load collections on a non-spanner backend should fail");
                 assert!(err.to_string().contains("Spanner backend"));
+            },
+        );
+    }
+
+    #[test]
+    fn test_empty_gcs_payload_prefix_fails() {
+        temp_env::with_vars(
+            [
+                (
+                    "SYNC_SYNCSTORAGE__DATABASE_URL",
+                    Some(TEST_SYNCSTORAGE_DATABASE_URL),
+                ),
+                ("SYNC_TOKENSERVER__DATABASE_URL", None),
+                ("SYNC_TOKENSERVER__ENABLED", None),
+                ("SYNC_SYNCSTORAGE__GCS_PAYLOAD_PREFIX", Some("")),
+            ],
+            || {
+                let err = Settings::with_env_and_config_file(None)
+                    .expect_err("an empty payload prefix should fail validation");
+                assert!(err.to_string().contains("GCS_PAYLOAD_PREFIX"));
+            },
+        );
+    }
+
+    #[test]
+    fn test_default_gcs_payload_prefix_validates() {
+        temp_env::with_vars(
+            [
+                (
+                    "SYNC_SYNCSTORAGE__DATABASE_URL",
+                    Some(TEST_SYNCSTORAGE_DATABASE_URL),
+                ),
+                ("SYNC_TOKENSERVER__DATABASE_URL", None),
+                ("SYNC_TOKENSERVER__ENABLED", None),
+                ("SYNC_SYNCSTORAGE__GCS_PAYLOAD_PREFIX", None),
+            ],
+            || {
+                let settings = Settings::with_env_and_config_file(None)
+                    .expect("the default payload prefix should validate");
+                assert!(!settings.syncstorage.gcs_payload_prefix.is_empty());
             },
         );
     }

--- a/syncserver/src/server/mod.rs
+++ b/syncserver/src/server/mod.rs
@@ -81,6 +81,9 @@ pub struct ServerState {
     /// Collections whose BSO payloads are off-loaded to GCS.
     pub gcs_payload_offload_collections: Arc<Vec<String>>,
 
+    /// Prefix for off-loaded GCS object names.
+    pub gcs_payload_prefix: Arc<String>,
+
     /// Shared GCS client built at startup. `None` when GCS off-load is disabled.
     pub gcs_client: Option<Storage>,
 
@@ -412,6 +415,7 @@ impl Server {
         let gcs_payload_bucket = settings.syncstorage.gcs_payload_bucket.clone();
         let gcs_payload_offload_collections =
             Arc::new(settings.syncstorage.gcs_payload_offload_collections.clone());
+        let gcs_payload_prefix = Arc::new(settings.syncstorage.gcs_payload_prefix.clone());
         let gcs_payload_max_concurrency = settings.syncstorage.gcs_payload_max_concurrency;
         let (gcs_client, gcs_control_client) = if gcs_payload_bucket.is_some() {
             let endpoint = settings.syncstorage.gcs_endpoint.as_deref();
@@ -474,6 +478,7 @@ impl Server {
                 glean_enabled,
                 gcs_payload_bucket: gcs_payload_bucket.clone(),
                 gcs_payload_offload_collections: Arc::clone(&gcs_payload_offload_collections),
+                gcs_payload_prefix: Arc::clone(&gcs_payload_prefix),
                 gcs_client: gcs_client.clone(),
                 gcs_control_client: gcs_control_client.clone(),
                 gcs_payload_max_concurrency,

--- a/syncserver/src/server/test.rs
+++ b/syncserver/src/server/test.rs
@@ -127,6 +127,7 @@ async fn get_test_state(settings: &Settings) -> ServerState {
         gcs_payload_offload_collections: Arc::new(
             settings.syncstorage.gcs_payload_offload_collections.clone(),
         ),
+        gcs_payload_prefix: Arc::new(settings.syncstorage.gcs_payload_prefix.clone()),
         gcs_client: match settings.syncstorage.gcs_payload_bucket {
             Some(_) => Some(
                 build_client(settings.syncstorage.gcs_endpoint.as_deref())

--- a/syncserver/src/web/extractors/test_utils.rs
+++ b/syncserver/src/web/extractors/test_utils.rs
@@ -80,6 +80,7 @@ pub fn make_state_with_limits(limits: Arc<ServerLimits>) -> ServerState {
         gcs_payload_bucket: None,
         gcs_payload_max_concurrency: syncstorage_settings.gcs_payload_max_concurrency,
         gcs_payload_offload_collections: Arc::new(Vec::new()),
+        gcs_payload_prefix: Arc::new(syncstorage_settings.gcs_payload_prefix.clone()),
     }
 }
 

--- a/syncserver/src/web/handlers.rs
+++ b/syncserver/src/web/handlers.rs
@@ -450,23 +450,23 @@ pub async fn post_collection(
         let client = state.gcs_client()?;
         // Take the payloads for concurrent uploads, with index to bind the payload url back to
         // the bso
-        let pending: Vec<(usize, String, String)> = coll
+        let pending: Vec<(usize, String)> = coll
             .bsos
             .valid
             .iter_mut()
             .enumerate()
-            .filter_map(|(i, bso)| bso.payload.take().map(|p| (i, bso.id.clone(), p)))
+            .filter_map(|(i, bso)| bso.payload.take().map(|p| (i, p)))
             .collect();
 
         let user_id = &coll.user_id;
-        let collection = coll.collection.as_str();
+        let prefix = state.gcs_payload_prefix.as_str();
         // fail-fast on first failure uploads; successful, orphaned uploads rely on GCS lifecyle
         // policy for clean-up.
         let uploads: Vec<(usize, String)> = stream::iter(pending)
-            .map(|(i, bso_id, payload)| {
+            .map(|(i, payload)| {
                 let client = client.clone();
                 async move {
-                    upload_payload(&client, bucket, user_id, collection, &bso_id, payload)
+                    upload_payload(&client, bucket, prefix, user_id, payload)
                         .await
                         .map(|url| (i, url))
                 }
@@ -845,9 +845,8 @@ pub async fn put_bso(
         let url = upload_payload(
             state.gcs_client()?,
             bucket,
+            &state.gcs_payload_prefix,
             &bso_req.user_id,
-            &bso_req.collection,
-            &bso_req.bso,
             payload,
         )
         .await?;

--- a/syncserver/src/web/handlers.rs
+++ b/syncserver/src/web/handlers.rs
@@ -448,14 +448,17 @@ pub async fn post_collection(
     let mut offload_urls: Vec<String> = Vec::new();
     if let Some(bucket) = offload_bucket(&state, &coll.collection) {
         let client = state.gcs_client()?;
-        // Take the payloads for concurrent uploads, with index to bind the payload url back to
-        // the bso
-        let pending: Vec<(usize, String)> = coll
+        // Take the payloads for concurrent uploads, with index to bind the payload url back to the
+        // bso. The upload step needs the bso id so it can write it to the gcs object metadata.
+        let pending: Vec<(usize, String, String)> = coll
             .bsos
             .valid
             .iter_mut()
             .enumerate()
-            .filter_map(|(i, bso)| bso.payload.take().map(|p| (i, p)))
+            .filter_map(|(i, bso)| {
+                let id = bso.id.clone();
+                bso.payload.take().map(|p| (i, id, p))
+            })
             .collect();
 
         let user_id = &coll.user_id;
@@ -463,10 +466,10 @@ pub async fn post_collection(
         // fail-fast on first failure uploads; successful, orphaned uploads rely on GCS lifecyle
         // policy for clean-up.
         let uploads: Vec<(usize, String)> = stream::iter(pending)
-            .map(|(i, payload)| {
+            .map(|(i, bso_id, payload)| {
                 let client = client.clone();
                 async move {
-                    upload_payload(&client, bucket, prefix, user_id, payload)
+                    upload_payload(&client, bucket, prefix, user_id, &bso_id, payload)
                         .await
                         .map(|url| (i, url))
                 }
@@ -847,6 +850,7 @@ pub async fn put_bso(
             bucket,
             &state.gcs_payload_prefix,
             &bso_req.user_id,
+            &bso_req.bso,
             payload,
         )
         .await?;

--- a/syncserver/src/web/payload_offload.rs
+++ b/syncserver/src/web/payload_offload.rs
@@ -10,6 +10,8 @@
 //! resolved by downloading from GCS after the database transaction commits,
 //! and `payload_link` is cleared before the response is rendered.
 //!
+//! Object names are formatted as `{gcs_payload_prefix}/{fxa_uid}/{uuid}`.
+//!
 //! Objects are written with the custom metadata `committed=false` and a
 //! `customTime` set to upload time; a later step flips `committed` to `true`
 //! once the database row is durably visible.
@@ -65,24 +67,22 @@ pub async fn build_client(endpoint: Option<&str>) -> Result<Storage, ApiError> {
         .map_err(|e| ApiErrorKind::Internal(format!("GCS builder error: {e}")).into())
 }
 
-/// Upload `payload` to `bucket` under the key `{fxa_uid}/{collection}/{bso_id}`
-/// and return the resulting `gs://` URL.
+/// Upload `payload` to `bucket` under the key `{prefix}/{fxa_uid}/{uuid}` and
+/// return the resulting `gs://` URL.
 ///
 /// The object is written with custom metadata `committed=false` and a
 /// `customTime` of the upload moment.
 pub async fn upload_payload(
     client: &Storage,
     bucket: &str,
+    prefix: &str,
     user_id: &UserIdentifier,
-    collection: &str,
-    bso_id: &str,
     payload: String,
 ) -> Result<String, ApiError> {
     let object_name = format!(
-        "{}/{}/{}/{}",
+        "{}/{}/{}",
+        prefix,
         user_id.fxa_uid,
-        collection,
-        bso_id,
         Uuid::new_v4().hyphenated()
     );
 

--- a/syncserver/src/web/payload_offload.rs
+++ b/syncserver/src/web/payload_offload.rs
@@ -14,7 +14,8 @@
 //!
 //! Objects are written with the custom metadata `committed=false` and a
 //! `customTime` set to upload time; a later step flips `committed` to `true`
-//! once the database row is durably visible.
+//! once the database row is durably visible. The objects also carry
+//! `bso_id`, `fxa_kid`, `original_size`, and `format_version`.
 
 use std::{collections::HashMap, time::SystemTime};
 
@@ -30,6 +31,14 @@ use crate::{
 };
 
 const COMMITTED_METADATA_KEY: &str = "committed";
+
+/// Custom metadata keys
+const BSO_ID_METADATA_KEY: &str = "bso_id";
+const FXA_KID_METADATA_KEY: &str = "fxa_kid";
+/// Byte length of the payload as received
+const ORIGINAL_SIZE_METADATA_KEY: &str = "original_size";
+const FORMAT_VERSION_METADATA_KEY: &str = "format_version";
+const FORMAT_VERSION: &str = "1";
 
 /// Counter for the best-effort GCS cleanup that runs when the database
 /// transaction of an offloading write fails. Tagged with the `handler` that
@@ -70,13 +79,14 @@ pub async fn build_client(endpoint: Option<&str>) -> Result<Storage, ApiError> {
 /// Upload `payload` to `bucket` under the key `{prefix}/{fxa_uid}/{uuid}` and
 /// return the resulting `gs://` URL.
 ///
-/// The object is written with custom metadata `committed=false` and a
-/// `customTime` of the upload moment.
+/// The object is written with a `customTime` of the upload moment and custom metadata:
+/// `committed=false`, plus the fields `bso_id`, `fxa_kid`, `original_size`, and `format_version`.
 pub async fn upload_payload(
     client: &Storage,
     bucket: &str,
     prefix: &str,
     user_id: &UserIdentifier,
+    bso_id: &str,
     payload: String,
 ) -> Result<String, ApiError> {
     let object_name = format!(
@@ -86,13 +96,28 @@ pub async fn upload_payload(
         Uuid::new_v4().hyphenated()
     );
 
+    // Capture the length here. The `payload` value moves into the upload call below.
+    let original_size = payload.len();
+
     let custom_time: wkt::Timestamp = SystemTime::now()
         .try_into()
         .map_err(|e| ApiErrorKind::Internal(format!("custom_time: {e}")))?;
 
     client
         .write_object(bucket_path(bucket), object_name.clone(), payload)
-        .set_metadata([(COMMITTED_METADATA_KEY.to_string(), "false".to_string())])
+        .set_metadata([
+            (COMMITTED_METADATA_KEY.to_string(), "false".to_string()),
+            (BSO_ID_METADATA_KEY.to_string(), bso_id.to_owned()),
+            (FXA_KID_METADATA_KEY.to_string(), user_id.fxa_kid.clone()),
+            (
+                ORIGINAL_SIZE_METADATA_KEY.to_string(),
+                original_size.to_string(),
+            ),
+            (
+                FORMAT_VERSION_METADATA_KEY.to_string(),
+                FORMAT_VERSION.to_owned(),
+            ),
+        ])
         .set_custom_time(custom_time)
         .send_buffered()
         .await?;

--- a/syncserver/src/web/payload_offload.rs
+++ b/syncserver/src/web/payload_offload.rs
@@ -89,12 +89,7 @@ pub async fn upload_payload(
     bso_id: &str,
     payload: String,
 ) -> Result<String, ApiError> {
-    let object_name = format!(
-        "{}/{}/{}",
-        prefix,
-        user_id.fxa_uid,
-        Uuid::new_v4().hyphenated()
-    );
+    let object_name = format!("{}/{}/{}", prefix, user_id.fxa_uid, Uuid::new_v4().simple());
 
     // Capture the length here. The `payload` value moves into the upload call below.
     let original_size = payload.len();

--- a/syncstorage-settings/src/lib.rs
+++ b/syncstorage-settings/src/lib.rs
@@ -192,6 +192,10 @@ impl Settings {
             self.limits.max_total_bytes =
                 min(self.limits.max_total_bytes, MAX_SPANNER_LOAD_SIZE as u32);
         }
+
+        // Object names are joined as `{prefix}/{fxa_uid}/{uuid}`, so a leading
+        // or trailing slash on the configured prefix yields an empty segment.
+        self.gcs_payload_prefix = self.gcs_payload_prefix.trim_matches('/').to_owned();
     }
 
     pub fn spanner_database_name(&self) -> Option<&str> {

--- a/syncstorage-settings/src/lib.rs
+++ b/syncstorage-settings/src/lib.rs
@@ -137,6 +137,10 @@ pub struct Settings {
     /// off-load path for all collections.
     pub gcs_payload_offload_collections: Vec<String>,
 
+    /// Prefix off-loaded GCS object names, which are formatted as
+    /// `{gcs_payload_prefix}/{fxa_uid}/{uuid}`.
+    pub gcs_payload_prefix: String,
+
     /// Maximum number of GCS payload uploads/downloads to run concurrently
     /// within a single batch request.
     pub gcs_payload_max_concurrency: NonZeroUsize,
@@ -174,6 +178,7 @@ impl Default for Settings {
             lbheartbeat_ttl_jitter: 25,
             gcs_payload_bucket: None,
             gcs_payload_offload_collections: Vec::new(),
+            gcs_payload_prefix: "v1".to_owned(),
             gcs_payload_max_concurrency: DEFAULT_GCS_PAYLOAD_MAX_CONCURRENCY,
             gcs_endpoint: None,
         }

--- a/tools/integration_tests/test_payload_link_reconciliation.py
+++ b/tools/integration_tests/test_payload_link_reconciliation.py
@@ -30,6 +30,7 @@ pytestmark = pytest.mark.skipif(
 
 
 PAYLOAD_BUCKET = os.environ.get("GCS_PAYLOAD_BUCKET", "")
+PAYLOAD_PREFIX = os.environ.get("GCS_PAYLOAD_PREFIX", "v1")
 POLL_TIMEOUT_SECONDS = int(os.environ.get("RECONCILER_POLL_TIMEOUT", "30"))
 POLL_INTERVAL_SECONDS = 0.5
 
@@ -76,8 +77,8 @@ def _list_blobs(gcs: storage.Client, prefix: str) -> list[storage.Blob]:
     return list(gcs.bucket(PAYLOAD_BUCKET).list_blobs(prefix=prefix))
 
 
-def _prefix_for(st_ctx: dict[str, Any], bso_id: str) -> str:
-    return f"{st_ctx['fxa_uid']}/{OFFLOAD_COLLECTION}/{bso_id}/"
+def _prefix_for(st_ctx: dict[str, Any]) -> str:
+    return f"{PAYLOAD_PREFIX}/{st_ctx['fxa_uid']}/"
 
 
 def test_upload_finalizes_object(st_ctx: dict[str, Any], gcs: storage.Client) -> None:
@@ -86,7 +87,7 @@ def test_upload_finalizes_object(st_ctx: dict[str, Any], gcs: storage.Client) ->
     _put_bso(st_ctx, bso_id)
 
     def committed_blob() -> storage.Blob | None:
-        for blob in _list_blobs(gcs, _prefix_for(st_ctx, bso_id)):
+        for blob in _list_blobs(gcs, _prefix_for(st_ctx)):
             blob.reload()
             if (blob.metadata or {}).get("committed") == "true":
                 return blob
@@ -104,7 +105,7 @@ def test_update_deletes_old_object(st_ctx: dict[str, Any], gcs: storage.Client) 
     bso_id = "reconcile-update"
     _put_bso(st_ctx, bso_id, payload="a" * 300_000)
     old = _wait_for(
-        lambda: (_list_blobs(gcs, _prefix_for(st_ctx, bso_id)) or [None])[0],
+        lambda: (_list_blobs(gcs, _prefix_for(st_ctx)) or [None])[0],
         "initial object exists",
     )
     assert old is not None
@@ -123,7 +124,7 @@ def test_delete_removes_object(st_ctx: dict[str, Any], gcs: storage.Client) -> N
     bso_id = "reconcile-delete"
     _put_bso(st_ctx, bso_id)
     blob = _wait_for(
-        lambda: (_list_blobs(gcs, _prefix_for(st_ctx, bso_id)) or [None])[0],
+        lambda: (_list_blobs(gcs, _prefix_for(st_ctx)) or [None])[0],
         "object exists after upload",
     )
     assert blob is not None

--- a/tools/integration_tests/test_payload_link_reconciliation.py
+++ b/tools/integration_tests/test_payload_link_reconciliation.py
@@ -100,6 +100,28 @@ def test_upload_finalizes_object(st_ctx: dict[str, Any], gcs: storage.Client) ->
     assert blob.custom_time.year == 2200
 
 
+def test_upload_writes_metadata(st_ctx: dict[str, Any], gcs: storage.Client) -> None:
+    """An offloaded object records which BSO it came from."""
+    bso_id = "reconcile-metadata"
+    payload = LARGE_PAYLOAD
+    _put_bso(st_ctx, bso_id, payload=payload)
+
+    def blob_for_bso() -> storage.Blob | None:
+        for blob in _list_blobs(gcs, _prefix_for(st_ctx)):
+            blob.reload()
+            if (blob.metadata or {}).get("bso_id") == bso_id:
+                return blob
+        return None
+
+    blob = _wait_for(blob_for_bso, f"object with bso_id={bso_id}")
+    assert blob is not None
+    metadata = blob.metadata or {}
+    assert metadata["bso_id"] == bso_id
+    assert metadata["fxa_kid"] == st_ctx["fxa_kid"]
+    assert metadata["original_size"] == str(len(payload))
+    assert metadata["format_version"] == "1"
+
+
 def test_update_deletes_old_object(st_ctx: dict[str, Any], gcs: storage.Client) -> None:
     """Replacing payload_link deletes the prior object."""
     bso_id = "reconcile-update"


### PR DESCRIPTION
Use the gcs object name as recommended by the doc in stor-581.

Closes STOR-692
