### PR TITLE
test: retry flaky spanner unit tests in ci

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -14,9 +14,11 @@ slow-timeout = { period = "300s" }
 
 [profile.ci]
 fail-fast = false
-# The Spanner emulator intermittently fails a request for no good reason, which
-# has surfaced in both syncstorage-db and syncserver tests. Retried tests are
-# reported as flaky, not silently passed.
+
+# The Spanner emulator intermittently returns a spurious ABORTED, surfacing as
+# Conflict/503. Retried tests are reported as flaky, not silently passed.
+[[profile.ci.overrides]]
+filter = 'package(syncstorage-db)'
 retries = 2
 
 [profile.ci.junit]

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -14,6 +14,10 @@ slow-timeout = { period = "300s" }
 
 [profile.ci]
 fail-fast = false
+# The Spanner emulator intermittently fails a request for no good reason, which
+# has surfaced in both syncstorage-db and syncserver tests. Retried tests are
+# reported as flaky, not silently passed.
+retries = 2
 
 [profile.ci.junit]
 path = "junit.xml"


### PR DESCRIPTION
## Description

`build-and-unit-test-spanner` intermittently fails with `Conflict, status: 503` -- a spurious ABORTED from the Spanner emulator. A different `syncstorage-db tests::db::*` test fails each time, including on master, so it is not branch-specific.

Enables nextest `retries` for the flaky tests.

I scoped to the `syncstorage-db` package and the `ci` profile only, so the rest of the workspace and all local runs still fail on the first try.`final-status-level = "flaky"` is already set, so retried tests stay visible rather and don't silently pass.

Not sure if that's an anti-pattern or not, so call me out on it if so. I just didn't want to make that setting apply to all crates

## Issue(s)

Closes [STOR-696](https://mozilla-hub.atlassian.net/browse/STOR-696).


[STOR-696]: https://mozilla-hub.atlassian.net/browse/STOR-696?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ