### PR TITLE
feat: track offloaded payload sizes in spanner

### DIFF
--- a/docker/docker-compose.e2e.reconciliation.yaml
+++ b/docker/docker-compose.e2e.reconciliation.yaml
@@ -145,9 +145,6 @@ services:
       # Collections used by test_storage.py -- opts them all into offload
       # so test_storage.py exercises the offload path as regression
       # coverage. Extend if new collections appear in the test suite.
-      # Deliberately excludes xxx_usage: the /info/quota and
-      # /info/collection_usage tests need a non-offloaded collection since
-      # byte accounting reads the inline Spanner payload. Do not add it here.
       SYNC_SYNCSTORAGE__GCS_PAYLOAD_OFFLOAD_COLLECTIONS: >-
         apis-1,crypto,meta,passwords,xxx_col,xxx_col1,xxx_col2,xxx_meh,xxxx,nonexistent
 

--- a/docs/src/payload-offload/overview.md
+++ b/docs/src/payload-offload/overview.md
@@ -8,7 +8,8 @@ offload lifts that ceiling for chosen collections: syncserver writes the
 payload to a Google Cloud Storage object and stores only a `gs://` URL in the
 BSO's `payload_link` column, leaving `payload` NULL. The payload's byte length
 is recorded alongside the URL in `payload_size`, since the row itself no longer
-carries the bytes to measure.
+carries the bytes to measure. Usage and quota accounting reads that column, so
+an offloaded payload still counts against the user's quota.
 
 Offload is off by default, opt-in per collection, and supported on the Spanner
 backend only. Nothing changes for a collection that is not opted in.
@@ -254,3 +255,6 @@ This is a work in progress. As of this writing:
 - Only the dev environment is built out. Stage and prod need the same set of
   resources plus a dedicated Spanner metadata database.
 - Change stream storage cost in prod has not been measured.
+- BSOs offloaded before `payload_size` existed have no recorded size and count
+  as 0 bytes toward usage and quota until they are rewritten. There is no
+  backfill.

--- a/docs/src/payload-offload/overview.md
+++ b/docs/src/payload-offload/overview.md
@@ -6,7 +6,9 @@ A Sync BSO payload normally lives inline in a Spanner column, and a payload
 larger than the per-record limit (2.5 MB by default) is rejected. Payload
 offload lifts that ceiling for chosen collections: syncserver writes the
 payload to a Google Cloud Storage object and stores only a `gs://` URL in the
-BSO's `payload_link` column, leaving `payload` NULL.
+BSO's `payload_link` column, leaving `payload` NULL. The payload's byte length
+is recorded alongside the URL in `payload_size`, since the row itself no longer
+carries the bytes to measure.
 
 Offload is off by default, opt-in per collection, and supported on the Spanner
 backend only. Nothing changes for a collection that is not opted in.
@@ -230,7 +232,7 @@ is in preserving one of them.
 | Upload, download, delete, URL parsing | `syncserver/src/web/payload_offload.rs` |
 | Which collections offload, request wiring | `syncserver/src/web/handlers.rs` |
 | Settings and startup validation | `syncstorage-settings/src/lib.rs` |
-| `payload_link` column, change stream, access role | `syncstorage-spanner/src/schema.ddl` |
+| `payload_link`/`payload_size` columns, change stream, access role | `syncstorage-spanner/src/schema.ddl` |
 | Dataflow pipeline (prod publisher, Java) | `tools/payload-link-dataflow/` |
 | Dev publisher (Python, emulator only) | `tools/payload-link-dataflow/payload-link-publisher-py/` |
 | Reconciler | `tools/payload-reconciler/` |

--- a/docs/src/syncstorage/syncstorage-spanner-db.md
+++ b/docs/src/syncstorage/syncstorage-spanner-db.md
@@ -88,7 +88,7 @@ These come from Spanner itself and bound what the server must respect:
 | `collection_id` | `INT64`        | Maps to a named collection. PK (part 3).                             |
 | `modified`      | `TIMESTAMP`    | Last modification time (server-assigned, updated on writes).         |
 | `count`         | `INT64`        | Count of BSOs in this collection (quota mode only).                  |
-| `total_bytes`   | `INT64`        | Total payload size of all BSOs (quota mode only).                    |
+| `total_bytes`   | `INT64`        | Total payload size of all BSOs (quota mode only). Counts an offloaded BSO by its recorded `payload_size`, so moving a payload to GCS does not move it out of the user's quota. |
 
 Enables `/info/collections`, `/info/collection_counts`, and `/info/collection_usage`.
 
@@ -103,7 +103,7 @@ Enables `/info/collections`, `/info/collection_counts`, and `/info/collection_us
 | `sortindex`     | `INT64`        | Indicates record importance for syncing (optional).                  |
 | `payload`       | `STRING(MAX)`  | Payload bytes (e.g. an encrypted JSON blob). Nullable: an offloaded BSO leaves this NULL and sets `payload_link` instead. |
 | `payload_link`  | `STRING(MAX)`  | `gs://` URL of the payload when it is stored in GCS rather than inline. NULL for an ordinary BSO. See [Payload Offload](../payload-offload/overview.md). |
-| `payload_size`  | `INT64`        | Byte length of the offloaded payload, recorded at upload time. Set only alongside `payload_link`; NULL for an inline payload, whose size is `BYTE_LENGTH(payload)`. |
+| `payload_size`  | `INT64`        | Byte length of the offloaded payload, recorded at upload time. Set only alongside `payload_link`; NULL for an inline payload, whose size is `BYTE_LENGTH(payload)`. Usage and quota accounting reads it as `COALESCE(BYTE_LENGTH(payload), payload_size, 0)`. |
 | `modified`      | `TIMESTAMP`    | Server-assigned modification timestamp.                              |
 | `expiry`        | `TIMESTAMP`    | Absolute expiration time. Spanner's row deletion policy prunes rows older than `expiry`. |
 

--- a/docs/src/syncstorage/syncstorage-spanner-db.md
+++ b/docs/src/syncstorage/syncstorage-spanner-db.md
@@ -103,6 +103,7 @@ Enables `/info/collections`, `/info/collection_counts`, and `/info/collection_us
 | `sortindex`     | `INT64`        | Indicates record importance for syncing (optional).                  |
 | `payload`       | `STRING(MAX)`  | Payload bytes (e.g. an encrypted JSON blob). Nullable: an offloaded BSO leaves this NULL and sets `payload_link` instead. |
 | `payload_link`  | `STRING(MAX)`  | `gs://` URL of the payload when it is stored in GCS rather than inline. NULL for an ordinary BSO. See [Payload Offload](../payload-offload/overview.md). |
+| `payload_size`  | `INT64`        | Byte length of the offloaded payload, recorded at upload time. Set only alongside `payload_link`; NULL for an inline payload, whose size is `BYTE_LENGTH(payload)`. |
 | `modified`      | `TIMESTAMP`    | Server-assigned modification timestamp.                              |
 | `expiry`        | `TIMESTAMP`    | Absolute expiration time. Spanner's row deletion policy prunes rows older than `expiry`. |
 
@@ -147,6 +148,7 @@ The 13 standard collections expected by clients have fixed reserved IDs (1–13)
 | `sortindex`     | `INT64`        | Optional; nullable since the upload may not set every field per item.  |
 | `payload`       | `STRING(MAX)`  | Optional; nullable for the same reason.                                |
 | `payload_link`  | `STRING(MAX)`  | `gs://` URL of a staged offloaded payload. Copied into the permanent `bsos` row at commit. See [Payload Offload](../payload-offload/overview.md). |
+| `payload_size`  | `INT64`        | Byte length of the staged offloaded payload. Travels with `payload_link` into the `bsos` row at commit. |
 | `ttl`           | `INT64`        | Time-to-live in seconds, optional.                                     |
 
 `INTERLEAVE IN PARENT batches ON DELETE CASCADE`. Note there is no `modified` column, the modification timestamp is assigned at commit time when rows are upserted into `bsos`.
@@ -201,10 +203,21 @@ With no secondary indexes on `bsos` (per [#2382](https://github.com/mozilla-serv
 | Component                                                       | Mutations |
 | --------------------------------------------------------------- | --------- |
 | 4 PK columns (`fxa_uid`, `fxa_kid`, `collection_id`, `bso_id`)  | 4         |
-| 4 non-PK columns (`sortindex`, `payload`, `modified`, `expiry`) | 4         |
-| **Total per BSO**                                               | **8**     |
+| 6 non-PK columns (`sortindex`, `payload`, `modified`, `expiry`, `payload_link`, `payload_size`) | 6 |
+| **Total per BSO**                                               | **10**    |
 
-For `N` BSOs in the batch: `8N` mutations.
+For `N` BSOs in the batch: `10N` mutations.
+
+> **The figures below still assume the pre-offload 8 mutations per BSO and are
+> stale.** `batch_commit_upsert.sql` gained `payload_link` with payload offload
+> ([#2407](https://github.com/mozilla-services/syncstorage-rs/pull/2407)) and
+> `payload_size` alongside it; both are written for every row in the batch,
+> whether or not the collection offloads. At 10 per BSO the ceiling is
+> `10N + 13 <= 80,000`, i.e. `N <= 7,998` — below the deployed
+> `max_total_records` of 9,984, which would consume 99,853 mutations at a full
+> batch. Recalculating the budget and the deployed value is tracked separately;
+> the totals, evolution, and justification sections below have not been
+> rewritten.
 
 #### Step 3 `delete_batch`
 

--- a/syncserver/src/server/test.rs
+++ b/syncserver/src/server/test.rs
@@ -472,6 +472,7 @@ async fn post_collection() {
         sortindex: Some(0),
         payload: Some("bar".to_string()),
         payload_link: None,
+        payload_size: None,
         ttl: Some(31_536_000),
     }]);
     let bytes =

--- a/syncserver/src/web/extractors/batch_bso_body.rs
+++ b/syncserver/src/web/extractors/batch_bso_body.rs
@@ -19,6 +19,10 @@ pub struct BatchBsoBody {
     /// accepted from the client.
     #[serde(default, skip_deserializing)]
     pub payload_link: Option<String>,
+    /// Byte length of the offloaded payload, recorded alongside
+    /// [`Self::payload_link`]; never accepted from the client.
+    #[serde(default, skip_deserializing)]
+    pub payload_size: Option<i64>,
 }
 
 impl BatchBsoBody {
@@ -55,6 +59,7 @@ impl From<BatchBsoBody> for PostCollectionBso {
             sortindex: b.sortindex,
             payload: b.payload,
             payload_link: b.payload_link,
+            payload_size: b.payload_size,
             ttl: b.ttl,
         }
     }

--- a/syncserver/src/web/handlers.rs
+++ b/syncserver/src/web/handlers.rs
@@ -462,13 +462,17 @@ pub async fn post_collection(
         let collection = coll.collection.as_str();
         // fail-fast on first failure uploads; successful, orphaned uploads rely on GCS lifecyle
         // policy for clean-up.
-        let uploads: Vec<(usize, String)> = stream::iter(pending)
+        // The payload's byte length is recorded alongside its URL: once the
+        // payload lives in GCS the row's own payload column is NULL, so its
+        // size is only knowable here.
+        let uploads: Vec<(usize, (String, i64))> = stream::iter(pending)
             .map(|(i, bso_id, payload)| {
                 let client = client.clone();
+                let payload_size = payload.len() as i64;
                 async move {
                     upload_payload(&client, bucket, user_id, collection, &bso_id, payload)
                         .await
-                        .map(|url| (i, url))
+                        .map(|url| (i, (url, payload_size)))
                 }
             })
             .buffer_unordered(state.gcs_payload_max_concurrency.get())
@@ -477,10 +481,11 @@ pub async fn post_collection(
 
         // Track uploaded URLs so they can be cleaned up from GCS if the DB
         // transaction below fails.
-        offload_urls.extend(uploads.iter().map(|(_, url)| url.clone()));
+        offload_urls.extend(uploads.iter().map(|(_, (url, _))| url.clone()));
 
-        reattach_by_index(&mut coll.bsos.valid, uploads, |bso, url| {
-            bso.payload_link = Some(url)
+        reattach_by_index(&mut coll.bsos.valid, uploads, |bso, (url, payload_size)| {
+            bso.payload_link = Some(url);
+            bso.payload_size = Some(payload_size);
         });
     }
 
@@ -703,6 +708,7 @@ pub async fn post_collection_batch(
                         sortindex: batch_bso.sortindex,
                         payload: batch_bso.payload,
                         payload_link: batch_bso.payload_link,
+                        payload_size: batch_bso.payload_size,
                         ttl: batch_bso.ttl,
                     })
                     .collect(),
@@ -839,9 +845,13 @@ pub async fn put_bso(
     // but the GCS cleanup after it needs to emit metrics.
     let metrics = bso_req.metrics.clone();
     let mut payload_link = None;
+    let mut payload_size = None;
     if let Some(bucket) = offload_bucket(&state, &bso_req.collection)
         && let Some(payload) = bso_req.body.payload.take()
     {
+        // Recorded before the upload consumes the payload: the row's payload
+        // column is NULL once offloaded, so its size is only knowable here.
+        payload_size = Some(payload.len() as i64);
         let url = upload_payload(
             state.gcs_client()?,
             bucket,
@@ -866,6 +876,7 @@ pub async fn put_bso(
                     sortindex: bso_req.body.sortindex,
                     payload: bso_req.body.payload,
                     payload_link: payload_link.clone(),
+                    payload_size,
                     ttl: bso_req.body.ttl,
                 })
                 .await?;

--- a/syncserver/src/web/payload_offload.rs
+++ b/syncserver/src/web/payload_offload.rs
@@ -4,7 +4,8 @@
 //! `gcs_payload_offload_collections` (both in syncstorage settings), the BSO
 //! write handlers upload the incoming payload to GCS prior to opening the
 //! database transaction. The returned object URL is written to the BSO
-//! `payload_link` column and the inline `payload` field is cleared.
+//! `payload_link` column, the payload's byte length to `payload_size`, and the
+//! inline `payload` field is cleared.
 //!
 //! On the read path, BSOs with a `payload_link` set have their payload
 //! resolved by downloading from GCS after the database transaction commits,

--- a/syncstorage-db-common/src/params.rs
+++ b/syncstorage-db-common/src/params.rs
@@ -228,6 +228,8 @@ pub struct PutBso {
     pub payload: Option<String>,
     // URI of an externally-stored payload (currently Spanner + GCS only)
     pub payload_link: Option<String>,
+    // Byte length of the externally-stored payload, set alongside payload_link
+    pub payload_size: Option<i64>,
     // ttl in seconds
     pub ttl: Option<u32>,
 }
@@ -239,6 +241,8 @@ pub struct PostCollectionBso {
     pub payload: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub payload_link: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub payload_size: Option<i64>,
     // ttl in seconds
     pub ttl: Option<u32>,
 }

--- a/syncstorage-db-common/src/results.rs
+++ b/syncstorage-db-common/src/results.rs
@@ -66,6 +66,12 @@ pub struct GetBso {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[diesel(sql_type = Nullable<Text>)]
     pub payload_link: Option<String>,
+    // NOTE: like expiry, payload_size is never rendered to clients: it's the
+    // byte length of the offloaded payload, loaded only for tests.
+    #[serde(skip_serializing)]
+    #[serde(skip_deserializing)]
+    #[diesel(sql_type = Nullable<BigInt>)]
+    pub payload_size: Option<i64>,
 }
 
 #[derive(Debug, Default)]

--- a/syncstorage-db/src/tests/batch.rs
+++ b/syncstorage-db/src/tests/batch.rs
@@ -160,6 +160,38 @@ async fn append_commit() -> Result<(), DbError> {
     .await
 }
 
+/// A staged offloaded BSO carries both payload_link and its payload_size
+/// through the commit into `bsos`. Spanner-only: they're Spanner-only columns.
+#[cfg(feature = "spanner")]
+#[tokio::test]
+async fn append_commit_offloaded() -> Result<(), DbError> {
+    const GS_URL: &str = "gs://test-bucket/fxa/clients/b0/abcd";
+
+    with_test_transaction(None, async |db: &mut dyn Db<Error = DbError>| {
+        let uid = 1;
+        let coll = "clients";
+        let mut bso = postbso("b0", None, None, None);
+        bso.payload_link = Some(GS_URL.to_owned());
+        bso.payload_size = Some(4096);
+        let new_batch = db.create_batch(cb(uid, coll, vec![bso])).await?;
+
+        let batch = db.get_batch(gb(uid, coll, new_batch.id)).await?.unwrap();
+        db.commit_batch(params::CommitBatch {
+            user_id: hid(uid),
+            collection: coll.to_owned(),
+            batch,
+        })
+        .await?;
+
+        let got = db.get_bso(gbso(uid, coll, "b0")).await?.unwrap();
+        assert_eq!(got.payload_link.as_deref(), Some(GS_URL));
+        assert_eq!(got.payload_size, Some(4096));
+        assert_eq!(got.payload, "");
+        Ok(())
+    })
+    .await
+}
+
 #[tokio::test]
 async fn quota_test_create_batch() -> Result<(), DbError> {
     let mut settings = Settings::test_settings().syncstorage;

--- a/syncstorage-db/src/tests/batch.rs
+++ b/syncstorage-db/src/tests/batch.rs
@@ -160,13 +160,16 @@ async fn append_commit() -> Result<(), DbError> {
     .await
 }
 
+// payload_link/payload_size are Spanner-only columns, so the offload tests
+// below are gated to the spanner backend.
+#[cfg(feature = "spanner")]
+const GS_URL: &str = "gs://test-bucket/fxa/clients/b0/abcd";
+
 /// A staged offloaded BSO carries both payload_link and its payload_size
-/// through the commit into `bsos`. Spanner-only: they're Spanner-only columns.
+/// through the commit into `bsos`.
 #[cfg(feature = "spanner")]
 #[tokio::test]
 async fn append_commit_offloaded() -> Result<(), DbError> {
-    const GS_URL: &str = "gs://test-bucket/fxa/clients/b0/abcd";
-
     with_test_transaction(None, async |db: &mut dyn Db<Error = DbError>| {
         let uid = 1;
         let coll = "clients";
@@ -274,6 +277,67 @@ async fn quota_test_append_batch() -> Result<(), DbError> {
             .await?;
             let id2 = db.create_batch(cb(uid, coll, bsos2)).await?;
             let result = db.append_to_batch(ab(uid, coll, id2.clone(), bsos3)).await;
+            if settings.enforce_quota {
+                assert!(result.is_err())
+            } else {
+                assert!(result.is_ok())
+            }
+            Ok(())
+        },
+    )
+    .await
+}
+
+/// Offloaded BSOs count toward the batch quota check through payload_size, on
+/// all three of its inputs: the committed collection total, the rows already
+/// pending in `batch_bsos`, and the running total of the incoming request.
+#[cfg(feature = "spanner")]
+#[tokio::test]
+async fn quota_test_append_batch_offloaded() -> Result<(), DbError> {
+    let mut settings = Settings::test_settings().syncstorage;
+
+    if !settings.enable_quota {
+        debug!("[test] Skipping test");
+        return Ok(());
+    }
+
+    let limit = 300;
+    settings.limits.max_quota_limit = limit;
+
+    with_test_transaction(
+        settings.clone(),
+        async |db: &mut dyn Db<Error = DbError>| {
+            let uid = 1;
+            let coll = "clients";
+            // Each is a third of the quota, offloaded: no inline bytes at all,
+            // so every byte counted has to come from payload_size.
+            let offloaded = |id: &str| {
+                let mut bso = postbso(id, None, None, None);
+                bso.payload_link = Some(GS_URL.to_owned());
+                bso.payload_size = Some((limit / 3) as i64);
+                bso
+            };
+
+            let new_batch = db
+                .create_batch(cb(uid, coll, vec![offloaded("b0")]))
+                .await?;
+            let batch = db
+                .get_batch(gb(uid, coll, new_batch.id.clone()))
+                .await?
+                .unwrap();
+            db.commit_batch(params::CommitBatch {
+                user_id: hid(uid),
+                collection: coll.to_owned(),
+                batch,
+            })
+            .await?;
+
+            let id2 = db
+                .create_batch(cb(uid, coll, vec![offloaded("b1")]))
+                .await?;
+            let result = db
+                .append_to_batch(ab(uid, coll, id2.clone(), vec![offloaded("b2")]))
+                .await;
             if settings.enforce_quota {
                 assert!(result.is_err())
             } else {

--- a/syncstorage-db/src/tests/db.rs
+++ b/syncstorage-db/src/tests/db.rs
@@ -1324,6 +1324,121 @@ async fn post_bsos_rejects_both_payload_and_payload_link() -> Result<(), DbError
     .await
 }
 
+/// payload_size records the byte length of an offloaded payload, which is
+/// otherwise unrecoverable from the row (payload is NULL).
+#[cfg(feature = "spanner")]
+#[tokio::test]
+async fn put_bso_offload_stores_payload_size() -> Result<(), DbError> {
+    with_test_transaction(None, async |db: &mut dyn Db<Error = DbError>| {
+        let uid = *UID;
+        let coll = "clients";
+        let bid = "b0";
+
+        let mut bso = pbso(uid, coll, bid, None, None, Some(DEFAULT_BSO_TTL));
+        bso.payload_link = Some(GS_URL.to_owned());
+        bso.payload_size = Some(4096);
+        db.put_bso(bso).await?;
+
+        let got = db.get_bso(gbso(uid, coll, bid)).await?.unwrap();
+        assert_eq!(got.payload_link.as_deref(), Some(GS_URL));
+        assert_eq!(got.payload_size, Some(4096));
+        Ok(())
+    })
+    .await
+}
+
+/// payload_size travels with payload_link: writing an inline payload over an
+/// offloaded BSO clears both.
+#[cfg(feature = "spanner")]
+#[tokio::test]
+async fn put_bso_inline_write_clears_payload_size() -> Result<(), DbError> {
+    with_test_transaction(None, async |db: &mut dyn Db<Error = DbError>| {
+        let uid = *UID;
+        let coll = "clients";
+        let bid = "b0";
+
+        let mut offloaded = pbso(uid, coll, bid, None, None, Some(DEFAULT_BSO_TTL));
+        offloaded.payload_link = Some(GS_URL.to_owned());
+        offloaded.payload_size = Some(4096);
+        db.put_bso(offloaded).await?;
+
+        db.put_bso(pbso(uid, coll, bid, Some("inline now"), None, None))
+            .await?;
+
+        let got = db.get_bso(gbso(uid, coll, bid)).await?.unwrap();
+        assert_eq!(got.payload_link, None);
+        assert_eq!(got.payload_size, None);
+        Ok(())
+    })
+    .await
+}
+
+/// A metadata-only update preserves the offloaded row's payload_size alongside
+/// its payload_link.
+#[cfg(feature = "spanner")]
+#[tokio::test]
+async fn put_bso_sortindex_only_preserves_payload_size() -> Result<(), DbError> {
+    with_test_transaction(None, async |db: &mut dyn Db<Error = DbError>| {
+        let uid = *UID;
+        let coll = "clients";
+        let bid = "b0";
+
+        let mut offloaded = pbso(uid, coll, bid, None, None, Some(DEFAULT_BSO_TTL));
+        offloaded.payload_link = Some(GS_URL.to_owned());
+        offloaded.payload_size = Some(4096);
+        db.put_bso(offloaded).await?;
+
+        db.put_bso(pbso(uid, coll, bid, None, Some(9), None))
+            .await?;
+
+        let got = db.get_bso(gbso(uid, coll, bid)).await?.unwrap();
+        assert_eq!(got.payload_link.as_deref(), Some(GS_URL));
+        assert_eq!(got.payload_size, Some(4096));
+        Ok(())
+    })
+    .await
+}
+
+/// The batched `post_bsos` write path records payload_size too, and clears it
+/// when a later inline write replaces the offloaded payload.
+#[cfg(feature = "spanner")]
+#[tokio::test]
+async fn post_bsos_offload_stores_payload_size() -> Result<(), DbError> {
+    with_test_transaction(None, async |db: &mut dyn Db<Error = DbError>| {
+        let uid = *UID;
+        let coll = "clients";
+
+        let mut bso = postbso("b0", None, None, Some(DEFAULT_BSO_TTL));
+        bso.payload_link = Some(GS_URL.to_owned());
+        bso.payload_size = Some(4096);
+        db.post_bsos(params::PostBsos {
+            user_id: hid(uid),
+            collection: coll.to_owned(),
+            bsos: vec![bso],
+            for_batch: false,
+        })
+        .await?;
+
+        let got = db.get_bso(gbso(uid, coll, "b0")).await?.unwrap();
+        assert_eq!(got.payload_link.as_deref(), Some(GS_URL));
+        assert_eq!(got.payload_size, Some(4096));
+
+        db.post_bsos(params::PostBsos {
+            user_id: hid(uid),
+            collection: coll.to_owned(),
+            bsos: vec![postbso("b0", Some("inline now"), None, None)],
+            for_batch: false,
+        })
+        .await?;
+
+        let got = db.get_bso(gbso(uid, coll, "b0")).await?.unwrap();
+        assert_eq!(got.payload_link, None);
+        assert_eq!(got.payload_size, None);
+        Ok(())
+    })
+    .await
+}
+
 #[cfg(feature = "spanner")]
 #[tokio::test]
 async fn get_collection_usage_only_links() -> Result<(), DbError> {

--- a/syncstorage-db/src/tests/db.rs
+++ b/syncstorage-db/src/tests/db.rs
@@ -1439,6 +1439,9 @@ async fn post_bsos_offload_stores_payload_size() -> Result<(), DbError> {
     .await
 }
 
+/// A BSO offloaded before payload_size existed has no recorded size, so it
+/// contributes 0 to usage — the behavior every offloaded row had before the
+/// column landed.
 #[cfg(feature = "spanner")]
 #[tokio::test]
 async fn get_collection_usage_only_links() -> Result<(), DbError> {
@@ -1458,6 +1461,7 @@ async fn get_collection_usage_only_links() -> Result<(), DbError> {
     .await
 }
 
+/// As above, for whole-storage usage.
 #[cfg(feature = "spanner")]
 #[tokio::test]
 async fn get_storage_usage_only_links() -> Result<(), DbError> {
@@ -1471,6 +1475,88 @@ async fn get_storage_usage_only_links() -> Result<(), DbError> {
 
         let usage = db.get_storage_usage(hid(uid)).await?;
         assert_eq!(usage, 0);
+        Ok(())
+    })
+    .await
+}
+
+/// An offloaded payload's bytes live in GCS, but payload_size keeps them
+/// visible to every usage accounting: per collection, per user, and the
+/// user_collections totals that back get_quota_usage.
+#[cfg(feature = "spanner")]
+#[tokio::test]
+async fn usage_counts_offloaded_payload_size() -> Result<(), DbError> {
+    with_test_transaction(None, async |db: &mut dyn Db<Error = DbError>| {
+        let uid = *UID;
+
+        db.delete_storage(hid(uid)).await?;
+        let mut bso = pbso(uid, "test", "foo", None, None, Some(DEFAULT_BSO_TTL));
+        bso.payload_link = Some(GS_URL.to_owned());
+        bso.payload_size = Some(4096);
+        db.put_bso(bso).await?;
+
+        let expected = HashMap::from([("test".to_owned(), 4096)]);
+        assert_eq!(db.get_collection_usage(hid(uid)).await?, expected);
+        assert_eq!(db.get_storage_usage(hid(uid)).await?, 4096);
+
+        if Settings::test_settings().syncstorage.enable_quota {
+            let quota = db
+                .get_quota_usage(params::GetQuotaUsage {
+                    user_id: hid(uid),
+                    collection: "test".to_owned(),
+                })
+                .await?;
+            assert_eq!(quota.total_bytes, 4096);
+        }
+        Ok(())
+    })
+    .await
+}
+
+/// Inline and offloaded BSOs in the same collection sum together.
+#[cfg(feature = "spanner")]
+#[tokio::test]
+async fn usage_sums_inline_and_offloaded() -> Result<(), DbError> {
+    with_test_transaction(None, async |db: &mut dyn Db<Error = DbError>| {
+        let uid = *UID;
+        let coll = "test";
+
+        db.delete_storage(hid(uid)).await?;
+        db.put_bso(pbso(uid, coll, "inline", Some("12345"), None, None))
+            .await?;
+        let mut offloaded = pbso(uid, coll, "offloaded", None, None, Some(DEFAULT_BSO_TTL));
+        offloaded.payload_link = Some(GS_URL.to_owned());
+        offloaded.payload_size = Some(4096);
+        db.put_bso(offloaded).await?;
+
+        let expected = HashMap::from([(coll.to_owned(), 4096 + 5)]);
+        assert_eq!(db.get_collection_usage(hid(uid)).await?, expected);
+        assert_eq!(db.get_storage_usage(hid(uid)).await?, 4096 + 5);
+        Ok(())
+    })
+    .await
+}
+
+/// An inline overwrite of an offloaded BSO drops the offloaded size from usage
+/// along with payload_size itself.
+#[cfg(feature = "spanner")]
+#[tokio::test]
+async fn usage_drops_payload_size_on_inline_overwrite() -> Result<(), DbError> {
+    with_test_transaction(None, async |db: &mut dyn Db<Error = DbError>| {
+        let uid = *UID;
+        let coll = "test";
+        let bid = "foo";
+
+        db.delete_storage(hid(uid)).await?;
+        let mut offloaded = pbso(uid, coll, bid, None, None, Some(DEFAULT_BSO_TTL));
+        offloaded.payload_link = Some(GS_URL.to_owned());
+        offloaded.payload_size = Some(4096);
+        db.put_bso(offloaded).await?;
+        assert_eq!(db.get_storage_usage(hid(uid)).await?, 4096);
+
+        db.put_bso(pbso(uid, coll, bid, Some("12345"), None, None))
+            .await?;
+        assert_eq!(db.get_storage_usage(hid(uid)).await?, 5);
         Ok(())
     })
     .await

--- a/syncstorage-db/src/tests/support.rs
+++ b/syncstorage-db/src/tests/support.rs
@@ -82,6 +82,7 @@ pub fn pbso(
         id: bid.to_owned(),
         payload: payload.map(|payload| payload.to_owned()),
         payload_link: None,
+        payload_size: None,
         sortindex,
         ttl,
     }
@@ -97,6 +98,7 @@ pub fn postbso(
         id: bid.to_owned(),
         payload: payload.map(str::to_owned),
         payload_link: None,
+        payload_size: None,
         sortindex,
         ttl,
     }

--- a/syncstorage-mysql/src/db/db_impl.rs
+++ b/syncstorage-mysql/src/db/db_impl.rs
@@ -297,9 +297,11 @@ impl Db for MysqlDb {
                 bso::payload,
                 bso::sortindex,
                 bso::expiry,
-                // payload_link is Spanner-only; bind a literal NULL so the
-                // shared results::GetBso Queryable derive is satisfied.
+                // payload_link/payload_size are Spanner-only; bind literal
+                // NULLs so the shared results::GetBso Queryable derive is
+                // satisfied.
                 sql::<Nullable<Text>>("NULL"),
+                sql::<Nullable<BigInt>>("NULL"),
             ))
             .filter(bso::user_id.eq(user_id))
             .filter(bso::collection_id.eq(collection_id))
@@ -464,6 +466,7 @@ impl Db for MysqlDb {
                 bso::sortindex,
                 bso::expiry,
                 sql::<Nullable<Text>>("NULL"),
+                sql::<Nullable<BigInt>>("NULL"),
             ))
             .filter(bso::user_id.eq(user_id))
             .filter(bso::collection_id.eq(&collection_id))
@@ -523,6 +526,7 @@ impl Db for MysqlDb {
                 id: pbso.id.clone(),
                 payload: pbso.payload,
                 payload_link: pbso.payload_link,
+                payload_size: pbso.payload_size,
                 sortindex: pbso.sortindex,
                 ttl: pbso.ttl,
             })

--- a/syncstorage-postgres/src/db/db_impl.rs
+++ b/syncstorage-postgres/src/db/db_impl.rs
@@ -614,6 +614,7 @@ impl TryFrom<GetBso> for results::GetBso {
             modified: SyncTimestamp::from_datetime(pg.modified)?,
             expiry: pg.expiry.timestamp_millis(),
             payload_link: None,
+            payload_size: None,
         })
     }
 }

--- a/syncstorage-spanner/src/db/batch_commit_upsert.sql
+++ b/syncstorage-spanner/src/db/batch_commit_upsert.sql
@@ -5,10 +5,11 @@
 -- NULL, and the COALESCE fallback applies.  payload is nullable and mutually
 -- exclusive with payload_link: whichever the batch row supplies is written and
 -- the other is set NULL; when neither is supplied the existing row's values are
--- preserved.
+-- preserved. payload_size follows payload_link: it holds the byte length of the
+-- offloaded payload and is NULL whenever the payload is inline.
 INSERT OR UPDATE INTO bsos
     (fxa_uid, fxa_kid, collection_id, bso_id, sortindex, payload, modified, expiry,
-     payload_link)
+     payload_link, payload_size)
 SELECT
     bb.fxa_uid,
     bb.fxa_kid,
@@ -31,11 +32,16 @@ SELECT
         WHEN bb.payload_link IS NOT NULL THEN bb.payload_link
         WHEN bb.payload IS NOT NULL THEN NULL
         ELSE existing.payload_link
+    END,
+    CASE
+        WHEN bb.payload_link IS NOT NULL THEN bb.payload_size
+        WHEN bb.payload IS NOT NULL THEN NULL
+        ELSE existing.payload_size
     END
   FROM batch_bsos AS bb
   LEFT JOIN (
       SELECT fxa_uid, fxa_kid, collection_id, bso_id,
-             sortindex, payload, expiry, payload_link
+             sortindex, payload, expiry, payload_link, payload_size
         FROM bsos
        WHERE fxa_uid = @fxa_uid
          AND fxa_kid = @fxa_kid

--- a/syncstorage-spanner/src/db/batch_impl.rs
+++ b/syncstorage-spanner/src/db/batch_impl.rs
@@ -274,6 +274,10 @@ pub async fn do_append(
             .payload_link
             .map(IntoSpannerValue::into_spanner_value)
             .unwrap_or_else(null_value);
+        let payload_size = bso
+            .payload_size
+            .map(IntoSpannerValue::into_spanner_value)
+            .unwrap_or_else(null_value);
 
         let mut row = ListValue::new();
         row.set_values(RepeatedField::from_vec(vec![
@@ -286,6 +290,7 @@ pub async fn do_append(
             payload,
             ttl,
             payload_link,
+            payload_size,
         ]));
         let mut value = Value::new();
         value.set_list_value(row);
@@ -321,6 +326,7 @@ pub async fn do_append(
         ("payload", TypeCode::STRING),
         ("ttl", TypeCode::INT64),
         ("payload_link", TypeCode::STRING),
+        ("payload_size", TypeCode::INT64),
     ]
     .into_iter()
     .map(|(name, field_type)| struct_type_field(name, field_type))
@@ -348,7 +354,7 @@ pub async fn do_append(
     db.sql(
         "INSERT OR UPDATE INTO batch_bsos
              (fxa_uid, fxa_kid, collection_id, batch_id, batch_bso_id,
-              sortindex, payload, ttl, payload_link)
+              sortindex, payload, ttl, payload_link, payload_size)
          SELECT
              incoming.fxa_uid,
              incoming.fxa_kid,
@@ -358,7 +364,8 @@ pub async fn do_append(
              COALESCE(incoming.sortindex, existing.sortindex),
              COALESCE(incoming.payload, existing.payload),
              COALESCE(incoming.ttl, existing.ttl),
-             COALESCE(incoming.payload_link, existing.payload_link)
+             COALESCE(incoming.payload_link, existing.payload_link),
+             COALESCE(incoming.payload_size, existing.payload_size)
            FROM UNNEST(@values) AS incoming
            LEFT JOIN batch_bsos AS existing
              ON existing.fxa_uid = incoming.fxa_uid

--- a/syncstorage-spanner/src/db/batch_impl.rs
+++ b/syncstorage-spanner/src/db/batch_impl.rs
@@ -16,7 +16,8 @@ use crate::error::DbError;
 use super::{
     PRETOUCH_TS, SpannerDb,
     support::{
-        IntoSpannerValue, as_type, null_value, struct_type_field, validate_payload_exclusive,
+        IntoSpannerValue, PAYLOAD_BYTES, as_type, null_value, struct_type_field,
+        validate_payload_exclusive,
     },
 };
 use crate::DbResult;
@@ -254,8 +255,12 @@ pub async fn do_append(
     let mut incoming_ids: Vec<String> = Vec::with_capacity(bsos.len());
     for bso in bsos {
         validate_payload_exclusive(bso.payload.as_ref(), bso.payload_link.as_ref())?;
+        // An offloaded BSO's bytes live in GCS, but they still count against
+        // the user's quota: fall back to the size recorded at upload.
         if let Some(ref payload) = bso.payload {
             running_size += payload.len();
+        } else if let Some(payload_size) = bso.payload_size {
+            running_size += usize::try_from(payload_size).unwrap_or(0);
         }
         incoming_ids.push(bso.id.clone());
         let sortindex = bso
@@ -403,15 +408,15 @@ async fn pending_batch_size(
     sqlparam_types.insert("incoming_ids".to_owned(), incoming_ids.spanner_type());
     sqlparams.insert("incoming_ids".to_owned(), incoming_ids.into_spanner_value());
     let result = db
-        .sql(
-            "SELECT COALESCE(SUM(BYTE_LENGTH(payload)), 0)
+        .sql(&format!(
+            "SELECT COALESCE(SUM({PAYLOAD_BYTES}), 0)
                FROM batch_bsos
               WHERE fxa_uid = @fxa_uid
                 AND fxa_kid = @fxa_kid
                 AND collection_id = @collection_id
                 AND batch_id = @batch_id
-                AND batch_bso_id NOT IN UNNEST(@incoming_ids)",
-        )
+                AND batch_bso_id NOT IN UNNEST(@incoming_ids)"
+        ))
         .await?
         .params(sqlparams)
         .param_types(sqlparam_types)

--- a/syncstorage-spanner/src/db/db_impl.rs
+++ b/syncstorage-spanner/src/db/db_impl.rs
@@ -654,7 +654,8 @@ impl Db for SpannerDb {
 
     async fn get_bsos(&mut self, params: params::GetBsos) -> DbResult<results::GetBsos> {
         let query = "\
-            SELECT bso_id, sortindex, payload, modified, expiry, payload_link
+            SELECT bso_id, sortindex, payload, modified, expiry, payload_link,
+                   payload_size
               FROM bsos
              WHERE fxa_uid = @fxa_uid
                AND fxa_kid = @fxa_kid
@@ -741,7 +742,8 @@ impl Db for SpannerDb {
             "bso_id" => params.id,
         };
         self.sql(
-            "SELECT bso_id, sortindex, payload, modified, expiry, payload_link
+            "SELECT bso_id, sortindex, payload, modified, expiry, payload_link,
+                   payload_size
                FROM bsos
               WHERE fxa_uid = @fxa_uid
                 AND fxa_kid = @fxa_kid
@@ -815,6 +817,7 @@ impl Db for SpannerDb {
                 sortindex: params.sortindex,
                 payload: params.payload,
                 payload_link: params.payload_link,
+                payload_size: params.payload_size,
                 ttl: params.ttl,
             },
             timestamp,

--- a/syncstorage-spanner/src/db/db_impl.rs
+++ b/syncstorage-spanner/src/db/db_impl.rs
@@ -14,7 +14,7 @@ use syncstorage_db_common::{Db, error::DbErrorIntrospect, params, results, util:
 
 use super::{
     CollectionLock, SpannerDb, TOMBSTONE,
-    support::{IntoSpannerValue, as_type, bso_from_row},
+    support::{IntoSpannerValue, PAYLOAD_BYTES, as_type, bso_from_row},
 };
 use crate::{DbResult, error::DbError};
 
@@ -329,14 +329,14 @@ impl Db for SpannerDb {
             "fxa_kid" => user_id.fxa_kid
         };
         let mut streaming = self
-            .sql(
-                "SELECT collection_id, COALESCE(SUM(BYTE_LENGTH(payload)), 0)
+            .sql(&format!(
+                "SELECT collection_id, COALESCE(SUM({PAYLOAD_BYTES}), 0)
                    FROM bsos
                   WHERE fxa_uid = @fxa_uid
                     AND fxa_kid = @fxa_kid
                     AND expiry > CURRENT_TIMESTAMP()
-                  GROUP BY collection_id",
-            )
+                  GROUP BY collection_id"
+            ))
             .await?
             .params(sqlparams)
             .param_types(sqlparam_types)
@@ -396,14 +396,14 @@ impl Db for SpannerDb {
             "fxa_kid" => user_id.fxa_kid
         };
         let result = self
-            .sql(
-                "SELECT COALESCE(SUM(BYTE_LENGTH(payload)), 0)
+            .sql(&format!(
+                "SELECT COALESCE(SUM({PAYLOAD_BYTES}), 0)
                    FROM bsos
                   WHERE fxa_uid = @fxa_uid
                     AND fxa_kid = @fxa_kid
                     AND expiry > CURRENT_TIMESTAMP()
-                  GROUP BY fxa_uid",
-            )
+                  GROUP BY fxa_uid"
+            ))
             .await?
             .params(sqlparams)
             .param_types(sqlparam_types)

--- a/syncstorage-spanner/src/db/mod.rs
+++ b/syncstorage-spanner/src/db/mod.rs
@@ -616,28 +616,41 @@ impl SpannerDb {
         // payload and payload_link are mutually exclusive: an inline write sets
         // payload and clears the link, an offload write sets the link and
         // clears payload, and a metadata-only update preserves whichever the
-        // existing row holds.
-        let (payload_expr, payload_link_expr) = match (bso.payload, bso.payload_link) {
-            (Some(payload), _) => {
-                sqlparam_types.insert("payload".to_owned(), payload.spanner_type());
-                sqlparams.insert("payload".to_owned(), payload.into_spanner_value());
-                ("@payload", "NULL")
-            }
-            (None, Some(payload_link)) => {
-                sqlparam_types.insert("payload_link".to_owned(), payload_link.spanner_type());
-                sqlparams.insert("payload_link".to_owned(), payload_link.into_spanner_value());
-                ("NULL", "@payload_link")
-            }
-            // Metadata-only write: preserve the existing row. An offloaded row
-            // keeps its NULL payload; an inline row keeps its payload; a fresh
-            // insert (no existing row) defaults to an empty inline payload so
-            // the row still satisfies the exactly-one invariant.
-            (None, None) => (
-                "CASE WHEN existing.payload_link IS NOT NULL THEN NULL \
+        // existing row holds. payload_size travels with payload_link: it's the
+        // byte length of the offloaded payload, and NULL whenever the payload
+        // is inline (where BYTE_LENGTH(payload) gives the same answer).
+        let (payload_expr, payload_link_expr, payload_size_expr) =
+            match (bso.payload, bso.payload_link) {
+                (Some(payload), _) => {
+                    sqlparam_types.insert("payload".to_owned(), payload.spanner_type());
+                    sqlparams.insert("payload".to_owned(), payload.into_spanner_value());
+                    ("@payload", "NULL", "NULL")
+                }
+                (None, Some(payload_link)) => {
+                    sqlparam_types.insert("payload_link".to_owned(), payload_link.spanner_type());
+                    sqlparams.insert("payload_link".to_owned(), payload_link.into_spanner_value());
+                    let payload_size_expr = if let Some(payload_size) = bso.payload_size {
+                        sqlparam_types
+                            .insert("payload_size".to_owned(), payload_size.spanner_type());
+                        sqlparams
+                            .insert("payload_size".to_owned(), payload_size.into_spanner_value());
+                        "@payload_size"
+                    } else {
+                        "NULL"
+                    };
+                    ("NULL", "@payload_link", payload_size_expr)
+                }
+                // Metadata-only write: preserve the existing row. An offloaded
+                // row keeps its NULL payload; an inline row keeps its payload;
+                // a fresh insert (no existing row) defaults to an empty inline
+                // payload so the row still satisfies the exactly-one invariant.
+                (None, None) => (
+                    "CASE WHEN existing.payload_link IS NOT NULL THEN NULL \
                       ELSE COALESCE(existing.payload, '') END",
-                "existing.payload_link",
-            ),
-        };
+                    "existing.payload_link",
+                    "existing.payload_size",
+                ),
+            };
 
         let expiry_expr = if let Some(ttl) = bso.ttl {
             let expiry = timestamp.as_i64() + (i64::from(ttl) * 1000);
@@ -661,16 +674,18 @@ impl SpannerDb {
 
         let sql = format!(
             "INSERT OR UPDATE INTO bsos
-                 (fxa_uid, fxa_kid, collection_id, bso_id, modified, payload, expiry, payload_link{sortindex_col})
+                 (fxa_uid, fxa_kid, collection_id, bso_id, modified, payload, expiry, payload_link,
+                  payload_size{sortindex_col})
              SELECT
                  @fxa_uid, @fxa_kid, @collection_id, @bso_id,
                  {modified_expr},
                  {payload_expr},
                  {expiry_expr},
-                 {payload_link_expr}{sortindex_expr}
+                 {payload_link_expr},
+                 {payload_size_expr}{sortindex_expr}
                FROM UNNEST([1]) --  provides a row source for the LEFT JOIN
           LEFT JOIN (
-                 SELECT modified, payload, expiry, sortindex, payload_link
+                 SELECT modified, payload, expiry, sortindex, payload_link, payload_size
                    FROM bsos
                   WHERE fxa_uid = @fxa_uid
                     AND fxa_kid = @fxa_kid
@@ -720,6 +735,10 @@ impl SpannerDb {
                 .payload_link
                 .map(IntoSpannerValue::into_spanner_value)
                 .unwrap_or_else(null_value);
+            let payload_size = bso
+                .payload_size
+                .map(IntoSpannerValue::into_spanner_value)
+                .unwrap_or_else(null_value);
 
             let mut row = ListValue::new();
             row.set_values(
@@ -729,6 +748,7 @@ impl SpannerDb {
                     payload,
                     ttl,
                     payload_link,
+                    payload_size,
                 ]
                 .into(),
             );
@@ -743,6 +763,7 @@ impl SpannerDb {
             ("payload", TypeCode::STRING),
             ("ttl", TypeCode::INT64),
             ("payload_link", TypeCode::STRING),
+            ("payload_size", TypeCode::INT64),
         ]
         .into_iter()
         .map(|(name, field_type)| struct_type_field(name, field_type))
@@ -776,7 +797,7 @@ impl SpannerDb {
         self.sql(
             "INSERT OR UPDATE INTO bsos
                  (fxa_uid, fxa_kid, collection_id, bso_id,
-                  sortindex, payload, modified, expiry, payload_link)
+                  sortindex, payload, modified, expiry, payload_link, payload_size)
              SELECT
                  @fxa_uid,
                  @fxa_kid,
@@ -803,6 +824,11 @@ impl SpannerDb {
                      WHEN incoming.payload_link IS NOT NULL THEN incoming.payload_link
                      WHEN incoming.payload IS NOT NULL THEN NULL
                      ELSE existing.payload_link
+                 END,
+                 CASE
+                     WHEN incoming.payload_link IS NOT NULL THEN incoming.payload_size
+                     WHEN incoming.payload IS NOT NULL THEN NULL
+                     ELSE existing.payload_size
                  END
                FROM UNNEST(@bsos) AS incoming
                LEFT JOIN bsos AS existing

--- a/syncstorage-spanner/src/db/mod.rs
+++ b/syncstorage-spanner/src/db/mod.rs
@@ -24,8 +24,8 @@ use crate::{
     pool::{CollectionCache, Conn},
 };
 use support::{
-    ExecuteSqlRequestBuilder, IntoSpannerValue, StreamedResultSetAsync, as_type, null_value,
-    struct_type_field, validate_payload_exclusive,
+    ExecuteSqlRequestBuilder, IntoSpannerValue, PAYLOAD_BYTES, StreamedResultSetAsync, as_type,
+    null_value, struct_type_field, validate_payload_exclusive,
 };
 
 mod batch_impl;
@@ -319,13 +319,13 @@ impl SpannerDb {
                 "collection_id" => collection_id,
             };
             let mut result = self
-                .sql(
-                    "SELECT COALESCE(SUM(BYTE_LENGTH(payload)), 0), COUNT(*)
+                .sql(&format!(
+                    "SELECT COALESCE(SUM({PAYLOAD_BYTES}), 0), COUNT(*)
                        FROM bsos
                       WHERE fxa_uid = @fxa_uid
                         AND fxa_kid = @fxa_kid
-                        AND collection_id = @collection_id",
-                )
+                        AND collection_id = @collection_id"
+                ))
                 .await?
                 .params(q_params)
                 .param_types(q_types)

--- a/syncstorage-spanner/src/db/support.rs
+++ b/syncstorage-spanner/src/db/support.rs
@@ -107,6 +107,15 @@ impl SpannerArrayElementType for Vec<u32> {
     const ARRAY_ELEMENT_TYPE_CODE: TypeCode = TypeCode::INT64;
 }
 
+/// SQL expression for a BSO's payload byte length, for `bsos` and
+/// `batch_bsos` alike.
+///
+/// An inline payload measures its own column. An offloaded one leaves `payload`
+/// NULL (so `BYTE_LENGTH` yields NULL) and falls back to the `payload_size`
+/// recorded at upload time. A row offloaded before `payload_size` existed has
+/// neither and contributes 0, as it did before this column.
+pub const PAYLOAD_BYTES: &str = "COALESCE(BYTE_LENGTH(payload), payload_size, 0)";
+
 pub fn as_type(v: TypeCode) -> Type {
     let mut t = Type::new();
     t.set_code(v);

--- a/syncstorage-spanner/src/db/support.rs
+++ b/syncstorage-spanner/src/db/support.rs
@@ -44,6 +44,14 @@ impl IntoSpannerValue for i32 {
     }
 }
 
+impl IntoSpannerValue for i64 {
+    const TYPE_CODE: TypeCode = TypeCode::INT64;
+
+    fn into_spanner_value(self) -> Value {
+        self.to_string().into_spanner_value()
+    }
+}
+
 impl IntoSpannerValue for u32 {
     const TYPE_CODE: TypeCode = TypeCode::INT64;
 
@@ -232,6 +240,16 @@ pub fn bso_from_row(mut row: Vec<Value>) -> DbResult<results::GetBso> {
             None
         } else {
             Some(row[5].take_string_value())
+        },
+        payload_size: if row[6].has_null_value() {
+            None
+        } else {
+            Some(
+                row[6]
+                    .get_string_value()
+                    .parse::<i64>()
+                    .map_err(|e| DbError::integrity(e.to_string()))?,
+            )
         },
     })
 }

--- a/syncstorage-spanner/src/schema.ddl
+++ b/syncstorage-spanner/src/schema.ddl
@@ -94,6 +94,19 @@ ALTER TABLE batch_bsos
 ALTER TABLE bsos
     ALTER COLUMN payload STRING(MAX);
 
+-- Byte length of an offloaded payload, recorded at upload time. Set only
+-- alongside payload_link (the payload column is NULL then, so its size is
+-- otherwise unrecoverable without fetching the object); NULL for an inline
+-- payload, whose size is BYTE_LENGTH(payload).
+--
+-- Rollback:
+--   ALTER TABLE bsos DROP COLUMN payload_size;
+--   ALTER TABLE batch_bsos DROP COLUMN payload_size;
+ALTER TABLE bsos
+    ADD COLUMN payload_size INT64;
+ALTER TABLE batch_bsos
+    ADD COLUMN payload_size INT64;
+
 -- Change stream that captures every write to payload_link on bsos and
 -- batch_bsos. A downstream reconciler (custom Dataflow flex template ->
 -- Pub/Sub -> Python cronjob) reads this stream to finalize newly

--- a/tools/integration_tests/test_storage.py
+++ b/tools/integration_tests/test_storage.py
@@ -71,14 +71,6 @@ def json_loads(value):
 _PLD = "*" * 500
 _ASCII = string.ascii_letters + string.digits
 
-# Collection deliberately kept OUT of GCS_PAYLOAD_OFFLOAD_COLLECTIONS in the
-# offload e2e stack. Byte-size accounting (/info/quota, /info/collection_usage)
-# sums the inline Spanner payload, which is NULL for offloaded BSOs, so those
-# endpoints only make sense against a non-offloaded collection. Metering of
-# offloaded/GCS data is tracked separately (STOR-372). Do not add this name to
-# the offload list in docker/docker-compose.e2e.reconciliation.yaml.
-_NON_OFFLOAD_COL = "xxx_usage"
-
 
 def randtext(size=10):
     """Return a random ASCII string of the given size."""
@@ -629,11 +621,7 @@ def test_app_newlines_when_payloads_contain_newlines(st_ctx):
 
 
 def test_collection_usage(st_ctx):
-    """Test collection usage.
-
-    Uses a non-offloaded collection: collection_usage sums the inline Spanner
-    payload, which is not populated for offloaded BSOs.
-    """
+    """Test collection usage."""
     app = st_ctx["app"]
     root = st_ctx["root"]
     retry_delete(app, root + "/storage")
@@ -641,13 +629,13 @@ def test_collection_usage(st_ctx):
     bso1 = {"id": "13", "payload": "XyX"}
     bso2 = {"id": "14", "payload": _PLD}
     bsos = [bso1, bso2]
-    retry_post_json(app, root + "/storage/" + _NON_OFFLOAD_COL, bsos)
+    retry_post_json(app, root + "/storage/xxx_col2", bsos)
 
     res = app.get(root + "/info/collection_usage")
     usage = res.json
-    col_size = usage[_NON_OFFLOAD_COL]
+    xxx_col2_size = usage["xxx_col2"]
     wanted = (len(bso1["payload"]) + len(bso2["payload"])) / 1024.0
-    assert round(col_size, 2) == round(wanted, 2)
+    assert round(xxx_col2_size, 2) == round(wanted, 2)
 
 
 def test_delete_collection_items(st_ctx):
@@ -870,17 +858,13 @@ def test_ifunmodifiedsince(st_ctx):
 
 
 def test_quota(st_ctx):
-    """Test quota.
-
-    Uses a non-offloaded collection so the written payload is stored inline and
-    counted by /info/quota; offloaded BSOs leave the Spanner payload NULL.
-    """
+    """Test quota."""
     app = st_ctx["app"]
     root = st_ctx["root"]
     res = app.get(root + "/info/quota")
     old_used = res.json[0]
     bso = {"payload": _PLD}
-    retry_put_json(app, root + "/storage/" + _NON_OFFLOAD_COL + "/12345", bso)
+    retry_put_json(app, root + "/storage/xxx_col2/12345", bso)
     res = app.get(root + "/info/quota")
     used = res.json[0]
     assert used - old_used == len(_PLD) / 1024.0


### PR DESCRIPTION
## Description

Integrates with the info/collections and quota in a separate commit, also separately partially reverts https://github.com/mozilla-services/syncstorage-rs/commit/79f6d5d880efc1c37bb6135d317c67e2a16785a3 which should no longer be necessary

## Issue(s)

Closes STOR-684
